### PR TITLE
Completed Garden DOI styling changes

### DIFF
--- a/garden/public/main.css
+++ b/garden/public/main.css
@@ -839,6 +839,22 @@ video {
   margin-bottom: -0.5rem;
 }
 
+.mb-2 {
+  margin-bottom: 0.5rem;
+}
+
+.-mb-1 {
+  margin-bottom: -0.25rem;
+}
+
+.-mb-3 {
+  margin-bottom: -0.75rem;
+}
+
+.-mb-4 {
+  margin-bottom: -1rem;
+}
+
 .flex {
   display: flex;
 }
@@ -1775,6 +1791,10 @@ video {
   text-underline-offset: 4px;
 }
 
+.underline-offset-auto {
+  text-underline-offset: auto;
+}
+
 .shadow-lg {
   --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
   --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
@@ -1921,12 +1941,30 @@ video {
   color: rgb(100 116 139 / var(--tw-text-opacity));
 }
 
+.hover\:text-blue:hover {
+  --tw-text-opacity: 1;
+  color: rgb(0 0 255 / var(--tw-text-opacity));
+}
+
+.hover\:text-green:hover {
+  --tw-text-opacity: 1;
+  color: rgb(83 168 108 / var(--tw-text-opacity));
+}
+
 .hover\:underline:hover {
   text-decoration-line: underline;
 }
 
 .hover\:no-underline:hover {
   text-decoration-line: none;
+}
+
+.hover\:underline-offset-4:hover {
+  text-underline-offset: 4px;
+}
+
+.hover\:underline-offset-auto:hover {
+  text-underline-offset: auto;
 }
 
 .hover\:opacity-75:hover {
@@ -1949,6 +1987,11 @@ video {
   --tw-saturate: saturate(1.5);
   -webkit-filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
           filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.focus\:outline-none:focus {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
 }
 
 @media (min-width: 640px) {

--- a/garden/src/components/DatasetBoxEntrypoint.tsx
+++ b/garden/src/components/DatasetBoxEntrypoint.tsx
@@ -11,7 +11,7 @@ const DatasetBoxEntrypoint = (props: { dataset: any; showFoundry: Function }) =>
   return (
     <div className="flex flex-col gap-2 border border-gray rounded-lg px-4">
       <h1 className="font-semibold text-2xl pt-4 break-words">{props.dataset.title}</h1>
-      <a target="blank" className="break-words text-blue hover:underline" href={props.dataset.url}>
+      <a target="blank" className="break-words text-green underline" href={props.dataset.url}>
         {props.dataset.url}
       </a>
       <div className="pb-4">

--- a/garden/src/pages/EntrypointPage.tsx
+++ b/garden/src/pages/EntrypointPage.tsx
@@ -254,7 +254,7 @@ return my_entrypoint(input)`
                 copy={copy}
                 doi={result[0].doi}
                 showTooltip={showTooltip}
-              />
+              />Enpoinsx
             </div>
           </div>
           <div className="text-gray-500 text-sm flex flex-wrap gap-1">

--- a/garden/src/pages/GardenPage.tsx
+++ b/garden/src/pages/GardenPage.tsx
@@ -4,6 +4,7 @@ import EntrypointBox from "../components/EntrypointBox";
 import Modal from "../components/Modal";
 import RelatedGardenBox from "../components/RelatedGardenBox";
 import Breadcrumbs from "../components/Breadcrumbs";
+import AccordionTop from "../components/AccordionTop";
 import DatasetBoxEntrypoint from "../components/DatasetBoxEntrypoint";
 import { searchGardenIndex } from "../globusHelpers";
 
@@ -119,6 +120,19 @@ const GardenPage = ({ bread }: { bread: any }) => {
     await navigator.clipboard.writeText(window.location.href);
     showTooltip()
   };
+
+  const copyDOI = async () => {
+    const DOItext: string = doi?.replace("/", "%2f") ?? '';
+
+    try {
+      await navigator.clipboard.writeText(DOItext);
+      console.log('Content copied to clipboard');
+    } catch (err) {
+      console.error('Failed to copy: ', err);
+    }
+
+  };
+
   const showTooltip = () => {
     if(tooltipVisible===false){
       setTooltipVisible(true)
@@ -230,9 +244,26 @@ const GardenPage = ({ bread }: { bread: any }) => {
               href={`https://doi.org/${result[0]?.entries[0].content.doi}`}
               target="_blank"
               rel="noopener noreferrer"
+              className = "text-green underline"
             >
               {result[0]?.entries[0].content.doi}
             </a>
+            <button title="Copy DOI" onClick={copyDOI} className="ml-2 -mb-1">
+              <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="gray"
+                  className="w-6 h-6"
+                >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M16.5 8.25V6a2.25 2.25 0 00-2.25-2.25H6A2.25 2.25 0 003.75 6v8.25A2.25 2.25 0 006 16.5h2.25m8.25-8.25H18a2.25 2.25 0 012.25 2.25V18A2.25 2.25 0 0118 20.25h-7.5A2.25 2.25 0 018.25 18v-1.5m8.25-8.25h-6a2.25 2.25 0 00-2.25 2.25v6"
+                />
+              </svg>
+            </button>
           </div>
           <div>
             <h2 className="font-semibold">Description</h2>

--- a/garden/src/pages/GardenPage.tsx
+++ b/garden/src/pages/GardenPage.tsx
@@ -4,7 +4,6 @@ import EntrypointBox from "../components/EntrypointBox";
 import Modal from "../components/Modal";
 import RelatedGardenBox from "../components/RelatedGardenBox";
 import Breadcrumbs from "../components/Breadcrumbs";
-import AccordionTop from "../components/AccordionTop";
 import DatasetBoxEntrypoint from "../components/DatasetBoxEntrypoint";
 import { searchGardenIndex } from "../globusHelpers";
 


### PR DESCRIPTION
"Format this content so users can tell it's a link.": Changed all DOI styling in Garden headers to be green and underlined, also changed blue links to be same styling. 

"On other pages, we have a copy button that when pressed, copies the text to the user's clipboard. Add the copy button to the DOI on the Garden page.": Added copy to clipboard functionality next to the DOI's.