### PR TITLE
Clean up deploy timeout interaction

### DIFF
--- a/garden/src/features/gardens/api/useCreateModalApp.tsx
+++ b/garden/src/features/gardens/api/useCreateModalApp.tsx
@@ -10,17 +10,39 @@ export const useCreateModalApp = () => {
   });
 };
 
+export class DeployTimeoutError extends Error {
+  constructor() {
+    const timeoutMsg = `This Garden is taking a long time to deploy. 
+          If your Modal App downloads large files or installs large libraries, this may be expected.
+          The installation is still happening in the background. 
+          Leave the form as it is, wait a few minutes, and try submitting again.`
+    super(timeoutMsg);
+    this.name = "DeployTimeoutError";
+  }
+}
+
 const createModalApp = async (
   req: ModalAppCreateRequest,
 ): Promise<AxiosResponse<ModalAppMetadataResponse>> => {
   try {
     // Make the initial request
     const response = await axios.post(`/modal-apps/async`, req);
+    
     // Extract the job id from the response
-    // const status = response.data.deploy_status
     const appId = response.data.id
+
+    // Set a timeout that is slightly shorter than the backend Lambda timeout
+    // 4 minutes + 55 seconds
+    const timeoutDuration = (4 * 60 * 1000) + (55 * 1000);
+    const startTime = Date.now();
+
     // Poll the job status
     while (true) {
+      // Check if we've exceeded the timeout
+      if (Date.now() - startTime > timeoutDuration) {
+        throw new DeployTimeoutError();
+      }
+
       const pollResponse = await axios.get(`/modal-apps/${appId}`);
       if (pollResponse.data.deploy_status === "error") {
         throw new ApiError(pollResponse.data.deploy_error);
@@ -29,7 +51,6 @@ const createModalApp = async (
         return pollResponse;
       }
       await new Promise((resolve) => setTimeout(resolve, 1000));
-      // TODO: Add a ... 2 minute? ... timeout
     }
 
   } catch (error: unknown) {

--- a/garden/src/features/gardens/components/create/CreateGardenForm.tsx
+++ b/garden/src/features/gardens/components/create/CreateGardenForm.tsx
@@ -8,7 +8,7 @@ import { Form } from "@/components/ui/form";
 import LoadingSpinner from "@/components/LoadingSpinner";
 import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
 import { CreateGardenFormFields } from "./CreateGardenFormFields";
-import { useCreateModalApp } from "../../api/useCreateModalApp";
+import { useCreateModalApp, DeployTimeoutError } from "../../api/useCreateModalApp";
 import { useCreateGardenAndDOI } from "../../api/useCreateGardenAndDOI";
 import { GardenCreateRequest } from "@/types";
 import { ApiError } from "../../utils/garden.utils";
@@ -83,6 +83,10 @@ export const CreateGardenForm = () => {
       toast.success("Garden created successfully!");
       navigate(`/garden/${encodeURIComponent(garden.doi)}`);
     } catch (error: unknown) {
+      if (error instanceof DeployTimeoutError) {
+        toast.warning(error.message, {closeButton: true, duration: 15000})
+        return;
+      }
       if (error instanceof AxiosError) {
          error = ApiError.fromAxiosError(error);
       }

--- a/garden/src/features/gardens/components/create/CreateGardenPage.tsx
+++ b/garden/src/features/gardens/components/create/CreateGardenPage.tsx
@@ -88,11 +88,17 @@ const GlobusGroupError = () => {
         <div className="space-y-12 text-center">
           <h1 className="text-4xl font-bold">Globus Group Required</h1>
           <p className="text-gray-700">
-            You must be a part of the Globus Group to create a Modal App. Please email{" "}
-            <a href="mailto:wengler@uchicago.edu" className="font-bold text-primary">
-              Will Engler (wengler@chicago.edu)
+            You must be a part of the publishing Globus Group to publish a Garden via a Modal App. Please email{" "}
+            <a href="mailto:willengler@uchicago.edu" className="font-bold text-primary">
+              Will Engler (willengler@uchicago.edu)
             </a>{" "}
-            to be added to the group.
+            or{" "}
+            <a href="mailto:owenpriceskelly@uchicago.edu" className="font-bold text-primary">
+              Owen Price Skelly (owenpriceskelly@uchicago.edu)
+            </a>{" "} to be added to the group. Include the email address linked to your Globus account.
+          </p>
+          <p className="text-gray-700">
+            If you are already a member of the group and are seeing this message, please try logging out and logging back in.
           </p>
           <div className=" flex items-center justify-center space-x-4">
             <Button onClick={() => navigate("/")} className="font-bold">


### PR DESCRIPTION
Before this PR, Modal App deployments would cause the frontend to keep polling the backend until it sees an error, and then the frontend would show a vague "internal error" toast. This PR handles the case where there hasn't been an error in Modal App deployment but it hasn't completed in the time it takes an initial lambda function invocation to deploy it. In this case, we show a descriptive error message to the user instructing them to retry.

This PR also tweaks the copy on the version of the Modal submission form that shows up if you're not in the publishing group. It includes my own (fixed) email address and Owen's now too.