### PR TITLE
Don't tie search visibility to DOI status

### DIFF
--- a/garden/src/components/HomePage.tsx
+++ b/garden/src/components/HomePage.tsx
@@ -59,6 +59,7 @@ const HomePage = () => {
       owner_identity_id: "100",
       id: 100,
       modal_function_ids: [],
+      is_test: false,
     },
     {
       title: "Atom segmentation deep learning models",
@@ -73,6 +74,7 @@ const HomePage = () => {
       owner_identity_id: "100",
       id: 100,
       modal_function_ids: [],
+      is_test: false,
     },
     {
       title: "Transmission electron microscopy (TEM) video analysis models",
@@ -101,6 +103,7 @@ const HomePage = () => {
       owner_identity_id: "100",
       id: 100,
       modal_function_ids: [],
+      is_test: false,
     },
     {
       title: "Semiconductor property prediction models",
@@ -114,6 +117,7 @@ const HomePage = () => {
       owner_identity_id: "100",
       id: 100,
       modal_function_ids: [],
+      is_test: false,
     },
     {
       title: "Materials Screening Performance Tests",
@@ -127,6 +131,7 @@ const HomePage = () => {
       owner_identity_id: "100",
       id: 100,
       modal_function_ids: [],
+      is_test: false,
     },
     {
       title: "Framework example garden",
@@ -141,6 +146,7 @@ const HomePage = () => {
       owner_identity_id: "100",
       id: 100,
       modal_function_ids: [],
+      is_test: false,
     },
   ];
 

--- a/garden/src/components/HomePage.tsx
+++ b/garden/src/components/HomePage.tsx
@@ -89,6 +89,7 @@ const HomePage = () => {
       owner_identity_id: "100",
       id: 100,
       modal_function_ids: [],
+      is_test: false,
     },
     {
       title: "Models for processing position-averaged convergent beam electron diffraction images",

--- a/garden/src/features/gardens/components/GardenDropdownOptions.tsx
+++ b/garden/src/features/gardens/components/GardenDropdownOptions.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { Archive, Edit, EllipsisVertical, Globe, Trash, TriangleAlert } from "lucide-react";
+import { Archive, Edit, EllipsisVertical, Globe, Trash, TriangleAlert, FlaskConical } from "lucide-react";
 
 import { useUpdateDOI } from "@/api/doi/useUpdateDOI";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
@@ -42,6 +42,7 @@ const GardenDropdownMenu = ({ garden }: { garden: Garden }) => {
   const [isPublishGardenModalOpen, setIsPublishGardenModalOpen] = React.useState(false);
   const [isDeleteGardenModalOpen, setIsDeleteGardenModalOpen] = React.useState(false);
   const [isArchiveGardenModalOpen, setIsArchiveGardenModalOpen] = React.useState(false);
+  const [isMakeTestModalOpen, setIsMakeTestModalOpen] = React.useState(false);
 
   if (!auth.isAuthenticated || garden.owner_identity_id !== auth.authorization?.user?.sub) {
     return null;
@@ -69,8 +70,15 @@ const GardenDropdownMenu = ({ garden }: { garden: Garden }) => {
             <>
               <DropdownMenuItem onSelect={() => setIsPublishGardenModalOpen(true)}>
                 <Globe className="mr-2 h-5 w-5" />
-                <span className="">Publish Garden</span>
+                <span className="">Register Garden DOI</span>
               </DropdownMenuItem>
+
+              {!garden.is_test && (
+                <DropdownMenuItem onSelect={() => setIsMakeTestModalOpen(true)}>
+                  <FlaskConical className="mr-2 h-5 w-5" />
+                  <span className="">Make Test Garden</span>
+                </DropdownMenuItem>
+              )}
 
               <DropdownMenuItem
                 onSelect={() => setIsDeleteGardenModalOpen(true)}
@@ -114,6 +122,12 @@ const GardenDropdownMenu = ({ garden }: { garden: Garden }) => {
         isOpen={isArchiveGardenModalOpen}
         setIsOpen={setIsArchiveGardenModalOpen}
       />
+      
+      <MakeTestGardenModal 
+        garden={garden}
+        isOpen={isMakeTestModalOpen}
+        setIsOpen={setIsMakeTestModalOpen}
+      />
     </>
   );
 };
@@ -145,7 +159,7 @@ const PublishGardenModal = ({
 
   const doi = garden.doi;
 
-  const handlePublishGarden = () => {
+  const handleRegisterGardenDOI = () => {
     updateDOI(
       {
         resource: garden,
@@ -156,10 +170,10 @@ const PublishGardenModal = ({
         onSuccess: () => {
           setIsOpen(false);
           setInput("");
-          toast.success("Garden published successfully!");
+          toast.success("Garden DOI registered successfully!");
           updateGarden({
             doi,
-            garden: { doi_is_draft: false, is_archived: false },
+            garden: { doi_is_draft: false, is_archived: false, is_test: false },
           });
 
           for (const entrypoint of garden.entrypoints || []) {
@@ -195,9 +209,9 @@ const PublishGardenModal = ({
     <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Publish Garden</AlertDialogTitle>
+          <AlertDialogTitle>Register Garden DOI</AlertDialogTitle>
           <AlertDialogDescription className="pb-4">
-            Publish your garden to make it findable on the web.
+            Register your garden's DOI to make it citable.
           </AlertDialogDescription>
           <Alert className="my-4 rounded-lg border-yellow-200 bg-yellow-50 p-4 text-yellow-800 shadow-md">
             <div className="mb-2 flex items-center space-x-2">
@@ -206,21 +220,21 @@ const PublishGardenModal = ({
             </div>
             <AlertDescription className="space-y-4">
               <ul className="list-disc space-y-1 pl-5">
-                <li>This will make your Garden public and available to everyone.</li>
-                <li>Published gardens can be archived (hidden) but not deleted.</li>
+                <li>This will make your Garden's DOI findable on doi.org.</li>
+                <li>Gardens with registered DOIs can be archived (hidden) but not deleted.</li>
               </ul>
             </AlertDescription>
           </Alert>
 
           <p className="pt-3 text-sm">
             Please type
-            <span className="font-semibold"> publish {doi} </span>to confirm:
+            <span className="font-semibold"> register {doi} </span>to confirm:
           </p>
           <div className=" mb-4">
             <Input
               type="text"
               className="mt-2 w-full rounded border border-gray-300 p-2"
-              placeholder={`publish ${doi}`}
+              placeholder={`register ${doi}`}
               value={input}
               onChange={(e) => setInput(e.target.value)}
               onPaste={(e) => {
@@ -235,21 +249,93 @@ const PublishGardenModal = ({
               checked={updateEntrypoints}
               onCheckedChange={(checked: boolean) => setUpdateEntrypoints(checked)}
             />
-            <Label className="">Also publish this Garden's entrypoints</Label>
+            <Label className="">Also register DOIs for all functions in this Garden</Label>
           </div>
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
           <AlertDialogAction
-            onClick={handlePublishGarden}
+            onClick={handleRegisterGardenDOI}
             disabled={isPending || input !== `publish ${doi}`}
             className="bg-primary hover:bg-primary/60"
           >
-            I understand, publish Garden
+            I understand, register DOI for this Garden
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
 
+      {isPending && <LoadingOverlay />}
+    </AlertDialog>
+  );
+};
+
+const MakeTestGardenModal = ({
+  garden,
+  isOpen,
+  setIsOpen,
+}: {
+  garden: Garden;
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+}) => {
+  const queryClient = useQueryClient();
+  const { mutate: updateGarden, isPending } = usePatchGarden();
+  const doi = garden.doi;
+
+  const handleMakeTestGarden = () => {
+    updateGarden(
+      {
+        doi,
+        garden: {
+          is_test: true
+        },
+      },
+      {
+        onSuccess: () => {
+          setIsOpen(false);
+          queryClient.invalidateQueries({ queryKey: ["garden", doi] });
+          toast.success("Garden converted to test mode successfully!");
+        },
+        onError: () => {
+          toast.error("Error converting garden to test mode");
+        },
+      }
+    );
+  };
+
+  return (
+    <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Convert to Test Garden</AlertDialogTitle>
+          <AlertDialogDescription className="pb-3">
+            Are you sure you want to convert this to a test garden?
+          </AlertDialogDescription>
+          <Alert className="rounded-lg border-yellow-200 bg-yellow-50 p-4 text-yellow-800 shadow-md">
+            <div className="mb-2 flex items-center space-x-2">
+              <FlaskConical className="mb-1 h-5 w-5 text-yellow-600" />
+              <AlertTitle className="text-lg font-semibold">What This Means</AlertTitle>
+            </div>
+            <AlertDescription className="space-y-4">
+              <ul className="list-disc space-y-1 pl-5">
+                <li>The garden will no longer appear in search results</li>
+                <li>Users can still access it directly via the URL</li>
+                <li>You can make it public again at any time</li>
+              </ul>
+            </AlertDescription>
+          </Alert>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleMakeTestGarden}
+            disabled={isPending}
+            className="bg-primary hover:bg-primary/60"
+          >
+            Make Test Garden
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
       {isPending && <LoadingOverlay />}
     </AlertDialog>
   );

--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -134,9 +134,6 @@ const GardenBody = ({ garden }: { garden: Garden }) => {
 };
 
 const VisibilityWarning = ({ garden, updateGarden }: { garden: Garden; updateGarden: Function }) => {
-  if (!auth.isAuthenticated || garden.owner_identity_id !== auth.authorization?.user?.sub) {
-    return null;
-  }
   const [isUpdating, setIsUpdating] = React.useState(false);
   const queryClient = useQueryClient();
 

--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -34,6 +34,7 @@ const GardenPage = () => {
     return <NotFoundPage />;
   }
 
+  const auth = useGlobusAuth();
   const { data: garden, isLoading, isError } = useGetGarden(doi);
   const { mutate: updateGarden } = usePatchGarden();
 
@@ -47,6 +48,7 @@ const GardenPage = () => {
   if (garden.is_archived) {
     return <TombstonePage garden={garden} />;
   }
+  const ownsThisGarden = auth.isAuthenticated && garden.owner_identity_id === auth?.authorization?.user?.sub;
 
   return (
     <div className="mx-auto max-w-7xl px-8 pt-16 font-display">
@@ -60,19 +62,16 @@ const GardenPage = () => {
           },
         ]}
       />
-      <GardenHeader garden={garden} />
+      <GardenHeader garden={garden} ownsThisGarden={ownsThisGarden} />
       <GardenBody garden={garden} />
-      {garden.is_test && <VisibilityWarning garden={garden} updateGarden={updateGarden} />}
+      {ownsThisGarden && garden.is_test && <VisibilityWarning garden={garden} updateGarden={updateGarden} />}
       <GardenAccordion garden={garden} />
       <RelatedGardens doi={garden.doi} />
     </div>
   );
 };
 
-const GardenHeader = ({ garden }: { garden: Garden }) => {
-  const auth = useGlobusAuth();
-  const ownsThisGarden = garden.owner_identity_id === auth?.authorization?.user?.sub;
-
+const GardenHeader = ({ garden, ownsThisGarden }: { garden: Garden, ownsThisGarden: boolean }) => {
   return (
     <div className="my-8 flex items-center justify-between gap-2 sm:gap-4">
       <div className="flex items-center">
@@ -135,6 +134,9 @@ const GardenBody = ({ garden }: { garden: Garden }) => {
 };
 
 const VisibilityWarning = ({ garden, updateGarden }: { garden: Garden; updateGarden: Function }) => {
+  if (!auth.isAuthenticated || garden.owner_identity_id !== auth.authorization?.user?.sub) {
+    return null;
+  }
   const [isUpdating, setIsUpdating] = React.useState(false);
   const queryClient = useQueryClient();
 

--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -146,6 +146,10 @@ const VisibilityWarning = ({ garden, updateGarden }: { garden: Garden; updateGar
         garden: { is_test: false }
       },
       {
+        onSuccess: () => {
+          queryClient.invalidateQueries({ queryKey: ["gardens"] });
+          queryClient.invalidateQueries({ queryKey: ["search"] });
+        },
         onError: () => {
           toast.error("Failed to make garden public. Please try again.");
         },

--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -1,9 +1,12 @@
+import React from "react";
+
 import { Link, useParams } from "react-router-dom";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { LinkIcon } from "lucide-react";
+import { LinkIcon, FlaskConicalIcon } from "lucide-react";
+import { toast } from "sonner";
 
 import Breadcrumb from "@/components/Breadcrumb";
 import CopyButton from "@/components/CopyButton";
@@ -15,11 +18,13 @@ import NotFoundPage from "@/components/NotFoundPage";
 import RelatedGardens from "@/features/gardens/components/RelatedGardens";
 import ShareModal from "@/components/ShareModal";
 import TombstonePage from "@/components/TombstonePage";
+import LoadingSpinner from "@/components/LoadingSpinner";
 
 import { useGetGarden } from "../api/useGetGarden";
+import { usePatchGarden } from "../api/usePatchGarden";
+import { useQueryClient } from "@tanstack/react-query";
 import { Garden } from "@/types";
 
-import { cn } from "@/utils/form.utils";
 import { useGlobusAuth } from "@/hooks/useGlobusAuth";
 import SaveGardenButton from "./SaveGardenButton";
 
@@ -30,6 +35,7 @@ const GardenPage = () => {
   }
 
   const { data: garden, isLoading, isError } = useGetGarden(doi);
+  const { mutate: updateGarden } = usePatchGarden();
 
   if (isLoading) {
     return <LoadingOverlay />;
@@ -56,6 +62,7 @@ const GardenPage = () => {
       />
       <GardenHeader garden={garden} />
       <GardenBody garden={garden} />
+      {garden.is_test && <VisibilityWarning garden={garden} updateGarden={updateGarden} />}
       <GardenAccordion garden={garden} />
       <RelatedGardens doi={garden.doi} />
     </div>
@@ -64,17 +71,15 @@ const GardenPage = () => {
 
 const GardenHeader = ({ garden }: { garden: Garden }) => {
   const auth = useGlobusAuth();
+  const ownsThisGarden = garden.owner_identity_id === auth?.authorization?.user?.sub;
 
   return (
     <div className="my-8 flex items-center justify-between gap-2 sm:gap-4">
       <div className="flex items-center">
         <h1 className="text-2xl sm:text-3xl">{garden.title}</h1>
-        {garden.owner_identity_id === auth?.authorization?.user?.sub && (
-          <Badge
-            className="ml-4 mt-1 px-3 text-sm"
-            variant={cn(garden.doi_is_draft ? "outline" : "default") as "default" | "outline"}
-          >
-            {garden.doi_is_draft ? "Draft" : garden.is_archived ? "Archived" : "Published"}
+        {ownsThisGarden && garden.is_archived && (
+          <Badge className="ml-4 mt-1 px-3 text-sm" variant={"default"}>
+            {"Archived"}
           </Badge>
         )}
       </div>
@@ -94,7 +99,7 @@ const GardenHeader = ({ garden }: { garden: Garden }) => {
 
 const GardenBody = ({ garden }: { garden: Garden }) => {
   return (
-    <div className="mb-20 rounded-lg border-0 bg-gray-100 p-4 text-sm text-gray-700">
+    <div className="mb-5 rounded-lg border-0 bg-gray-100 p-4 text-sm text-gray-700">
       <div className="flex w-full flex-row justify-between">
         <div className="mb-4">
           <h2 className="font-semibold">Contributors</h2>
@@ -113,11 +118,70 @@ const GardenBody = ({ garden }: { garden: Garden }) => {
             {garden.doi}
           </a>
           <CopyButton content={garden.doi} hint="Copy DOI" className="h-8 w-8 p-0.5" />
+          <Badge 
+            variant={garden.doi_is_draft ? "outline" : "default"}
+            className="text-xs font-medium"
+          >
+            {garden.doi_is_draft ? "Draft" : "Registered"}
+          </Badge>
         </div>
       </div>
       <div>
         <h2 className="font-semibold">Description</h2>
         <p>{garden.description}</p>
+      </div>
+    </div>
+  );
+};
+
+const VisibilityWarning = ({ garden, updateGarden }: { garden: Garden; updateGarden: Function }) => {
+  const [isUpdating, setIsUpdating] = React.useState(false);
+  const queryClient = useQueryClient();
+
+  const handleMakePublic = () => {
+    setIsUpdating(true);
+    updateGarden(
+      {
+        doi: garden.doi,
+        garden: { is_test: false }
+      },
+      {
+        onError: () => {
+          toast.error("Failed to make garden public. Please try again.");
+        },
+        onSettled: () => {
+          setIsUpdating(false);
+        }
+      }
+    );
+  };
+
+  return (
+    <div className="mb-6 rounded-lg border-2 border-yellow-200 bg-yellow-50 p-4">
+      <div className="flex items-start gap-3">
+        <FlaskConicalIcon className="mt-1 h-5 w-5 text-yellow-600" />
+        <div>
+          <h3 className="font-medium text-yellow-900">This is a Test Garden</h3>
+          <p className="mt-1 text-sm text-yellow-700">
+            This garden won't show up in search results. Other users can still access it directly if you share the link.
+          </p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-3 border-yellow-300 text-yellow-700 hover:bg-yellow-100 hover:text-yellow-800"
+            onClick={handleMakePublic}
+            disabled={isUpdating}
+          >
+            {isUpdating ? (
+              <>
+                <LoadingSpinner/>
+                Making Public...
+              </>
+            ) : (
+              "Make Garden Public"
+            )}
+          </Button>
+        </div>
       </div>
     </div>
   );
@@ -136,7 +200,7 @@ const GardenAccordion = ({ garden }: { garden: Garden }) => {
     },
   ];
   return (
-    <Tabs defaultValue="entrypoints" className="mb-12 min-h-[400px] w-full">
+    <Tabs defaultValue="entrypoints" className="mb-12 mt-10 min-h-[400px] w-full">
       <TabsList className="m-0 grid w-full grid-cols-2 rounded-none bg-transparent p-0 ">
         {tabs.map(({ name }) => (
           <TabsTrigger

--- a/garden/src/features/gardens/components/create/CreateGardenForm.tsx
+++ b/garden/src/features/gardens/components/create/CreateGardenForm.tsx
@@ -29,16 +29,17 @@ export const CreateGardenForm = () => {
       description: "",
       authors: [],
       contributors: [],
-      entrypoint_ids: [], // Required
+      entrypoint_ids: [],
       doi: "", // Will be generated
-      doi_is_draft: true, // Required
+      doi_is_draft: true,
+      is_test: true,
       year: "2024",
       language: "en",
       tags: [],
       version: "1.0.0",
-      owner_identity_id: uuid || "", // Required - from auth
-      publisher: "Garden-AI", // Required
-      is_archived: false, // Required
+      owner_identity_id: uuid || "",
+      publisher: "Garden-AI",
+      is_archived: false,
       modal: {
         app_name: "",
         file_contents: "",

--- a/garden/src/features/gardens/components/create/CreateGardenFormFields.tsx
+++ b/garden/src/features/gardens/components/create/CreateGardenFormFields.tsx
@@ -1,7 +1,10 @@
 import { UseFormReturn, useFormContext } from "react-hook-form";
 import { useSearchParams } from "react-router-dom";
 
+import { FlaskConicalIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+
 import {
   FormControl,
   FormDescription,
@@ -25,6 +28,9 @@ export const CreateGardenFormFields = () => {
   const { isSubmitting } = form.formState;
 
   const [searchParams, setSearchParams] = useSearchParams();
+
+  const isTestGarden = form.watch("is_test");
+
   return (
     <div className="space-y-12">
       <div className="space-y-8">
@@ -120,6 +126,36 @@ export const CreateGardenFormFields = () => {
       )}
 
       <div className="space-y-8">
+        <h2 className="text-2xl font-semibold">Visibility Settings</h2>
+        <div className="mt-8">
+          <FormField
+              control={form.control}
+              name="is_test"
+              render={({ field }) => (
+                <FormItem className="space-y-1">
+                  <div className="flex items-center justify-between rounded-lg border border-gray-100 bg-white p-4">
+                    <div className="flex items-center gap-2">
+                      <FlaskConicalIcon className="h-5 w-5 text-gray-500" />
+                      <div>
+                        <h3 className="text-base font-medium text-gray-900">Make this a test Garden</h3>
+                        <p className="text-sm text-gray-500">If checked, this Garden will not be visible in search results. (You can change this later)</p>
+                      </div>
+                    </div>
+                    <FormControl>
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                        className="data-[state=checked]:bg-primary"
+                      />
+                    </FormControl>
+                  </div>
+                </FormItem>
+              )}
+            />
+        </div>
+      </div>
+
+      <div className="space-y-8">
         <h2 className="text-2xl font-bold">Contributors</h2>
         <FormField
           control={form.control}
@@ -176,7 +212,7 @@ export const CreateGardenFormFields = () => {
 
       <div className="mt-8 flex justify-end gap-2">
         <Button type="submit" className={"inline-block"}>
-          {isSubmitting ? "Creating Garden..." : "Create Garden"}
+          {isSubmitting ? "Creating Garden..." : `Create ${isTestGarden ? "Test": ""} Garden`}
         </Button>
       </div>
     </div>

--- a/garden/src/features/gardens/types/garden.types.ts
+++ b/garden/src/features/gardens/types/garden.types.ts
@@ -32,6 +32,7 @@ export const gardenFormSchema = z
     publisher: z.string(),
     doi: z.string(),
     is_archived: z.boolean(),
+    is_test: z.boolean(),
     modal: z.object({
       app_name: z.string(),
       base_image_name: z.string(),

--- a/garden/src/features/search/api/useSearchGardens.ts
+++ b/garden/src/features/search/api/useSearchGardens.ts
@@ -44,7 +44,7 @@ export const transformSearchParamsToSearchRequest = (searchParams: URLSearchPara
 
   const defaultFilters: GardenSearchFilter[] = [
     {
-      field_name: "doi_is_draft",
+      field_name: "is_test",
       values: ["false"],
     },
     {

--- a/garden/src/types/backend-schema.ts
+++ b/garden/src/types/backend-schema.ts
@@ -1294,6 +1294,11 @@ export interface components {
             doi: string;
             /** Doi Is Draft */
             doi_is_draft?: boolean | null;
+            /**
+             * Is Test
+             * @default false
+             */
+            is_test: boolean;
             /** Description */
             description: string | null;
             /**
@@ -1343,6 +1348,11 @@ export interface components {
             doi: string;
             /** Doi Is Draft */
             doi_is_draft?: boolean | null;
+            /**
+             * Is Test
+             * @default false
+             */
+            is_test: boolean;
             /** Description */
             description: string | null;
             /**
@@ -1417,6 +1427,8 @@ export interface components {
             };
             /** Is Archived */
             is_archived?: boolean | null;
+            /** Is Test */
+            is_test?: boolean | null;
             /** Entrypoint Ids */
             entrypoint_ids?: string[] | null;
         };


### PR DESCRIPTION
Closes https://github.com/Garden-AI/garden-frontend/issues/228

This PR
- Updates the Garden creation form with a new option to publish a garden as a "test" or not
- Uses a garden's test status to determine whether to show/hide it in search
- Adds options in the garden detail page to make a test garden public or vice versa

Screenshots ...


<img width="965" alt="Screenshot 2024-12-12 at 12 03 18 PM" src="https://github.com/user-attachments/assets/a05e825b-3b6f-4ccc-9d8e-689322100b73" />
<img width="1009" alt="Screenshot 2024-12-12 at 12 03 14 PM" src="https://github.com/user-attachments/assets/f14fd3f2-64ca-4ede-bdd8-073e0549c8ae" />
<img width="1115" alt="Screenshot 2024-12-12 at 12 03 03 PM" src="https://github.com/user-attachments/assets/be16172c-3947-4122-9ffe-2b8b44a9a360" />

<img width="1125" alt="Screenshot 2024-12-12 at 12 02 52 PM" src="https://github.com/user-attachments/assets/1a7ee889-ff64-4287-9cef-90b4d28264c0" />
