### PR TITLE
Make the search a wildcard instead of 2023. Tweak some copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# MacOS cruft
+.DS_Store
+.AppleDouble
+.LSOverride
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Garden
+Copyright (c) 2024 Garden
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/garden/public/main.css
+++ b/garden/public/main.css
@@ -770,18 +770,6 @@ video {
   margin-top: 1.5rem;
 }
 
-.mb-2 {
-  margin-bottom: 0.5rem;
-}
-
-.mb-4 {
-  margin-bottom: 1rem;
-}
-
-.mb-5 {
-  margin-bottom: 1.25rem;
-}
-
 .block {
   display: block;
 }

--- a/garden/src/pages/GardenPage.tsx
+++ b/garden/src/pages/GardenPage.tsx
@@ -34,7 +34,7 @@ const GardenPage = ({ bread }: { bread: any }) => {
   useEffect(() => {
     async function Search() {
       try {
-        const gmetaArray = await searchGardenIndex({q: "2023", limit: "6"});
+        const gmetaArray = await searchGardenIndex({q: "*", limit: "6"});
         const otherGardenEntries = gmetaArray.filter(
           (gard: any) => gard.entries[0].content.doi !== doi
         )

--- a/garden/src/pages/HomePage.tsx
+++ b/garden/src/pages/HomePage.tsx
@@ -9,7 +9,7 @@ const HomePage = () => {
   useEffect(() => {
     async function Search() {
       try {
-        const gmetaArray = await searchGardenIndex({q: "2023", limit: "6"});
+        const gmetaArray = await searchGardenIndex({q: "*", limit: "6"});
         setResult(gmetaArray);
       } catch (error) {
         setResult([]);

--- a/garden/src/pages/PipelinePage.tsx
+++ b/garden/src/pages/PipelinePage.tsx
@@ -462,8 +462,8 @@ const PipelinePage = ({ bread }: { bread: any }) => {
             )} */}
             {active === "Notebook" && (
               <div className="px-6">
-                <p>This notebook contains the function that executes the model(s) in this pipeline.</p>
-                <p className="mb-6">Running this pipeline is equivalent to running all cells of this notebook once!</p>
+                <p>This notebook contains the definition of this pipeline, tagged with @garden_entrypoint</p>
+                <p className="mb-6">When you execute the pipeline, it runs in a Python session created by running every cell in this notebook once.</p>
                 <NotebookViewer notebookURL={result[0].notebook_url} />
               </div>
             )}

--- a/garden/src/pages/SearchPage.tsx
+++ b/garden/src/pages/SearchPage.tsx
@@ -13,7 +13,7 @@ const SearchPage = ({ bread }: { bread: any }) => {
   useEffect(() => {
     async function Search() {
       try {
-        const gmetaArray = await searchGardenIndex({q: "2023", limit: "1000"});
+        const gmetaArray = await searchGardenIndex({q: "*", limit: "1000"});
         setResult(gmetaArray);
       } catch (error) {
         setResult([]);


### PR DESCRIPTION
New gardens weren't appearing on the Garden search page. This is because we were searching for the string "2023". This PR has us do a wildcard search instead.

I also tweaked some copy that Jennifer wrote - I don't think we should suggest that calling the entrypoint function executes the whole notebook every time.