### PR TITLE
Fix dataset rendering issues

### DIFF
--- a/garden/src/pages/EntrypointPage.tsx
+++ b/garden/src/pages/EntrypointPage.tsx
@@ -483,7 +483,7 @@ return my_entrypoint(input)`
                   <h1 className="underline text-2xl py-8">
                     Datasets used in this entrypoint
                   </h1>
-                  {result[0].models[0]?.datasets ? (
+                  {result[0].models[0]?.datasets.length > 0 ? (
                     <div className="grid grid-cols-1 gap-2 md:grid-cols-2 sm:gap-12 lg:px-24 py-4">
                       {
                         result[0].models[0].datasets.map((dataset: any) => (

--- a/garden/src/pages/EntrypointPage.tsx
+++ b/garden/src/pages/EntrypointPage.tsx
@@ -483,12 +483,13 @@ return my_entrypoint(input)`
                   <h1 className="underline text-2xl py-8">
                     Datasets used in this entrypoint
                   </h1>
-                  {result[0].models[0]?.dataset ? (
+                  {result[0].models[0]?.datasets ? (
                     <div className="grid grid-cols-1 gap-2 md:grid-cols-2 sm:gap-12 lg:px-24 py-4">
-                      {/* {result[0].models[0].dataset.map((dataset: any) => {
-                        return <DatasetBoxEntrypoint dataset={dataset} showFoundry={foundry}/>;
-                      })} */}
-                      <DatasetBoxEntrypoint dataset={result[0].models[0].dataset} showFoundry={foundry}/>
+                      {
+                        result[0].models[0].datasets.map((dataset: any) => (
+                          <DatasetBoxEntrypoint dataset={dataset} showFoundry={foundry}/>
+                        ))
+                      }
                     </div>
                   ) : (
                     <p className="text-center pt-8 pb-16 text-xl">


### PR DESCRIPTION
Closes #84

This PR tweaks the garden and entrypoint pages so that they show all the datasets associated with a given garden/entrypoint. (But no more than that!)

Screenshots of some different
<img width="1339" alt="Screenshot 2024-03-14 at 5 07 27 PM" src="https://github.com/Garden-AI/garden-frontend/assets/6283143/f0755b43-7c45-4359-8fa1-ec8792fbad86">
<img width="615" alt="Screenshot 2024-03-14 at 5 07 06 PM" src="https://github.com/Garden-AI/garden-frontend/assets/6283143/38fc4316-9380-4c21-b228-b8771f37ad28">
<img width="636" alt="Screenshot 2024-03-14 at 5 06 57 PM" src="https://github.com/Garden-AI/garden-frontend/assets/6283143/a6642ef7-4c84-492a-861f-62f83086f36a">
 cases:
<img width="1339" alt="Screenshot 2024-03-14 at 5 09 42 PM" src="https://github.com/Garden-AI/garden-frontend/assets/6283143/9b9f7124-b820-40ca-bca2-26ad05aca382">
