### PR TITLE
Fixes and enhancements ahead of DLHub migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ After cloning, run `npm install` to pull in dependencies and then `npm start` to
 # Using msw mocks
 
 The `src/mocks` folder has configuration for `msw`, a library that mocks external API responses. 
-This is useful to set up static garden/pipeline responses to develop against no matter the state of the backend.
+This is useful to set up static garden/entrypoint responses to develop against no matter the state of the backend.
 
 To use this when developing locally, uncomment `REACT_APP_SHOULD_MOCK="true"` in `.env.development`.
 

--- a/garden/public/main.css
+++ b/garden/public/main.css
@@ -770,10 +770,6 @@ video {
   margin-top: 1.5rem;
 }
 
-.block {
-  display: block;
-}
-
 .flex {
   display: flex;
 }

--- a/garden/src/App.tsx
+++ b/garden/src/App.tsx
@@ -7,7 +7,7 @@ import TermsPage from './pages/TermsPage';
 import ScrollToTop from './components/ScrollToTop'
 import SearchPage from './pages/SearchPage';
 import HomePage from './pages/HomePage';
-import PipelinePage from './pages/PipelinePage';
+import EntrypointPage from './pages/EntrypointPage';
 import Navbar from './components/Navbar';
 import Footer from './components/Footer';
 
@@ -23,11 +23,11 @@ new authorization.PKCEAuthorization({
 });
 
 function App() {
-  const breadcrumbs: { home: string; search: string; garden: Array<string>; pipeline: Array<string>; } = {
+  const breadcrumbs: { home: string; search: string; garden: Array<string>; entrypoint: Array<string>; } = {
     home: 'Home',
     search: '',
     garden: [],
-    pipeline: []
+    entrypoint: []
 
   }
   return (
@@ -41,7 +41,7 @@ function App() {
           <Route path="/terms" element={<TermsPage />} />
           <Route path="/search" element={<SearchPage bread={breadcrumbs} />} />
           <Route path="/garden/:doi" element={<GardenPage bread={breadcrumbs} />} />
-          <Route path="/pipeline/:doi" element={<PipelinePage bread={breadcrumbs} />} />
+          <Route path="/entrypoint/:doi" element={<EntrypointPage bread={breadcrumbs} />} />
         </Routes>
         <Footer />
       </HashRouter>

--- a/garden/src/components/AccordionTop.tsx
+++ b/garden/src/components/AccordionTop.tsx
@@ -11,7 +11,7 @@ import {
 
 // https://szhsin.github.io/react-accordion/ for the accordion tabs
 
-const AccordionTop = ({ pipeline }: { pipeline: any }) => {
+const AccordionTop = ({ entrypoint }: { entrypoint: any }) => {
   const providerValue = useAccordionProvider({
     allowMultiple: true,
   });
@@ -81,10 +81,10 @@ const AccordionTop = ({ pipeline }: { pipeline: any }) => {
           }}
         >
           <div className="grid grid-cols-1 md:grid-cols-2 py-4 gap-x-12 lg:gap-x-32 gap-y-12 px-8 lg:px-16">
-            {pipeline[0].papers ? pipeline[0].papers.length > 0 ? (
+            {entrypoint[0].papers ? entrypoint[0].papers.length > 0 ? (
               <>
               {increaseCount()}
-                {pipeline[0].papers.map((paper: any) => {
+                {entrypoint[0].papers.map((paper: any) => {
                   return (
                     <div className="flex flex-col justify-between border border-gray-300 border-1 rounded-xl">
                       <div className="flex items-center px-2 pt-2 pb-6 gap-4 w-full">
@@ -177,10 +177,10 @@ const AccordionTop = ({ pipeline }: { pipeline: any }) => {
               <></>
             ): <></>}
             {/* repo box */}
-            {pipeline[0].repositories ? pipeline[0].repositories.length>0 ? (
+            {entrypoint[0].repositories ? entrypoint[0].repositories.length>0 ? (
               <>
                 {increaseCount()}
-                {pipeline[0].repositories.map((repo: any) => {
+                {entrypoint[0].repositories.map((repo: any) => {
                   return (
                     <div className="flex flex-col justify-between border border-gray-300 border-1 rounded-xl">
                       <div className="flex items-center px-2 pt-2 pb-6 gap-4 w-full">

--- a/garden/src/components/Breadcrumbs.tsx
+++ b/garden/src/components/Breadcrumbs.tsx
@@ -31,7 +31,7 @@ const Breadcrumbs = ({ crumbs }: { crumbs: any }) => {
             </>
           )}
           <span className="text-black">/</span>
-          {crumbs.pipeline.length === 0 ? (
+          {crumbs.entrypoint.length === 0 ? (
             <button
               onClick={() => navigate(crumbs.garden[1])}
               className="text-black underline"
@@ -46,16 +46,16 @@ const Breadcrumbs = ({ crumbs }: { crumbs: any }) => {
               {crumbs.garden[0]}
             </button>
           )}
-          {crumbs.pipeline.length === 0 ? (
+          {crumbs.entrypoint.length === 0 ? (
             <></>
           ) : (
             <span className="text-black">/</span>
           )}
           <button
-            onClick={() => navigate(crumbs.pipeline[1])}
+            onClick={() => navigate(crumbs.entrypoint[1])}
             className="underline"
           >
-            {crumbs.pipeline[0]}
+            {crumbs.entrypoint[0]}
           </button>
         </div>
       </div>

--- a/garden/src/components/DatasetBoxEntrypoint.tsx
+++ b/garden/src/components/DatasetBoxEntrypoint.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 
-const DatasetBoxPipeline = (props: { dataset: any; showFoundry: Function }) => {
+const DatasetBoxEntrypoint = (props: { dataset: any; showFoundry: Function }) => {
 
   useEffect(() => {
     if (props.dataset.url.toString().includes("foundry")) {
@@ -29,4 +29,4 @@ const DatasetBoxPipeline = (props: { dataset: any; showFoundry: Function }) => {
   );
 };
 
-export default DatasetBoxPipeline;
+export default DatasetBoxEntrypoint;

--- a/garden/src/components/EntrypointBox.tsx
+++ b/garden/src/components/EntrypointBox.tsx
@@ -1,28 +1,28 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 
-const PipelineBox = ({ pipeline }: { pipeline: any }) => {
+const EntrypointBox = ({ entrypoint }: { entrypoint: any }) => {
   const navigate = useNavigate();
-  const text = pipeline.doi.replace("/", "%2f");
+  const text = entrypoint.doi.replace("/", "%2f");
 
   return (
     <div
       className="border border-gray-200 shadow-sm rounded-lg p-5 flex flex-col justify-between hover:shadow-md hover:cursor-pointer"
-      onClick={() => navigate(`/pipeline/${text}`)}
+      onClick={() => navigate(`/entrypoint/${text}`)}
     >
       <div className="flex flex-col gap-2">
-        <h2 className="text-xl">{pipeline.title}</h2>
+        <h2 className="text-xl">{entrypoint.title}</h2>
         <p className="text-gray-500">
-          {pipeline.steps.length}{" "}
-          {pipeline.steps.length < 2 ? <span>step</span> : <span>steps</span>}
+          {entrypoint.steps.length}{" "}
+          {entrypoint.steps.length < 2 ? <span>step</span> : <span>steps</span>}
         </p>
         <div className="max-h-[120px] overflow-y-hidden">
           <p className="bg-gradient-to-b from-black to-white bg-clip-text text-transparent h-[160px] overflow-y-hidden">
-            {pipeline.description}
+            {entrypoint.description}
           </p>
         </div>
       </div>
-      {pipeline.tags.length > 0 ? (
+      {entrypoint.tags.length > 0 ? (
         <div className="text-black flex gap-2">
           <svg
             xmlns="http://www.w3.org/2000/svg"
@@ -44,7 +44,7 @@ const PipelineBox = ({ pipeline }: { pipeline: any }) => {
             />
           </svg>
           <div>
-            {pipeline.tags
+            {entrypoint.tags
               .map((t: any) => <span key={t}>{t}</span>)
               .reduce((prev: any, curr: any) => [prev, ", ", curr])}
           </div>
@@ -56,4 +56,4 @@ const PipelineBox = ({ pipeline }: { pipeline: any }) => {
   );
 };
 
-export default PipelineBox;
+export default EntrypointBox;

--- a/garden/src/components/EntrypointMetrics.tsx
+++ b/garden/src/components/EntrypointMetrics.tsx
@@ -1,4 +1,4 @@
-const PipelineMetrics = () =>{
+const EntrypointMetrics = () =>{
 
     return (
         <div className="flex gap-4">
@@ -67,4 +67,4 @@ const PipelineMetrics = () =>{
     )
 }
 
-export default PipelineMetrics
+export default EntrypointMetrics

--- a/garden/src/components/ExampleFunction.tsx
+++ b/garden/src/components/ExampleFunction.tsx
@@ -1,0 +1,51 @@
+import { IpynbRenderer } from "react-ipynb-renderer";
+import "../../src/ipynbPreview.css"
+
+type ExampleFunctionProps = {
+    functionText: string;
+};
+
+export const ExampleFunction = ({ functionText }: ExampleFunctionProps) => {
+    // break up functionText into lines
+    const lines = functionText.split("\n").map((line) => line + "\n");
+    const notebookJson = makeMinimalNotebook(lines);
+    return (
+        <div className="px-4 no-input-number">
+            <IpynbRenderer ipynb={notebookJson} />
+        </div>
+        
+    );
+};
+
+function makeMinimalNotebook(code: Array<string>) {
+    const notebook = {
+        "nbformat": 4,
+        "nbformat_minor": 2,
+        "metadata": {
+          "kernelspec": {
+            "name": "python3",
+            "display_name": "Python 3",
+            "language": "python"
+          },
+          "language_info": {
+            "name": "python",
+            "version": "3.x",
+            "mimetype": "text/x-python",
+            "codemirror_mode": { "name": "ipython", "version": 3 },
+            "pygments_lexer": "ipython3",
+            "nbconvert_exporter": "python",
+            "file_extension": ".py"
+          }
+        },
+        "cells": [
+          {
+            "cell_type": "code",
+            "execution_count": null,
+            "metadata": {},
+            "outputs": [],
+            "source": code
+          }
+        ]
+      };
+    return notebook;
+}

--- a/garden/src/components/FairScore.tsx
+++ b/garden/src/components/FairScore.tsx
@@ -6,7 +6,7 @@ const FairScore = () => {
       className="border-y border-gray-300"
       header={({ state: { isEnter } }) => (
         <div className="inline-flex w-full justify-between p-4">
-          <span className="">&#128167; Pipeline FAIR-ness</span>
+          <span className="">&#128167; Entrypoint FAIR-ness</span>
           {isEnter ? (
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/garden/src/ipynbPreview.css
+++ b/garden/src/ipynbPreview.css
@@ -3485,3 +3485,6 @@ span.token[style="color: rgb(239, 59, 125);"] {
 	font-weight: bold;
 }
 
+.no-input-number .ipynb-renderer-root div.prompt {
+	display: none;
+}

--- a/garden/src/mocks/handlers.ts
+++ b/garden/src/mocks/handlers.ts
@@ -56,7 +56,7 @@ export const handlers = [
                                         "year": "2023",
                                         "base_image_uri": "docker://index.docker.io/maxtuecke/garden-ai:python-3.10-jupyter-torch",
                                         "full_image_uri": "docker://index.docker.io/willengler/dev:latest",
-                                        "description": "Pipeline for predicting the tensile strength (in MPa) of different compositions of alloy steels",
+                                        "description": "entrypoint for predicting the tensile strength (in MPa) of different compositions of alloy steels",
                                         "func_uuid": "2a4fff73-6e1d-479f-8ad2-a92fc20070ca",
                                         "title": "Steel Alloy Tensile Strength Prediction",
                                         "notebook_url": "https://pipeline-notebooks-dev.s3.amazonaws.com/willengler@uchicago.edu/iris_classifier.ipynb-23e7e94c476b299a73c446ad1ea25351b8025d011b26b784de07cdd544ebd874.ipynb",

--- a/garden/src/pages/EntrypointPage.tsx
+++ b/garden/src/pages/EntrypointPage.tsx
@@ -2,7 +2,6 @@ import React, { useState, useRef, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import Modal from "../components/Modal";
 import AccordionTop from "../components/AccordionTop";
-import RelatedGardenBox from "../components/RelatedGardenBox";
 import DatasetBoxEntrypoint from "../components/DatasetBoxEntrypoint";
 import { searchGardenIndex } from "../globusHelpers";
 import Breadcrumbs from "../components/Breadcrumbs";
@@ -26,11 +25,9 @@ const EntrypointPage = ({ bread }: { bread: any }) => {
   const [pClass, setPClass] = useState("overflow-x-hidden whitespace-nowrap");
   const [buttonIndex, setButtonIndex] = useState(0);
   const [result, setResult] = useState<any>(undefined);
-  const [appears, setAppears] = useState<any>(undefined);
+  const [gardenDOI, setGardenDOI] = useState("");
   const [showFoundry, setShowFoundry] = useState(false);
   const [tooltipVisible, setTooltipVisible]= useState(false);
-
-
 
   const widthRef = useRef<HTMLParagraphElement>(null);
   const bottom = useRef<HTMLDivElement>(null);
@@ -61,14 +58,15 @@ const EntrypointPage = ({ bread }: { bread: any }) => {
     async function Search() {
       try {
         const gmetaArray = await searchGardenIndex({q: doi || ""});
-        const selectedEntrypoint = gmetaArray[0].entries[0].content.entrypoints.filter(
+        const selectedGarden = gmetaArray[0].entries[0].content
+        const selectedEntrypoint = selectedGarden.entrypoints.filter(
           (pipe: any) => pipe.doi === doi
         )
         setResult(selectedEntrypoint)
-        setAppears(gmetaArray);
+        setGardenDOI(selectedGarden.doi)
       } catch (error) {
         setResult([]);
-        setAppears([]);
+        setGardenDOI("");
       }
     }
     Search();
@@ -121,15 +119,6 @@ const EntrypointPage = ({ bread }: { bread: any }) => {
   console.log(result)
   const text = doi?.replace("/", "%2f");
   bread.entrypoint = [result[0].title, `/entrypoint/${text}`];
-
-  //Garden doi for the code block
-  let gardenDOI = "";
-  if (bread.garden.length !== 0) {
-    gardenDOI = bread.garden[1].replace("/garden/", "");
-    gardenDOI = gardenDOI.replace("%2f", "/");
-  } else {
-    gardenDOI = appears[0].entries[0].content.doi;
-  }
 
   const copy = async () => {
     await navigator.clipboard.writeText(window.location.href);
@@ -469,26 +458,11 @@ const EntrypointPage = ({ bread }: { bread: any }) => {
             )}
             {active === "Related" && (
               <div className="px-6">
-                {appears.length > 0 ? (
-                  <div>
-                    <h1 className="underline text-2xl pb-8">
-                      Appears in these Gardens
-                    </h1>
-                    <div className=" grid grid-cols-1 gap-2 md:grid-cols-2 sm:gap-12 lg:px-24">
-                      {appears.map((related: any) => (
-                        <RelatedGardenBox related={related} />
-                      ))}
-                    </div>
-                  </div>
-                ) : (
-                  <></>
-                )}
-
                 <div>
                   <h1 className="underline text-2xl py-8">
                     Datasets used in this entrypoint
                   </h1>
-                  {result[0].models[0].dataset ? (
+                  {result[0].models[0]?.dataset ? (
                     <div className="grid grid-cols-1 gap-2 md:grid-cols-2 sm:gap-12 lg:px-24 py-4">
                       {/* {result[0].models[0].dataset.map((dataset: any) => {
                         return <DatasetBoxEntrypoint dataset={dataset} showFoundry={foundry}/>;

--- a/garden/src/pages/EntrypointPage.tsx
+++ b/garden/src/pages/EntrypointPage.tsx
@@ -3,18 +3,18 @@ import { useNavigate, useParams } from "react-router-dom";
 import Modal from "../components/Modal";
 import AccordionTop from "../components/AccordionTop";
 import RelatedGardenBox from "../components/RelatedGardenBox";
-import DatasetBoxPipeline from "../components/DatasetBoxPipeline";
+import DatasetBoxEntrypoint from "../components/DatasetBoxEntrypoint";
 import { searchGardenIndex } from "../globusHelpers";
 import Breadcrumbs from "../components/Breadcrumbs";
 import { NotebookViewer } from "../components/NotebookViewer";
 import SyntaxHighlighter from 'react-syntax-highlighter';
 // import OpenInButtons from "../components/OpenInButtons";
 // import CitePinButtons from "../components/CitePinButtons";
-// import PipelineMetrics from "../components/PipelineMetrics";
+// import entrypointMetrics from "../components/entrypointMetrics";
 // import DiscussionTabContent from "../components/DiscussionTabContent";
 // import DiscussionTab from "../components/DiscussionTab";
 
-const PipelinePage = ({ bread }: { bread: any }) => {
+const EntrypointPage = ({ bread }: { bread: any }) => {
   const { doi } = useParams();
   const navigate = useNavigate();
 
@@ -56,15 +56,15 @@ const PipelinePage = ({ bread }: { bread: any }) => {
     }
   }
 
-  //API call to get the data based on the doi of the pipeline
+  //API call to get the data based on the doi of the entrypoint
   useEffect(() => {
     async function Search() {
       try {
         const gmetaArray = await searchGardenIndex({q: doi || ""});
-        const selectedPipeline = gmetaArray[0].entries[0].content.entrypoints.filter(
+        const selectedEntrypoint = gmetaArray[0].entries[0].content.entrypoints.filter(
           (pipe: any) => pipe.doi === doi
         )
-        setResult(selectedPipeline)
+        setResult(selectedEntrypoint)
         setAppears(gmetaArray);
       } catch (error) {
         setResult([]);
@@ -97,13 +97,13 @@ const PipelinePage = ({ bread }: { bread: any }) => {
     );
   }
 
-  //The doi does not match up to a pipeline, message appears
+  //The doi does not match up to a entrypoint, message appears
   if (result.length === 0) {
     return (
       <div className="justify-center items-center flex fixed inset-0 z-50 font-display bg-green">
         <div className="w-[75vw] sm:w-[50vw] min-h-[50vh] border border-black rounded-xl bg-white flex flex-col items-center">
           <h1 className=" py-12 px-4 text-4xl font-semibold text-center">
-            No Pipeline Found
+            No Entrypoint Found
           </h1>
           <p className="text-center px-4">
             The page you were looking for does not exist
@@ -120,7 +120,7 @@ const PipelinePage = ({ bread }: { bread: any }) => {
   }
   console.log(result)
   const text = doi?.replace("/", "%2f");
-  bread.pipeline = [result[0].title, `/pipeline/${text}`];
+  bread.entrypoint = [result[0].title, `/entrypoint/${text}`];
 
   //Garden doi for the code block
   let gardenDOI = "";
@@ -184,7 +184,7 @@ const PipelinePage = ({ bread }: { bread: any }) => {
       <div className="h-full w-full flex flex-col gap-12 px-4 sm:px-16 lg:px-36 pt-12 sm:pt-24 pb-2 font-display">
         {/* Place breadcrumbs here */}
         <Breadcrumbs crumbs={bread} />
-        {/* Pipeline Header */}
+        {/* Entrypoint Header */}
         <div className="flex flex-col gap-1">
           <div className="flex gap4 sm:gap-8">
             <h1 className="text-2xl sm:text-3xl font-display">{result[0].title}</h1>
@@ -266,7 +266,7 @@ const PipelinePage = ({ bread }: { bread: any }) => {
             )}
           </div>
           {/* Total Runs/Pins/Shares/Citations goes here */}
-          {/* <PipelineMetrics/> */}
+          {/* <EntrypointMetrics/> */}
           <div className="flex flex-wrap pt-4 mr-8 text-base sm:text-lg">
             <p className="font-semibold pr-2">Contributors:</p>
             <p className={pClass} ref={widthRef}>
@@ -310,7 +310,7 @@ const PipelinePage = ({ bread }: { bread: any }) => {
         </div>
 
         <div className="flex flex-col gap-8 w-full">
-          <h2 className="text-2xl sm:text-3xl text-center">Run this pipeline</h2>
+          <h2 className="text-2xl sm:text-3xl text-center">Run this entrypoint</h2>
           <div className="sm:flex justify-center py-2">
             <div className="bg-gray-800 text-white py-6 px-4 sm:px-6 text-sm sm:text-base rounded-xl break-words">
               <code className="leading-loose">
@@ -337,7 +337,7 @@ const PipelinePage = ({ bread }: { bread: any }) => {
           </div>
         </div>
 
-        <AccordionTop pipeline={result} />
+        <AccordionTop entrypoint={result} />
 
         <div className="pb-12">
           <div className="flex justify-evenly h-12 ">
@@ -462,8 +462,8 @@ const PipelinePage = ({ bread }: { bread: any }) => {
             )} */}
             {active === "Notebook" && (
               <div className="px-6">
-                <p>This notebook contains the definition of this pipeline, tagged with @garden_entrypoint</p>
-                <p className="mb-6">When you execute the pipeline, it runs in a Python session created by running every cell in this notebook once.</p>
+                <p>This notebook contains the definition of this entrypoint, tagged with @garden_entrypoint</p>
+                <p className="mb-6">When you execute the entrypoint, it runs in a Python session created by running every cell in this notebook once.</p>
                 <NotebookViewer notebookURL={result[0].notebook_url} />
               </div>
             )}
@@ -486,18 +486,18 @@ const PipelinePage = ({ bread }: { bread: any }) => {
 
                 <div>
                   <h1 className="underline text-2xl py-8">
-                    Datasets used in this pipeline
+                    Datasets used in this entrypoint
                   </h1>
                   {result[0].models[0].dataset ? (
                     <div className="grid grid-cols-1 gap-2 md:grid-cols-2 sm:gap-12 lg:px-24 py-4">
                       {/* {result[0].models[0].dataset.map((dataset: any) => {
-                        return <DatasetBoxPipeline dataset={dataset} showFoundry={foundry}/>;
+                        return <DatasetBoxEntrypoint dataset={dataset} showFoundry={foundry}/>;
                       })} */}
-                      <DatasetBoxPipeline dataset={result[0].models[0].dataset} showFoundry={foundry}/>
+                      <DatasetBoxEntrypoint dataset={result[0].models[0].dataset} showFoundry={foundry}/>
                     </div>
                   ) : (
                     <p className="text-center pt-8 pb-16 text-xl">
-                      No datasets available for this pipeline
+                      No datasets available for this entrypoint
                     </p>
                   )}
                   {showFoundry === true ? (
@@ -553,4 +553,4 @@ const PipelinePage = ({ bread }: { bread: any }) => {
   );
 };
 
-export default PipelinePage;
+export default EntrypointPage;

--- a/garden/src/pages/EntrypointPage.tsx
+++ b/garden/src/pages/EntrypointPage.tsx
@@ -10,7 +10,7 @@ import { ExampleFunction } from "../components/ExampleFunction";
 import SyntaxHighlighter from 'react-syntax-highlighter';
 // import OpenInButtons from "../components/OpenInButtons";
 // import CitePinButtons from "../components/CitePinButtons";
-// import entrypointMetrics from "../components/entrypointMetrics";
+// import EntrypointMetrics from "../components/EntrypointMetrics";
 // import DiscussionTabContent from "../components/DiscussionTabContent";
 // import DiscussionTab from "../components/DiscussionTab";
 
@@ -341,26 +341,6 @@ return my_entrypoint(input)`
           <h2 className="text-2xl sm:text-3xl text-center">Run this entrypoint</h2>
           <div className="sm:flex justify-center py-2">
             <ExampleFunction functionText={exampleFunctionText(gardenDOI, result[0])}/>
-            
-            {/* <div className="bg-gray-800 text-white py-6 px-4 sm:px-6 text-sm sm:text-base rounded-xl break-words">
-              <code className="leading-loose">
-                <span className="text-purple">import</span> GardenClient <br />
-                client = garden_ai.GardenClient()
-                <br />
-                <br />
-                <span className="text-orange">garden</span> =
-                client.get_published_garden(
-                <span className="text-green">"{gardenDOI}"</span>)<br />
-                <br />
-                <br />
-                <span className="text-orange">
-                  garden.
-                  <span className="text-white">{result[0].short_name}</span>
-                </span>
-                (<span className="text-green">'Data Here'</span>)
-              </code>
-            </div> */}
-
             <div className="flex flex-col items-center justify-center">
               {/* <OpenInButtons/> */}
             </div>

--- a/garden/src/pages/GardenPage.tsx
+++ b/garden/src/pages/GardenPage.tsx
@@ -1,10 +1,10 @@
 import React, { useState, useEffect } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import PipelineBox from "../components/PipelineBox";
+import EntrypointBox from "../components/EntrypointBox";
 import Modal from "../components/Modal";
 import RelatedGardenBox from "../components/RelatedGardenBox";
 import Breadcrumbs from "../components/Breadcrumbs";
-import DatasetBoxPipeline from "../components/DatasetBoxPipeline";
+import DatasetBoxEntrypoint from "../components/DatasetBoxEntrypoint";
 import { searchGardenIndex } from "../globusHelpers";
 
 const GardenPage = ({ bread }: { bread: any }) => {
@@ -92,7 +92,7 @@ const GardenPage = ({ bread }: { bread: any }) => {
   console.log(result);
   const text = doi?.replace("/", "%2f");
   bread.garden = [result[0]?.entries[0].content.title, `/garden/${text}`];
-  bread.pipeline = [];
+  bread.entrypoint = [];
 
   const copy = async () => {
     await navigator.clipboard.writeText(window.location.href);
@@ -235,15 +235,15 @@ const GardenPage = ({ bread }: { bread: any }) => {
           <div className="flex justify-evenly h-12 ">
             <button
               className={
-                active === "Pipelines"
+                active === "Entrypoints"
                   ? "bg-green bg-opacity-30 w-full border-b-4 border-green"
                   : active === ""
                   ? "bg-green bg-opacity-30 w-full border-b-4 border-green"
                   : "bg-gray-100 w-full hover:bg-gradient-to-b hover:from-gray-100 hover:from-70% hover:to-green hover:border-b-1 hover:border-green"
               }
-              onClick={() => setActive("Pipelines")}
+              onClick={() => setActive("Entrypoints")}
             >
-              Pipelines
+              Entrypoints
             </button>
             {/* Discussion Tab Here */}
             {/* <DiscussionTab active={active} setActive={setDiscussionTab}/> */}
@@ -262,17 +262,17 @@ const GardenPage = ({ bread }: { bread: any }) => {
             {active === "" && (
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
                 {result[0]?.entries[0].content.entrypoints.map(
-                  (pipeline: any) => (
-                    <PipelineBox key={pipeline.doi} pipeline={pipeline} />
+                  (entrypoint: any) => (
+                    <EntrypointBox key={entrypoint.doi} entrypoint={entrypoint} />
                   )
                 )}
               </div>
             )}
-            {active === "Pipelines" && (
+            {active === "Entrypoints" && (
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
                 {result[0]?.entries[0].content.entrypoints.map(
-                  (pipeline: any) => (
-                    <PipelineBox key={pipeline.doi} pipeline={pipeline} />
+                  (entrypoint: any) => (
+                    <EntrypointBox key={entrypoint.doi} entrypoint={entrypoint} />
                   )
                 )}
               </div>
@@ -300,7 +300,7 @@ const GardenPage = ({ bread }: { bread: any }) => {
                           <>
                             {increaseCount()}
                             <div>
-                              {allDatasets.map(dataset => <DatasetBoxPipeline dataset={dataset} showFoundry={foundry}/>)}
+                              {allDatasets.map(dataset => <DatasetBoxEntrypoint dataset={dataset} showFoundry={foundry}/>)}
                             </div>
                           </>
                         ) : (

--- a/garden/src/pages/HomePage.tsx
+++ b/garden/src/pages/HomePage.tsx
@@ -142,19 +142,19 @@ const HomePage = () => {
             principles to ensure accessibility and reproducibility. Gardens allow
             you engage with a broader audience by making publication of models
             quick and easy. This is efficiently achieved through sub-sections of a
-            garden called “pipelines”.
+            garden called “entrypoints”.
           </p>
         </div>
 
-        {/* Third section (Pipelines...) */}
+        {/* Third section (Entrypoints...) */}
         <div className="mt-14">
-          <h1 className="text-xl sm:text-3xl lg:text-4xl font-semibold pb-8">Pipelines</h1>
+          <h1 className="text-xl sm:text-3xl lg:text-4xl font-semibold pb-8">Entrypoints</h1>
           <p className="text-md sm:text-lg">
-            Pipelines are pages within a garden where all the relevant models and
-            its associated materials are stored. Each pipeline is composed of
+            Entrypoints are pages within a garden where all the relevant models and
+            its associated materials are stored. Each entrypoint is composed of
             steps such as input, function, output, etc. If a particular model is
-            relevant in more than one garden, then that pipeline can be reused and
-            displayed across them all, as they are not garden specific. Pipelines
+            relevant in more than one garden, then that entrypoint can be reused and
+            displayed across them all, as they are not garden specific. Entrypoints
             play a key role in the accessibility and reproducibility of a garden
             page.
           </p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "garden-frontend",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "garden-frontend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Closes #72. Closes #70.

### Description

This PR does the following:
- Renames "pipeline" to "entrypoint".
- Displays a test function in the top code snippet block if the entrypoint author provided one. Also changes the styling to reuse the new Jupyter code cell style.
- Adds a null check so that the Related tab doesn't crash if an entrypoint doesn't have a model
- Removes the carousel that shows other gardens the entrypoint belongs in. This had inaccurate logic and was always showing that the entrypoint belonged in other gardens when it didn't.

### Screenshots

Here is what it looks like when there is a test function:

<img width="956" alt="Screenshot 2024-02-20 at 3 36 20 PM" src="https://github.com/Garden-AI/garden-frontend/assets/6283143/ae28e71f-15ac-4285-9a2f-bdef8b2f9d56">

... and when there isn't:

<img width="939" alt="Screenshot 2024-02-20 at 3 58 09 PM" src="https://github.com/Garden-AI/garden-frontend/assets/6283143/ba69c7ff-34e4-4e26-9230-6f88aa499899">