### PR TITLE
Google Analytics (closes issue #94)

### DIFF
--- a/garden/package-lock.json
+++ b/garden/package-lock.json
@@ -19,6 +19,7 @@
         "@types/react-dom": "^18.0.11",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-ga4": "^2.1.0",
         "react-ipynb-renderer": "^2.1.2",
         "react-router-dom": "^6.10.0",
         "react-scripts": "5.0.1",
@@ -16285,6 +16286,11 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "node_modules/react-ga4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-ga4/-/react-ga4-2.1.0.tgz",
+      "integrity": "sha512-ZKS7PGNFqqMd3PJ6+C2Jtz/o1iU9ggiy8Y8nUeksgVuvNISbmrQtJiZNvC/TjDsqD0QlU5Wkgs7i+w9+OjHhhQ=="
     },
     "node_modules/react-ipynb-renderer": {
       "version": "2.1.2",

--- a/garden/package.json
+++ b/garden/package.json
@@ -16,6 +16,7 @@
     "@types/react-dom": "^18.0.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-ga4": "^2.1.0",
     "react-ipynb-renderer": "^2.1.2",
     "react-router-dom": "^6.10.0",
     "react-scripts": "5.0.1",

--- a/garden/src/App.tsx
+++ b/garden/src/App.tsx
@@ -1,17 +1,22 @@
-import React from 'react';
 import { authorization } from "@globus/sdk/cjs";
 import { SEARCH_SCOPE, GLOBUS_NATIVE_CLIENT_ID } from "./constants";
-import { HashRouter, Routes, Route } from "react-router-dom";
-import GardenPage from './pages/GardenPage';
-import TermsPage from './pages/TermsPage';
-import ScrollToTop from './components/ScrollToTop'
-import SearchPage from './pages/SearchPage';
-import HomePage from './pages/HomePage';
-import EntrypointPage from './pages/EntrypointPage';
-import Navbar from './components/Navbar';
-import Footer from './components/Footer';
-import TeamsPage from './pages/TeamsPage';
-import ReactGA from "react-ga4";
+import {
+  Routes,
+  Route,
+  RouterProvider,
+  createHashRouter,
+  Outlet,
+} from "react-router-dom";
+import GardenPage from "./pages/GardenPage";
+import TermsPage from "./pages/TermsPage";
+import ScrollToTop from "./components/ScrollToTop";
+import SearchPage from "./pages/SearchPage";
+import HomePage from "./pages/HomePage";
+import EntrypointPage from "./pages/EntrypointPage";
+import Navbar from "./components/Navbar";
+import Footer from "./components/Footer";
+import TeamsPage from "./pages/TeamsPage";
+import useGoogleAnalytics from "./services/analytics";
 
 /*
   We are not making calls that need authentication, but making a PKCEAuthorization 
@@ -24,38 +29,62 @@ new authorization.PKCEAuthorization({
   requested_scopes: `openid profile email ${SEARCH_SCOPE}`,
 });
 
-function App() {
-  ReactGA.initialize("G-99GHD3HEZP");
-  ReactGA.send({
-    hitType: "pageview",
-    page: window.location.pathname + window.location.search,
-  });
+const router = createHashRouter([
+  {
+    path: "*",
+    element: <Root />,
+  },
+]);
 
-  const breadcrumbs: { home: string; search: string; garden: Array<string>; entrypoint: Array<string>; } = {
-    home: 'Home',
-    search: '',
-    garden: [],
-    entrypoint: []
-  }
-  return (
-    <div>
-      <HashRouter>
-        <ScrollToTop />
-        <Navbar />
-        <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/home" element={<HomePage />} />
-          <Route path="/terms" element={<TermsPage />} />
-          <Route path="/search" element={<SearchPage bread={breadcrumbs} />} />
-          <Route path="/garden/:doi" element={<GardenPage bread={breadcrumbs} />} />
-          <Route path="/entrypoint/:doi" element={<EntrypointPage bread={breadcrumbs} />} />
-          <Route path="/team" element={<TeamsPage/>}/>
-        </Routes>
-        <Footer />
-      </HashRouter>
-    </div>
-  )
+function App() {
+  return <RouterProvider router={router} />;
 }
 
+function Root() {
+  const breadcrumbs: {
+    home: string;
+    search: string;
+    garden: Array<string>;
+    entrypoint: Array<string>;
+  } = {
+    home: "Home",
+    search: "",
+    garden: [],
+    entrypoint: [],
+  };
+  return (
+    <Routes>
+      <Route path="*" element={<RootLayout />}>
+        <Route index element={<HomePage />} />
+        {/*  We should eventually eliminate this next route unless there is explicit need for it- can just use '/' as 'home' */}
+        <Route path="home" element={<HomePage />} />
+        <Route path="terms" element={<TermsPage />} />
+        <Route path="search" element={<SearchPage bread={breadcrumbs} />} />
+        <Route
+          path="garden/:doi"
+          element={<GardenPage bread={breadcrumbs} />}
+        />
+        <Route
+          path="entrypoint/:doi"
+          element={<EntrypointPage bread={breadcrumbs} />}
+        />
+        <Route path="team" element={<TeamsPage />} />
+      </Route>
+    </Routes>
+  );
+}
+
+// TODO: Extract this to a separate file, perhaps in a 'layouts' folder
+function RootLayout() {
+  useGoogleAnalytics();
+  return (
+    <>
+      <ScrollToTop />
+      <Navbar />
+      <Outlet />
+      <Footer />
+    </>
+  );
+}
 
 export default App;

--- a/garden/src/App.tsx
+++ b/garden/src/App.tsx
@@ -11,6 +11,7 @@ import EntrypointPage from './pages/EntrypointPage';
 import Navbar from './components/Navbar';
 import Footer from './components/Footer';
 import TeamsPage from './pages/TeamsPage';
+import ReactGA from "react-ga4";
 
 /*
   We are not making calls that need authentication, but making a PKCEAuthorization 
@@ -24,12 +25,17 @@ new authorization.PKCEAuthorization({
 });
 
 function App() {
+  ReactGA.initialize("G-99GHD3HEZP");
+  ReactGA.send({
+    hitType: "pageview",
+    page: window.location.pathname + window.location.search,
+  });
+
   const breadcrumbs: { home: string; search: string; garden: Array<string>; entrypoint: Array<string>; } = {
     home: 'Home',
     search: '',
     garden: [],
     entrypoint: []
-
   }
   return (
     <div>

--- a/garden/src/services/analytics.js
+++ b/garden/src/services/analytics.js
@@ -12,7 +12,7 @@ const trackPageView = () => {
     hitType: "pageview",
     page: window.location.hash,
   });
-  console.log("Page view tracked");
+  // console.log("Page view tracked");
 };
 
 const useGoogleAnalytics = () => {

--- a/garden/src/services/analytics.js
+++ b/garden/src/services/analytics.js
@@ -1,0 +1,25 @@
+import ReactGA from "react-ga4";
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const TRACKING_ID = "G-99GHD3HEZP"; // May move this to an environment variable later, perhaps different for dev and prod
+
+// Initialize Google Analytics
+ReactGA.initialize(TRACKING_ID);
+
+const trackPageView = () => {
+  ReactGA.send({
+    hitType: "pageview",
+    page: window.location.hash,
+  });
+  console.log("Page view tracked");
+};
+
+const useGoogleAnalytics = () => {
+  const location = useLocation();
+  useEffect(() => {
+    trackPageView();
+  }, [location]);
+};
+
+export default useGoogleAnalytics;


### PR DESCRIPTION
This pull request implements support for Google Analytics tracking. Each time a viewer navigates to a new page, an event is logged in Google Analytics.

## Main View
![Screenshot 2024-06-03 121221](https://github.com/Garden-AI/garden-frontend/assets/71043373/17828658-9ede-427f-af7d-e24f30cae727)

## Tracking Events (page views)
![Screenshot 2024-06-03 125008](https://github.com/Garden-AI/garden-frontend/assets/71043373/6678dfb7-3953-4afa-b5bf-cdcf58b0e85a)

With Google Analytics we can generate reports and dashboards that show us the traffic going to each garden page, and more in depth analysis if needed.
