### PR TITLE
Allow pasting and fix DOI registration text check

### DIFF
--- a/garden/src/features/gardens/components/GardenDropdownOptions.tsx
+++ b/garden/src/features/gardens/components/GardenDropdownOptions.tsx
@@ -237,10 +237,6 @@ const PublishGardenModal = ({
               placeholder={`register ${doi}`}
               value={input}
               onChange={(e) => setInput(e.target.value)}
-              onPaste={(e) => {
-                e.preventDefault();
-                return false;
-              }}
             />
           </div>
           <div className="flex items-center space-x-2 py-4">
@@ -256,7 +252,7 @@ const PublishGardenModal = ({
           <AlertDialogCancel>Cancel</AlertDialogCancel>
           <AlertDialogAction
             onClick={handleRegisterGardenDOI}
-            disabled={isPending || input !== `publish ${doi}`}
+            disabled={isPending || input !== `register ${doi}`}
             className="bg-primary hover:bg-primary/60"
           >
             I understand, register DOI for this Garden
@@ -402,10 +398,6 @@ const DeleteGardenModal = ({
               placeholder={`delete ${doi}`}
               value={input}
               onChange={(e) => setInput(e.target.value)}
-              onPaste={(e) => {
-                e.preventDefault();
-                return false;
-              }}
             />
           </div>
         </AlertDialogHeader>
@@ -498,10 +490,6 @@ const ArchiveGardenModal = ({
               placeholder={`archive ${doi}`}
               value={input}
               onChange={(e) => setInput(e.target.value)}
-              onPaste={(e) => {
-                e.preventDefault();
-                return false;
-              }}
             />
           </div>
         </AlertDialogHeader>


### PR DESCRIPTION
Fixes #247. Also fixes another issue that Ben G reported where the register DOI dialog wasn't satisfied when the requested text was put into the form.

Now users can copy/paste "publish {garden DOI}" or similar into our confirmation dialogs.

![Screenshot 2025-01-27 at 10 33 02 AM](https://github.com/user-attachments/assets/f54c40c2-ac13-4a53-8c90-5e1503a049a0)
