### PR TITLE
Regenerate tailwind CSS

### DIFF
--- a/garden/public/main.css
+++ b/garden/public/main.css
@@ -608,100 +608,12 @@ video {
   inset: 0px;
 }
 
-.right-4 {
-  right: 1rem;
-}
-
-.top-4 {
-  top: 1rem;
-}
-
-.top-\[\] {
-  top: ;
-}
-
-.top-\[50\] {
-  top: 50;
-}
-
-.top-\[50vw\] {
-  top: 50vw;
-}
-
-.right-\[\] {
-  right: ;
-}
-
-.right-\[50vw\] {
-  right: 50vw;
-}
-
-.top-\[50vh\] {
-  top: 50vh;
+.right-\[35vw\] {
+  right: 35vw;
 }
 
 .top-\[10vh\] {
   top: 10vh;
-}
-
-.right-1\/2 {
-  right: 50%;
-}
-
-.top-1\/2 {
-  top: 50%;
-}
-
-.left-1\/2 {
-  left: 50%;
-}
-
-.top-1\/4 {
-  top: 25%;
-}
-
-.top-2 {
-  top: 0.5rem;
-}
-
-.top-8 {
-  top: 2rem;
-}
-
-.right-\[55vw\] {
-  right: 55vw;
-}
-
-.right-\[5vw\] {
-  right: 5vw;
-}
-
-.right-\[30vw\] {
-  right: 30vw;
-}
-
-.right-\[70vw\] {
-  right: 70vw;
-}
-
-.right-\[40vw\] {
-  right: 40vw;
-}
-
-.right-\[45vw\] {
-  right: 45vw;
-}
-
-.right-\[43vw\] {
-  right: 43vw;
-}
-
-.right-\[20vw\] {
-  right: 20vw;
-}
-
-.right-\[35vw\] {
-  right: 35vw;
 }
 
 .z-50 {
@@ -714,10 +626,6 @@ video {
 
 .col-span-full {
   grid-column: 1 / -1;
-}
-
-.col-span-3 {
-  grid-column: span 3 / span 3;
 }
 
 .float-right {
@@ -786,11 +694,6 @@ video {
   margin-bottom: 1rem;
 }
 
-.mx-10 {
-  margin-left: 2.5rem;
-  margin-right: 2.5rem;
-}
-
 .mb-6 {
   margin-bottom: 1.5rem;
 }
@@ -843,6 +746,10 @@ video {
   margin-top: 3rem;
 }
 
+.mt-14 {
+  margin-top: 3.5rem;
+}
+
 .mt-16 {
   margin-top: 4rem;
 }
@@ -861,47 +768,6 @@ video {
 
 .mt-6 {
   margin-top: 1.5rem;
-}
-
-
-.mb-2 {
-  margin-bottom: 0.5rem;
-}
-
-.mb-72 {
-  margin-bottom: 18rem;
-}
-
-.ml-12 {
-  margin-left: 3rem;
-}
-
-.ml-14 {
-  margin-left: 3.5rem;
-}
-
-.ml-6 {
-  margin-left: 1.5rem;
-}
-
-.mr-12 {
-  margin-right: 3rem;
-}
-
-.mt-8 {
-  margin-top: 2rem;
-}
-
-.mt-14 {
-  margin-top: 3.5rem;
-
-.mb-20 {
-  margin-bottom: 5rem;
-}
-
-.ml-10 {
-  margin-left: 2.5rem;
-
 }
 
 .block {
@@ -976,10 +842,6 @@ video {
 
 .h-full {
   height: 100%;
-}
-
-.h-\[650px\] {
-  height: 650px;
 }
 
 .max-h-\[120px\] {
@@ -1060,16 +922,8 @@ video {
   width: max-content;
 }
 
-.w-28 {
-  width: 7rem;
-}
-
-.w-\[14rem\] {
-  width: 14rem;
-}
-
-.w-\[30vw\] {
-  width: 30vw;
+.min-w-\[10vw\] {
+  min-width: 10vw;
 }
 
 .min-w-\[25px\] {
@@ -1082,14 +936,6 @@ video {
 
 .min-w-\[50\%\] {
   min-width: 50%;
-}
-
-.min-w-\[20vw\] {
-  min-width: 20vw;
-}
-
-.min-w-\[10vw\] {
-  min-width: 10vw;
 }
 
 .max-w-3xl {
@@ -1118,18 +964,6 @@ video {
 
 .max-w-sm {
   max-width: 24rem;
-}
-
-.max-w-\[\] {
-  max-width: ;
-}
-
-.max-w-\[5\] {
-  max-width: 5;
-}
-
-.max-w-\[20vw\] {
-  max-width: 20vw;
 }
 
 .flex-shrink-0 {
@@ -1185,10 +1019,6 @@ video {
 
 .grid-rows-3 {
   grid-template-rows: repeat(3, minmax(0, 1fr));
-}
-
-.grid-rows-4 {
-  grid-template-rows: repeat(4, minmax(0, 1fr));
 }
 
 .flex-row {
@@ -1302,10 +1132,6 @@ video {
 
 .overflow-y-scroll {
   overflow-y: scroll;
-}
-
-.scroll-auto {
-  scroll-behavior: auto;
 }
 
 .scroll-smooth {
@@ -1498,15 +1324,6 @@ video {
   object-fit: contain;
 }
 
-
-.object-scale-down {
-  object-fit: scale-down;
-
-.object-center {
-  object-position: center;
-
-}
-
 .p-1 {
   padding: 0.25rem;
 }
@@ -1612,11 +1429,6 @@ video {
   padding-bottom: 2rem;
 }
 
-.py-20 {
-  padding-top: 5rem;
-  padding-bottom: 5rem;
-}
-
 .pb-0 {
   padding-bottom: 0px;
 }
@@ -1647,6 +1459,10 @@ video {
 
 .pb-6 {
   padding-bottom: 1.5rem;
+}
+
+.pb-64 {
+  padding-bottom: 16rem;
 }
 
 .pb-8 {
@@ -1715,18 +1531,6 @@ video {
 
 .pt-8 {
   padding-top: 2rem;
-}
-
-.pb-24 {
-  padding-bottom: 6rem;
-}
-
-.pb-64 {
-  padding-bottom: 16rem;
-
-.pb-20 {
-  padding-bottom: 5rem;
-
 }
 
 .text-left {
@@ -1864,21 +1668,8 @@ video {
   text-decoration-line: underline;
 }
 
-
 .no-underline {
   text-decoration-line: none;
-
-.opacity-100 {
-  opacity: 1;
-}
-
-.opacity-0 {
-  opacity: 0;
-}
-
-.opacity-10 {
-  opacity: 0.1;
-
 }
 
 .shadow-lg {
@@ -1901,28 +1692,6 @@ video {
 .filter {
   -webkit-filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
           filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
-}
-
-.transition-opacity {
-  transition-property: opacity;
-  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-  transition-duration: 150ms;
-}
-
-.duration-300 {
-  transition-duration: 300ms;
-}
-
-.duration-1000 {
-  transition-duration: 1000ms;
-}
-
-.duration-700 {
-  transition-duration: 700ms;
-}
-
-.ease-in {
-  transition-timing-function: cubic-bezier(0.4, 0, 1, 1);
 }
 
 .App {
@@ -2074,16 +1843,8 @@ video {
 }
 
 @media (min-width: 640px) {
-  .sm\:right-\[\] {
-    right: ;
-  }
-
   .sm\:right-\[45vw\] {
     right: 45vw;
-  }
-
-  .sm\:right-\[40vw\] {
-    right: 40vw;
   }
 
   .sm\:col-span-2 {
@@ -2203,10 +1964,6 @@ video {
     width: 7rem;
   }
 
-  .sm\:w-\[18rem\] {
-    width: 18rem;
-  }
-
   .sm\:max-w-\[3vw\] {
     max-width: 3vw;
   }
@@ -2249,11 +2006,6 @@ video {
   .sm\:py-20 {
     padding-top: 5rem;
     padding-bottom: 5rem;
-  }
-
-  .sm\:px-20 {
-    padding-left: 5rem;
-    padding-right: 5rem;
   }
 
   .sm\:pl-36 {
@@ -2301,11 +2053,6 @@ video {
     font-size: 1.25rem;
     line-height: 1.75rem;
   }
-
-  .sm\:text-5xl {
-    font-size: 3rem;
-    line-height: 1;
-  }
 }
 
 @media (min-width: 768px) {
@@ -2341,11 +2088,6 @@ video {
     margin-bottom: 2.5rem;
   }
 
-  .md\:mx-24 {
-    margin-left: 6rem;
-    margin-right: 6rem;
-  }
-
   .md\:ml-10 {
     margin-left: 2.5rem;
   }
@@ -2356,10 +2098,6 @@ video {
 
   .md\:grid {
     display: grid;
-  }
-
-  .md\:w-\[24rem\] {
-    width: 24rem;
   }
 
   .md\:columns-2 {


### PR DESCRIPTION
The staging site's styling was busted. This fixes it.

### Testing

I ran `npm run build` on the staging branch exactly as it was, served the built directory, and repro-ed the buggy behavior. Then I ran `npm start` which triggered a tailwind generation. Then `npm run build` and serve again confirmed it was fixed.

### Preventing This

I think the root cause here was that we merged a few PRs in a row. Each had changes in Tailwind code and corresponding auto-gen'd output. But we needed to rerun tailwind on the final product. We'll have to do this manually until/unless we build this into our CI