### PR TITLE
`pipelines` key in garden search entity is now `entrypoints`

### DIFF
--- a/garden/src/mocks/handlers.ts
+++ b/garden/src/mocks/handlers.ts
@@ -17,13 +17,13 @@ export const handlers = [
                     "entries": [
                         {
                             "content": {
-                                "pipeline_aliases": {},
+                                "entrypoint_aliases": {},
                                 "year": "2023",
                                 "description": "A collection of seedling gardens that illustrate the different flavors of ML libraries that Garden supports",
                                 "language": "en",
                                 "title": "Flavor Examples",
                                 "tags": ["science"],
-                                "pipelines": [
+                                "entrypoints": [
                                     {
                                         "models": [
                                             {
@@ -77,7 +77,7 @@ export const handlers = [
                                 ],
                                 "publisher": "Garden-AI",
                                 "contributors": [],
-                                "pipeline_ids": [
+                                "entrypoint_ids": [
                                     "10.23677/etya-kq52",
                                 ],
                                 "authors": [

--- a/garden/src/pages/GardenPage.tsx
+++ b/garden/src/pages/GardenPage.tsx
@@ -261,7 +261,7 @@ const GardenPage = ({ bread }: { bread: any }) => {
           <div className="pt-8">
             {active === "" && (
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                {result[0]?.entries[0].content.pipelines.map(
+                {result[0]?.entries[0].content.entrypoints.map(
                   (pipeline: any) => (
                     <PipelineBox key={pipeline.doi} pipeline={pipeline} />
                   )
@@ -270,7 +270,7 @@ const GardenPage = ({ bread }: { bread: any }) => {
             )}
             {active === "Pipelines" && (
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-                {result[0]?.entries[0].content.pipelines.map(
+                {result[0]?.entries[0].content.entrypoints.map(
                   (pipeline: any) => (
                     <PipelineBox key={pipeline.doi} pipeline={pipeline} />
                   )
@@ -288,7 +288,7 @@ const GardenPage = ({ bread }: { bread: any }) => {
                 </div>
                 <div>
                   <div className="grid grid-cols-1 gap-2 md:grid-cols-2 sm:gap-12 lg:px-24 pb-4">
-                    {result[0]?.entries[0].content.pipelines.map(
+                    {result[0]?.entries[0].content.entrypoints.map(
                       (pipe: any) => {
                         const allDatasets = [];
                         for (let model of pipe.models) {

--- a/garden/src/pages/PipelinePage.tsx
+++ b/garden/src/pages/PipelinePage.tsx
@@ -61,7 +61,7 @@ const PipelinePage = ({ bread }: { bread: any }) => {
     async function Search() {
       try {
         const gmetaArray = await searchGardenIndex({q: doi || ""});
-        const selectedPipeline = gmetaArray[0].entries[0].content.pipelines.filter(
+        const selectedPipeline = gmetaArray[0].entries[0].content.entrypoints.filter(
           (pipe: any) => pipe.doi === doi
         )
         setResult(selectedPipeline)


### PR DESCRIPTION
Companion PR to Owen's SDK PR: https://github.com/Garden-AI/garden/pull/365

This does the minimum necessary changes to keep the frontend working with the rename on the backend. This doesn't change any copy or display elements.

Tested this with the local mock server.