### PR TITLE
hopefully this fixes the build issue

### DIFF
--- a/garden/src/components/HomePage.tsx
+++ b/garden/src/components/HomePage.tsx
@@ -351,6 +351,7 @@ const HomePage = () => {
               <SyntaxHighlighter>
                 {`from garden_ai import GardenClient
 
+garden_client = GardenClient()
 garden = garden_client.get_garden("10.26311/ep98-br79")
 
 def predict_properties():

--- a/garden/vite.config.ts
+++ b/garden/vite.config.ts
@@ -5,6 +5,7 @@ import viteTsconfigPaths from "vite-tsconfig-paths";
 import path from "path";
 
 export default defineConfig({
+  base: './',
   plugins: [react(), viteTsconfigPaths()],
   resolve: {
     alias: {


### PR DESCRIPTION
The index.html that comes out of the build process used to look like this ...

```
<script type="module" crossorigin src="./assets/index-BPAE_Lh9.js"></script>    <link rel="stylesheet" crossorigin href="./assets/index-Bn2MldEb.css">
```

But since Shane's restructuring PR it looks like this ...

```
<script type="module" crossorigin src="/assets/index-BPAE_Lh9.js"></script>    <link rel="stylesheet" crossorigin href="/assets/index-Bn2MldEb.css">
```

Note the missing period. This PR gets the all-important period back in. It also fixes a copy issue that ben found