### PR TITLE
Fix typo in footer

### DIFF
--- a/garden/src/components/Footer.tsx
+++ b/garden/src/components/Footer.tsx
@@ -46,7 +46,7 @@ const Footer = () => {
                 href="https://github.com/Garden-AI/garden/issues"
                 className="no-underline hover:underline"
               >
-                Github
+                GitHub
               </a>
             </p>
             <p>


### PR DESCRIPTION
Capitalize H in GitHub in the footer.