### PR TITLE
Remove copy and share buttons from modal function if doi is null

### DIFF
--- a/garden/src/features/modal/components/ModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/ModalFunctionPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from "react-router-dom";
+import { useLocation, useParams } from "react-router-dom";
 
 import { useGetModalFunction } from "../api/useGetModalFunction";
 
@@ -53,18 +53,20 @@ const ModalFunctionPage = () => {
 const ModalFunctionHeader = ({ modalFunction }: { modalFunction: ModalFunction }) => {
   return (
     <div>
-      <div className="mb-4 ">
+      <div className="mb-4">
         <div className="flex flex-row justify-between">
           <h1 className="text-xl md:text-3xl">{modalFunction.title}</h1>
-          <div className="hidden flex-col items-center md:flex md:flex-row">
-            <CopyButton
-              hint="Copy Link"
-              content={`https://doi.org/${modalFunction.doi}`}
-              icon={<LinkIcon />}
-              className="border-none bg-transparent"
-            />
-            <ShareModal doi={modalFunction.doi!} />
-          </div>
+          {modalFunction.doi && (
+            <div className="hidden flex-col items-center md:flex md:flex-row">
+              <CopyButton
+                hint="Copy Link"
+                content={`https://doi.org/${modalFunction.doi}`}
+                icon={<LinkIcon />}
+                className="border-none bg-transparent"
+              />
+              <ShareModal doi={modalFunction.doi} />
+            </div>
+          )}
         </div>
       </div>
     </div>
@@ -76,7 +78,7 @@ const ModalFunctionBody = ({ modalFunction }: { modalFunction: ModalFunction }) 
     <div className="space-y-6 py-6">
       <div className="mb-6 flex flex-wrap items-center gap-1 text-sm text-gray-500">
         <span>
-          DOI: {modalFunction.doi} | {modalFunction.year} |{" "}
+          {modalFunction.doi ? `DOI: ${modalFunction.doi} | ` : ""} {modalFunction.year} |{" "}
         </span>
         <TagIcon className="h-4 w-4" />
         <span>{modalFunction.tags?.join(", ")}</span>

--- a/garden/src/features/modal/components/ModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/ModalFunctionPage.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 
 import { useGetModalFunction } from "../api/useGetModalFunction";
 


### PR DESCRIPTION
Resolves: #243 

This PR removes the copy and share buttons from the modal function page if the function does not have a doi.

Before:
![image](https://github.com/user-attachments/assets/9b533d66-fc67-4b63-aa90-0a3904230f88)

![image](https://github.com/user-attachments/assets/1a55a77d-5f0f-48f2-b67a-aed3ab1c41ae)


After this PR (notice the lack of copy and share buttons):
![image](https://github.com/user-attachments/assets/8a19313d-f1e3-443e-911b-3fda1d4d60c5)
