### PR TITLE
Staging to production ready for new DB rollout

### DIFF
--- a/garden/src/pages/GardenPage.tsx
+++ b/garden/src/pages/GardenPage.tsx
@@ -36,7 +36,8 @@ export default function GardenPage() {
     
     for (const userGarden of userGardens) {
       if (userGarden.doi === garden.doi) {
-        return true;
+        // return true when adding edit button back in
+        return false;
       }
     }
     return false;


### PR DESCRIPTION
We want to release a version of the frontend that is compatible with the new backend that is being released on Monday. Our user profile features and metadata editing are not yet production ready, so this PR is to hide those features and make sure that all the other frontend code is using the new backend schema.

Luckily, our user profile features and metadata editing can be hidden by just hiding the login. This branch has all the up-to-date user profile and metadata editing features, but they are not accessible to users at this time.

To add these features back:
- To add login back in: components/navbar.tsx line 94
- To add Garden metadata back in: pages/GardenPage.tsx line 39
     - _Note: I think this logic was not working as intended because the edit button was visible to me as a user who was not logged in._