### PR TITLE
Set up login and a rudimentary search example

### DIFF
--- a/garden/package-lock.json
+++ b/garden/package-lock.json
@@ -8,6 +8,7 @@
       "name": "garden",
       "version": "0.1.0",
       "dependencies": {
+        "@globus/sdk": "^0.0.4-alpha.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -2220,6 +2221,18 @@
       "integrity": "sha512-IoD2MfUnOV58ghIHCiil01PcohxjbYR/qCxsoC+xNgUwh1EY8jOOrYmu3d3a71+tJJ23uscEV4X2HJWMsPJu4g==",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@globus/sdk": {
+      "version": "0.0.4-alpha.0",
+      "resolved": "https://registry.npmjs.org/@globus/sdk/-/sdk-0.0.4-alpha.0.tgz",
+      "integrity": "sha512-ZN3fgacT9284BoFHOyF2VrPf6/Yn+8Dlg6FwYCBkQThpM9P3vSaMqML2w19xmbzC0KpkD2i8hrVyBk4Me8I2ZA==",
+      "dependencies": {
+        "cross-fetch": "^3.1.5",
+        "js-pkce": "^1.2.1"
+      },
+      "engines": {
+        "node": "^14 || ^16 || ^18"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -5761,6 +5774,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dependencies": {
+        "node-fetch": "2.6.7"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -5773,6 +5794,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
@@ -11270,6 +11296,14 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/js-pkce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/js-pkce/-/js-pkce-1.2.1.tgz",
+      "integrity": "sha512-W/A/Rm4XWHa/t4neTSTAgc05W+udlMIVclAxaBCkldnsVNDVk7k/huFMifOHlIPzj23+t+BpNijSY/1h/4tstQ==",
+      "dependencies": {
+        "crypto-js": "^4.0.0"
+      }
+    },
     "node_modules/js-sdsl": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.4.0.tgz",
@@ -11915,6 +11949,44 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-forge": {

--- a/garden/package.json
+++ b/garden/package.json
@@ -5,6 +5,7 @@
   "//": "For homepage, see https://create-react-app.dev/docs/deployment/#serving-the-same-build-from-different-paths",
   "private": true,
   "dependencies": {
+    "@globus/sdk": "^0.0.4-alpha.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
@@ -25,6 +26,7 @@
     "deploy-staging": "gh-pages -d build -r https://github.com/Garden-AI/garden-frontend-staging",
     "deploy-prod": "gh-pages -d build",
     "start": "react-scripts start & npx tailwindcss -i ./src/App.css -o public/main.css --watch",
+    "start-https": "HTTPS=true react-scripts start & npx tailwindcss -i ./src/App.css -o public/main.css --watch",
     "build": "react-scripts build && npx tailwindcss -i ./src/App.css -o public/main.css",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/garden/public/main.css
+++ b/garden/public/main.css
@@ -562,19 +562,6 @@ video {
   --tw-backdrop-sepia:  ;
 }
 
-.text-3xl {
-  font-size: 1.875rem;
-  line-height: 2.25rem;
-}
-
-.font-bold {
-  font-weight: 700;
-}
-
-.underline {
-  text-decoration-line: underline;
-}
-
 .App {
   text-align: center;
 }

--- a/garden/src/App.tsx
+++ b/garden/src/App.tsx
@@ -7,18 +7,55 @@ import { HashRouter, Routes, Route } from "react-router-dom";
 // but we can bring them back once we get rid of the placeholder.
 // import './App.css';
 
+import { useEffect, useState } from "react";
+import { authorization } from "@globus/sdk";
+import { GLOBUS_NATIVE_CLIENT_ID, SEARCH_SCOPE, GARDEN_SCOPE } from './constants';
+
+const pkce = authorization.pkce({
+  client_id: GLOBUS_NATIVE_CLIENT_ID,
+  /**
+   * The redirect URI Globus Auth will send requests to after authorization.
+   */
+  redirect_uri: "http://localhost:3000/",
+  /**
+   * Any supported Globus scopes required by your application.
+   */
+  requested_scopes: `openid profile email ${SEARCH_SCOPE} ${GARDEN_SCOPE}`,
+});
+
 function App() {
+  const [isAuthenticated, setAuthenticated] = useState(pkce.hasToken());
+
+    useEffect(() => {
+        async function getToken() {
+            await pkce.handleCodeRedirect();
+            setAuthenticated(pkce.hasToken());
+        }
+        getToken();
+    }, []);
+
+    function handleLogin() {
+        pkce.redirect();
+    }
+
+    function handleLogOut() {
+        setAuthenticated(false);
+        pkce.revoke();
+        window.location.replace("/");
+    }
+
+    const MainApp = () => <RealStuff isAuthenticated={isAuthenticated} handleLogOut={handleLogOut} handleLogin={handleLogin} />
   return (
+    <div>
     <HashRouter>
       <Routes>
-        <Route path="/" element={<PlaceholderPage />}/>
-        <Route path="secret" element={<RealStuff />}/>
+        <Route path="/" element={isAuthenticated ? MainApp() : <PlaceholderPage />}/>
+        <Route path="secret" element={MainApp()}/>
       </Routes>
     </HashRouter>
-      
+    </div>
   )
 }
 
 
 export default App;
-

--- a/garden/src/App.tsx
+++ b/garden/src/App.tsx
@@ -9,7 +9,7 @@ import { HashRouter, Routes, Route } from "react-router-dom";
 
 import { useEffect, useState } from "react";
 import { authorization } from "@globus/sdk";
-import { GLOBUS_NATIVE_CLIENT_ID, SEARCH_SCOPE, GARDEN_SCOPE } from './constants';
+import { GLOBUS_NATIVE_CLIENT_ID, SEARCH_SCOPE } from './constants';
 
 const pkce = authorization.pkce({
   client_id: GLOBUS_NATIVE_CLIENT_ID,
@@ -20,7 +20,7 @@ const pkce = authorization.pkce({
   /**
    * Any supported Globus scopes required by your application.
    */
-  requested_scopes: `openid profile email ${SEARCH_SCOPE} ${GARDEN_SCOPE}`,
+  requested_scopes: `openid profile email ${SEARCH_SCOPE}`,
 });
 
 function App() {

--- a/garden/src/RealStuff.tsx
+++ b/garden/src/RealStuff.tsx
@@ -1,5 +1,35 @@
-export default function RealStuff() {
+import SearchWidget from "./api_demos/SearchWidget";
+
+interface RealStuffProps {
+  isAuthenticated: boolean;
+  handleLogin: () => void;
+  handleLogOut: () => void;
+}
+
+export default function RealStuff(props: RealStuffProps) {
+    const {isAuthenticated, handleLogin, handleLogOut} = props
     return (
-        <p>Innovative cool Garden implementation here!</p>
+        <div className="app">
+        <header className="app-header">
+          <h1>Garden Dev Page</h1>
+        </header>
+        <main className="app-main">
+          {!isAuthenticated && (
+            <div>
+              <button onClick={handleLogin}>Sign In using Globus Auth</button>
+            </div>
+          )}
+          {isAuthenticated && (
+            <div>
+              <h1>Welcome!</h1>
+              <button onClick={handleLogOut}>Log Out</button>
+              <hr />
+              <div>
+                <SearchWidget/>
+              </div>
+            </div>
+          )}
+        </main>
+      </div>
     )
 }

--- a/garden/src/api_demos/SearchWidget.tsx
+++ b/garden/src/api_demos/SearchWidget.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from "react";
+
+import { GARDEN_INDEX_URL, SEARCH_SCOPE } from "../constants"
+import { fetchWithScope } from "@globus/sdk/dist/src/lib/core/fetch"
+
+export default function GardenWidget() {
+    const [status, setStatus] = useState<string>("");
+
+    const callSearch = async () => {
+        try {
+            const response = await fetchWithScope(SEARCH_SCOPE, GARDEN_INDEX_URL + "/search?q=\"ionization\"");
+        
+            if (!response.ok) {
+                throw new Error('Network response was not ok');
+            }
+            const content = await response.text()
+            setStatus(content);
+        } catch (error) {
+            setStatus("failed");
+        }
+    };
+
+    const handleClick = () => {
+        callSearch();
+    };
+
+    return (
+        <div>
+        <button onClick={handleClick}>Find some gardens</button>
+        <p>{status}</p>
+        </div>
+    );
+}

--- a/garden/src/api_demos/SearchWidget.tsx
+++ b/garden/src/api_demos/SearchWidget.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 
 import { GARDEN_INDEX_URL, SEARCH_SCOPE } from "../constants"
-import { fetchWithScope } from "@globus/sdk/dist/src/lib/core/fetch"
+import { fetchWithScope } from "../globusHelpers"
 
 export default function GardenWidget() {
     const [status, setStatus] = useState<string>("");

--- a/garden/src/constants.ts
+++ b/garden/src/constants.ts
@@ -1,5 +1,5 @@
 const GLOBUS_NATIVE_CLIENT_ID = "1fbb4126-1e48-4f30-8c0f-d71c2715c244"
-const SEARCH_SCOPE = "urn:globus:auth:scope:search.api.globus.org:all"
+const SEARCH_SCOPE = "urn:globus:auth:scope:search.api.globus.org:search"
 const SEARCH_ENDPOINT = "https://search.api.globus.org/"
 const GARDEN_INDEX_UUID = "58e4df29-4492-4e7d-9317-b27eba62a911"
 const GARDEN_INDEX_URL = `${SEARCH_ENDPOINT}/v1/index/${GARDEN_INDEX_UUID}`;

--- a/garden/src/constants.ts
+++ b/garden/src/constants.ts
@@ -1,10 +1,8 @@
 const GLOBUS_NATIVE_CLIENT_ID = "1fbb4126-1e48-4f30-8c0f-d71c2715c244"
 const SEARCH_SCOPE = "urn:globus:auth:scope:search.api.globus.org:all"
-const GARDEN_SCOPE = "https://auth.globus.org/scopes/0948a6b0-a622-4078-b0a4-bfd6d77d65cf/action_all"
-const GARDEN_ENDPOINT = "https://nu3cetwc84.execute-api.us-east-1.amazonaws.com/garden_prod"
 const SEARCH_ENDPOINT = "https://search.api.globus.org/"
 const GARDEN_INDEX_UUID = "58e4df29-4492-4e7d-9317-b27eba62a911"
 const GARDEN_INDEX_URL = `${SEARCH_ENDPOINT}/v1/index/${GARDEN_INDEX_UUID}`;
     
 
-export {GLOBUS_NATIVE_CLIENT_ID, SEARCH_SCOPE, GARDEN_SCOPE, GARDEN_ENDPOINT, SEARCH_ENDPOINT, GARDEN_INDEX_URL};
+export {GLOBUS_NATIVE_CLIENT_ID, SEARCH_SCOPE, SEARCH_ENDPOINT, GARDEN_INDEX_URL};

--- a/garden/src/constants.ts
+++ b/garden/src/constants.ts
@@ -1,0 +1,10 @@
+const GLOBUS_NATIVE_CLIENT_ID = "1fbb4126-1e48-4f30-8c0f-d71c2715c244"
+const SEARCH_SCOPE = "urn:globus:auth:scope:search.api.globus.org:all"
+const GARDEN_SCOPE = "https://auth.globus.org/scopes/0948a6b0-a622-4078-b0a4-bfd6d77d65cf/action_all"
+const GARDEN_ENDPOINT = "https://nu3cetwc84.execute-api.us-east-1.amazonaws.com/garden_prod"
+const SEARCH_ENDPOINT = "https://search.api.globus.org/"
+const GARDEN_INDEX_UUID = "58e4df29-4492-4e7d-9317-b27eba62a911"
+const GARDEN_INDEX_URL = `${SEARCH_ENDPOINT}/v1/index/${GARDEN_INDEX_UUID}`;
+    
+
+export {GLOBUS_NATIVE_CLIENT_ID, SEARCH_SCOPE, GARDEN_SCOPE, GARDEN_ENDPOINT, SEARCH_ENDPOINT, GARDEN_INDEX_URL};

--- a/garden/src/globusHelpers/index.ts
+++ b/garden/src/globusHelpers/index.ts
@@ -1,0 +1,71 @@
+import { auth } from "@globus/sdk";
+
+export interface StorageSystem {
+    get(key: string): any | undefined;
+    set(key: string, value: any): void;
+    remove(key: string): void;
+    clear(): void;
+}
+
+type GlobusScope = string;
+
+export type FetchOverrides =
+  | (Omit<RequestInit, "headers"> & {
+      headers?: Record<string, string>;
+    })
+  | undefined;
+
+export class LocalStorage implements StorageSystem {
+  get(key: string) {
+    const value = localStorage.getItem(key);
+    return value !== null ? JSON.parse(value) : null;
+  }
+
+  set(key: string, value: any) {
+    localStorage.setItem(key, JSON.stringify(value));
+  }
+
+  remove(key: string) {
+    localStorage.removeItem(key);
+  }
+
+  clear() {
+    localStorage.clear();
+  }
+}
+
+function isValidToken(check: unknown): check is auth.Token {
+    const maybe = check as auth.Token;
+    return Boolean(maybe.token_type && maybe.access_token);
+  }
+
+export function getTokenForScope(scope: string) {
+    const storage = new LocalStorage()
+    const token = storage.get(scope);
+    if (!token || !isValidToken(token)) {
+      return null;
+    }
+    return `${token.token_type} ${token.access_token}`;
+  }
+
+export function fetchWithScope(
+    scope: GlobusScope,
+    input: RequestInfo | URL,
+    fetchOverrides: FetchOverrides = {}
+) {
+    const headers = fetchOverrides.headers || {};
+    /**
+     * If an `Authorization` override header was provided, we skip any
+     * sort of lookup and use the provided value.
+     */
+    if (!headers?.["Authorization"]) {
+    const token = getTokenForScope(scope);
+    if (token) {
+        headers["Authorization"] = token;
+    }
+    }
+    return fetch(input, {
+    ...fetchOverrides,
+    headers,
+    });
+}


### PR DESCRIPTION
This PR adds the ability to log in with Globus Auth and issue a fixed request to the Garden Globus Search index. 

## Dirty hacks

This is only configured to work locally so far. There is a fixed OAuth redirect pointing at http://localhost:3000. But it's enough to get local development started with basic login and can be expanded from here to accommodate our live deployment environments.

Also, the alpha Globus JS SDK doesn't have a Search implementation. It does have helpful lower level bits that let us use the tokens that come back from the auth response. But it doesn't expose those parts. So I've had to copy some of that code into `globusHelpers`. The interface between the SDK and our copied out code is `localstorage`. If the SDK changes how it stores things in localstorage in future releases, our code will break. 

## How to try it out

1. `npm start` from the garden repo.
2. Go to http://localhost:3000/#/secret
3. Log in and then hit "find some gardens" to see a result from the Search API



<img width="967" alt="Screenshot 2023-05-18 at 1 00 12 PM" src="https://github.com/Garden-AI/garden-frontend/assets/6283143/db556c0b-5883-495b-8825-375422b5ee96">
