### PR TITLE
Download notebook contents separately from search result

### DIFF
--- a/garden/public/main.css
+++ b/garden/public/main.css
@@ -2183,11 +2183,6 @@ video {
     padding-right: 9rem;
   }
 
-  .lg\:text-3xl {
-    font-size: 1.875rem;
-    line-height: 2.25rem;
-  }
-
   .lg\:text-4xl {
     font-size: 2.25rem;
     line-height: 2.5rem;

--- a/garden/src/components/NotebookViewer.tsx
+++ b/garden/src/components/NotebookViewer.tsx
@@ -1,14 +1,44 @@
+import { useEffect, useState } from "react";
 import { IpynbRenderer } from "react-ipynb-renderer";
 import "react-ipynb-renderer/dist/styles/monokai.css";
 
 type NotebookViewerProps = {
-  notebookJson: any;
+  notebookURL: string;
 };
 
-export const NotebookViewer = ({notebookJson}: NotebookViewerProps) => {
+export const NotebookViewer = ({ notebookURL }: NotebookViewerProps) => {
+  const [notebookJson, setNotebookJson] = useState<any>(null);
+  const [loadingError, setLoadingError] = useState<boolean>(false);
+
+  useEffect(() => {
+    const fetchNotebook = async () => {
+      try {
+        const response = await fetch(notebookURL);
+        const json = await response.json();
+        setNotebookJson(json);
+      } catch (error) {
+        console.error("Error fetching notebook:", error);
+        setLoadingError(true);
+      }
+    };
+
+    fetchNotebook();
+  }, [notebookURL]);
+
+  if (notebookJson) {
+    return <IpynbRenderer ipynb={notebookJson} />;
+  }
+  else if (loadingError) {
+    return (
+      <p className="text-center pt-8 pb-16 text-xl">
+        Could not load notebook
+      </p>
+    );
+  }
+  // No error and no notebook yet, so we're still loading
   return (
-    <IpynbRenderer
-      ipynb={notebookJson}
-    />
+    <p className="text-center pt-8 pb-16 text-xl">
+      Loading notebook ...
+    </p>
   );
 };

--- a/garden/src/mocks/handlers.ts
+++ b/garden/src/mocks/handlers.ts
@@ -1,6 +1,11 @@
 import { http, HttpResponse } from 'msw'
 
 export const handlers = [
+    http.get('https://pipeline-notebooks-dev.s3.amazonaws.com/willengler@uchicago.edu/iris_classifier.ipynb-23e7e94c476b299a73c446ad1ea25351b8025d011b26b784de07cdd544ebd874.ipynb', () => {
+        return HttpResponse.text(
+            "{\"cells\":[{\"cell_type\":\"markdown\",\"metadata\":{},\"source\":[\"### Running the cell below will load every definition in your original notebook within a containerized environment.\"]},{\"cell_type\":\"code\",\"execution_count\":null,\"metadata\":{},\"outputs\":[],\"source\":[\"import dill\\n\",\"\\n\",\"_globals_pre_load = dict(globals())\\n\",\"\\n\",\"dill.load_session(\\\"session.pkl\\\")\\n\",\"print([k for k in globals() if k not in _globals_pre_load])  # displays everything that was loaded\\n\",\"\\n\",\"del dill\\n\",\"del _globals_pre_load\"]},{\"cell_type\":\"markdown\",\"metadata\":{},\"source\":[\"### Now that your definitions have been loaded, feel free to test anything you like with confidence that this environment is nearly identical to the one that is executed remotely.\"]},{\"cell_type\":\"code\",\"execution_count\":null,\"metadata\":{},\"outputs\":[],\"source\":[]}],\"metadata\":{\"kernelspec\":{\"display_name\":\"Python 3 (ipykernel)\",\"language\":\"python\",\"name\":\"python3\"},\"language_info\":{\"codemirror_mode\":{\"name\":\"ipython\",\"version\":3},\"file_extension\":\".py\",\"mimetype\":\"text/x-python\",\"name\":\"python\",\"nbconvert_exporter\":\"python\",\"pygments_lexer\":\"ipython3\",\"version\":\"3.10.12\"}},\"nbformat\":4,\"nbformat_minor\":4}"
+        );
+    }),
     http.get('https://search.api.globus.org/v1/index/58e4df29-4492-4e7d-9317-b27eba62a911/search', () => {
         return HttpResponse.json({
             "total": 1,
@@ -54,7 +59,7 @@ export const handlers = [
                                         "description": "Pipeline for predicting the tensile strength (in MPa) of different compositions of alloy steels",
                                         "func_uuid": "2a4fff73-6e1d-479f-8ad2-a92fc20070ca",
                                         "title": "Steel Alloy Tensile Strength Prediction",
-                                        "notebook": "{\"cells\":[{\"cell_type\":\"markdown\",\"metadata\":{},\"source\":[\"### Running the cell below will load every definition in your original notebook within a containerized environment.\"]},{\"cell_type\":\"code\",\"execution_count\":null,\"metadata\":{},\"outputs\":[],\"source\":[\"import dill\\n\",\"\\n\",\"_globals_pre_load = dict(globals())\\n\",\"\\n\",\"dill.load_session(\\\"session.pkl\\\")\\n\",\"print([k for k in globals() if k not in _globals_pre_load])  # displays everything that was loaded\\n\",\"\\n\",\"del dill\\n\",\"del _globals_pre_load\"]},{\"cell_type\":\"markdown\",\"metadata\":{},\"source\":[\"### Now that your definitions have been loaded, feel free to test anything you like with confidence that this environment is nearly identical to the one that is executed remotely.\"]},{\"cell_type\":\"code\",\"execution_count\":null,\"metadata\":{},\"outputs\":[],\"source\":[]}],\"metadata\":{\"kernelspec\":{\"display_name\":\"Python 3 (ipykernel)\",\"language\":\"python\",\"name\":\"python3\"},\"language_info\":{\"codemirror_mode\":{\"name\":\"ipython\",\"version\":3},\"file_extension\":\".py\",\"mimetype\":\"text/x-python\",\"name\":\"python\",\"nbconvert_exporter\":\"python\",\"pygments_lexer\":\"ipython3\",\"version\":\"3.10.12\"}},\"nbformat\":4,\"nbformat_minor\":4}",
+                                        "notebook_url": "https://pipeline-notebooks-dev.s3.amazonaws.com/willengler@uchicago.edu/iris_classifier.ipynb-23e7e94c476b299a73c446ad1ea25351b8025d011b26b784de07cdd544ebd874.ipynb",
                                         "tags": [],
                                         "steps": [
                                             {

--- a/garden/src/pages/PipelinePage.tsx
+++ b/garden/src/pages/PipelinePage.tsx
@@ -461,7 +461,7 @@ const PipelinePage = ({ bread }: { bread: any }) => {
               <DiscussionTabContent active={active} comments={fakeComments}/>
             )} */}
             {active === "Notebook" && (
-              <NotebookViewer notebookJson={JSON.parse(result[0].notebook)} />
+              <NotebookViewer notebookURL={result[0].notebook_url} />
             )}
             {active === "Related" && (
               <div className="px-6">


### PR DESCRIPTION
The last step of https://github.com/Garden-AI/garden/issues/345

## Overview

This PR adapts the frontend to the changes from https://github.com/Garden-AI/garden/pull/354. Namely, there is now a `notebook_url` field on the pipeline object. And the NotebookViewer component goes and fetches the notebook contents.

## Discussion

I don't like having a fetch this far down in the component hierarchy fwiw but I think making this happen up higher would be a bigger refactor than I want to undertake.

## Testing

I tested this both with a modified mock and against a real URL in our S3 bucket