### PR TITLE
Pare down fields on Modal form

### DIFF
--- a/garden/src/features/gardens/components/ModalFunctions.tsx
+++ b/garden/src/features/gardens/components/ModalFunctions.tsx
@@ -9,10 +9,11 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
+import { GardenCreateFormData } from "../types/garden.types";
 import { useFormContext, useFieldArray } from "react-hook-form";
 
 const ModalFunctions = () => {
-  const { control } = useFormContext();
+  const { control } = useFormContext<GardenCreateFormData>();
   const { fields } = useFieldArray({
     name: "modal.modal_functions",
     control,
@@ -21,20 +22,24 @@ const ModalFunctions = () => {
   return (
     <div className="space-y-8">
       {fields.map((func, index) => (
-        <ModalFunction key={func.id} index={index} />
+        <ModalFunction 
+          key={func.id} 
+          index={index} 
+          functionName={func.function_name as string}
+        />
       ))}
     </div>
   );
 };
 
-const ModalFunction = ({ index }: { index: number }) => {
+const ModalFunction = ({ index, functionName }: { index: number, functionName: string }) => {
   const { control, watch } = useFormContext();
 
   const functionText = watch(`modal.modal_functions.${index}.function_text`);
   return (
     <div className="mb-6 rounded-lg bg-white p-6 shadow-md">
       <div className="mb-4 ">
-        <h3 className="text-xl font-semibold text-gray-800">Modal Function #{index + 1}</h3>
+        <h3 className="text-xl font-semibold text-gray-800">{functionName}</h3>
       </div>
 
       <div className="mb-4 grid grid-cols-1 gap-4 md:grid-cols-2">
@@ -48,50 +53,14 @@ const ModalFunction = ({ index }: { index: number }) => {
                 <Input {...field} type="text" className="w-full" placeholder="My Modal Function" />
               </FormControl>
               <FormDescription className="text-xs">
-                The title of your modal function. This will be displayed on the modal function page
+                The title of your function. This will be displayed on the function page
                 and appear in search results.
               </FormDescription>
               <FormMessage />
             </FormItem>
           )}
         />
-
-        <FormField
-          control={control}
-          name={`modal.modal_functions.${index}.year`}
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel className="font-bold text-gray-700">Year</FormLabel>
-              <FormControl>
-                <Input {...field} type="text" className="w-full" placeholder="2024" />
-              </FormControl>
-              <FormMessage />
-              <FormDescription className="text-xs">
-                The year this modal function was created.
-              </FormDescription>
-            </FormItem>
-          )}
-        />
       </div>
-
-      <FormField
-        control={control}
-        name={`modal.modal_functions.${index}.function_name`}
-        render={({ field }) => (
-          <FormItem className="mb-4">
-            <FormLabel className="font-bold text-gray-700">Function Name</FormLabel>
-            <FormControl>
-              <Input {...field} type="text" className="w-full" placeholder="my_function" />
-            </FormControl>
-            <FormMessage />
-            <FormDescription className="text-xs">
-              The Python name of your function. This must match the function name in your uploaded
-              file.
-            </FormDescription>
-          </FormItem>
-        )}
-      />
-
       <FormField
         control={control}
         name={`modal.modal_functions.${index}.description`}
@@ -101,13 +70,13 @@ const ModalFunction = ({ index }: { index: number }) => {
             <FormControl>
               <Textarea
                 {...field}
-                placeholder="A function that does something cool"
+                placeholder="This function takes X kind of input and returns Y kind of output in roughly Z seconds."
                 className="h-32 w-full resize-none"
               />
             </FormControl>
             <FormDescription className="text-xs">
-              A high level overview of your modal function, its purpose, and its contents. This will
-              be displayed on the modal function page and appear in search results.
+              A high level overview of your function, its purpose, and its contents. This will
+              be displayed on the function page and appear in search results.
             </FormDescription>
             <FormMessage />
           </FormItem>

--- a/garden/src/features/gardens/components/UploadModalFormFields.tsx
+++ b/garden/src/features/gardens/components/UploadModalFormFields.tsx
@@ -21,6 +21,7 @@ export const UploadModalFormFields = () => {
   const { mutateAsync: validateModalFile } = useValidateModalFile();
   const [fileContents, setFileContents] = React.useState("");
 
+  const appName = form.watch("modal.app_name");
   const handleFileUpload = async (
     field: ControllerRenderProps<FieldValues, "modal.file_contents">,
     e: React.ChangeEvent<HTMLInputElement>
@@ -30,7 +31,6 @@ export const UploadModalFormFields = () => {
       console.error("Could not find file");
       return;
     }
-    
     setIsFileUploading(true);
     try {
       const contents = await fileToString(file);
@@ -43,6 +43,7 @@ export const UploadModalFormFields = () => {
       }
 
       // Set all form values in a single batch
+      const currentYear = new Date().getFullYear().toString();
       form.reset((oldValues) => ({
         ...oldValues,
         modal: {
@@ -52,7 +53,9 @@ export const UploadModalFormFields = () => {
           modal_functions: modal_functions.map((func) => ({
             function_name: func.function_name,
             description: func.description,
-            year: "2024",
+            pip_requirements: func.requirements,
+            conda_requirements: func.conda_requirements,
+            year: currentYear,
             is_archived: false,
             doi: null,
             title: "",
@@ -76,11 +79,16 @@ export const UploadModalFormFields = () => {
     }
   };
 
+  let sectionTitle = "Modal App";
+  if (appName) {
+    sectionTitle += `: ${appName}`;
+  }  
+
   return (
     <div className="py-8">
       <div className="space-y-8">
         <section>
-          <h2 className="mb-2 text-2xl font-bold">Modal App</h2>
+          <h2 className="mb-2 text-2xl font-bold">{sectionTitle}</h2>
           <p className="mb-4 text-sm text-gray-500">
             Upload a Python file that defines your Modal App. Please see our{" "}
             <Link
@@ -128,52 +136,8 @@ export const UploadModalFormFields = () => {
             ) : (
               fileContents && (
                 <div>
-                  <FormField
-                    control={form.control}
-                    name="modal.app_name"
-                    render={({ field }) => (
-                      <FormItem className="mb-8">
-                        <FormLabel className="font-bold">App Name</FormLabel>
-                        <FormControl>
-                          <Input
-                            {...field}
-                            type="text"
-                            placeholder="my-app-name"
-                            className="w-full"
-                          />
-                        </FormControl>
-                        <FormDescription>
-                          The name of your Modal App. It is the string inside modal.App() in your
-                          Python file.
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="modal.base_image_name"
-                    render={({ field }) => (
-                      <FormItem className="mb-8">
-                        <FormLabel className="font-bold">Base Image Name</FormLabel>
-                        <FormControl>
-                          <Input
-                            {...field}
-                            type="text"
-                            placeholder="python3.11"
-                            className="w-full"
-                          />
-                        </FormControl>
-                        <FormDescription>
-                          The base image used by your Modal App.
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
                   <ModalFunctions />
                 </div>
-                
               )
             )}
           </div>

--- a/garden/src/features/gardens/components/create/CreateGardenForm.tsx
+++ b/garden/src/features/gardens/components/create/CreateGardenForm.tsx
@@ -55,10 +55,10 @@ export const CreateGardenForm = () => {
     try {
       let gardenCreateRequest: GardenCreateRequest = {
         ...values,
-        doi_is_draft: true, // Ensure this is set
-        is_archived: false, // Ensure this is set
-        publisher: "Garden-AI", // Ensure this is set
-        owner_identity_id: uuid || "", // Ensure this is set
+        doi_is_draft: true,
+        is_archived: false,
+        publisher: "Garden-AI",
+        owner_identity_id: uuid || "",
       };
 
       const formType = searchParams.get("type");
@@ -72,7 +72,7 @@ export const CreateGardenForm = () => {
           owner_identity_id: uuid,
           overwrite_existing: true,
         });
-        gardenCreateRequest.modal_function_ids = modalAppResponse.data.modal_function_ids.map(parseInt);
+        gardenCreateRequest.modal_function_ids = modalAppResponse.data.modal_function_ids.map(id => parseInt(id));
       }
 
       const { garden } = await createGardenAndDOI(gardenCreateRequest);

--- a/garden/src/features/gardens/components/create/CreateGardenFormFields.tsx
+++ b/garden/src/features/gardens/components/create/CreateGardenFormFields.tsx
@@ -174,39 +174,6 @@ export const CreateGardenFormFields = () => {
         />
       </div>
 
-      <div className="space-y-8">
-        <h2 className="text-2xl font-bold">Miscellaneous</h2>
-
-        <FormField
-          control={form.control}
-          name="language"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel className="font-bold">Language</FormLabel>
-              <FormControl>
-                <Input placeholder="en" {...field} />
-              </FormControl>
-              <FormDescription>The language of your Garden.</FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-        <FormField
-          control={form.control}
-          name="version"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel className="font-bold">Version</FormLabel>
-              <FormControl>
-                <Input placeholder="1.0.0" {...field} />
-              </FormControl>
-              <FormDescription>The version of your Garden.</FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-      </div>
-
       <div className="mt-8 flex justify-end gap-2">
         <Button type="submit" className={"inline-block"}>
           {isSubmitting ? "Creating Garden..." : "Create Garden"}


### PR DESCRIPTION
Closes #231

This PR trims down forms from the Modal app submission form. Make the user think as little as possible!

There are some fields that are just boilerplate where we can submit the right thing. (eg, version number, language code) There are some fields that we infer that the user shouldn't edit (eg, function name, app name, image name). If the user shouldn't edit the field, it shouldn't be a field. We still gather this info, save it on the backend, and show it in the appropriate places.

## Before

![Screenshot 2024-12-09 at 3 19 07 PM](https://github.com/user-attachments/assets/b4056cf7-1b22-415f-9d3d-f9fbd9564c6d)
![Screenshot 2024-12-09 at 3 19 02 PM](https://github.com/user-attachments/assets/15c213c3-890d-4958-9455-b465207e4a96)
![Screenshot 2024-12-09 at 3 18 54 PM](https://github.com/user-attachments/assets/b18ea264-69ea-4dbf-b27e-74b1d13f65b7)
![Screenshot 2024-12-09 at 3 18 46 PM](https://github.com/user-attachments/assets/757335bf-4e08-40c6-8e4e-f9b5c422a0dc)

## After

The "General" section is unchanged. Here are the parts that are changed.

![Screenshot 2024-12-09 at 3 21 22 PM](https://github.com/user-attachments/assets/0963191c-b6f6-4ce4-92b8-3476af6cd527)
![Screenshot 2024-12-09 at 3 21 16 PM](https://github.com/user-attachments/assets/84ce381a-2148-430d-b9fd-54fdb8661c68)



