### PR TITLE
example_usage field for new modal functions

### DIFF
--- a/garden/src/features/gardens/components/ModalFunctions.tsx
+++ b/garden/src/features/gardens/components/ModalFunctions.tsx
@@ -22,9 +22,9 @@ const ModalFunctions = () => {
   return (
     <div className="space-y-8">
       {fields.map((func, index) => (
-        <ModalFunction 
-          key={func.id} 
-          index={index} 
+        <ModalFunction
+          key={func.id}
+          index={index}
           functionName={func.function_name as string}
         />
       ))}
@@ -36,6 +36,15 @@ const ModalFunction = ({ index, functionName }: { index: number, functionName: s
   const { control, watch } = useFormContext();
 
   const functionText = watch(`modal.modal_functions.${index}.function_text`);
+  const exampleUsage = watch(`modal.modal_functions.${index}.example_usage`);
+  // Build the complete example text with preamble
+  const completeExampleText = `from garden_ai import GardenClient
+client = GardenClient()
+my_garden = client.get_garden(my_garden_doi)
+
+${exampleUsage || `input = ['Data Here']
+return my_garden.${functionName}(input)`}`;
+
   return (
     <div className="mb-6 rounded-lg bg-white p-6 shadow-md">
       <div className="mb-4 ">
@@ -82,8 +91,51 @@ const ModalFunction = ({ index, functionName }: { index: number, functionName: s
           </FormItem>
         )}
       />
+
+      <div className="mt-8">
+        <FormField
+          control={control}
+          name={`modal.modal_functions.${index}.example_usage`}
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="font-bold text-gray-700">Example Usage</FormLabel>
+              <FormControl>
+                <Textarea
+                  {...field}
+                  className="font-mono"
+                  placeholder="Show how to use this function..."
+                  onKeyDown={(e) => {
+                    // Handle tab key for indentation
+                    if (e.key === 'Tab') {
+                      e.preventDefault();
+                      const start = e.currentTarget.selectionStart;
+                      const end = e.currentTarget.selectionEnd;
+                      const value = e.currentTarget.value;
+                      e.currentTarget.value = value.substring(0, start) + '    ' + value.substring(end);
+                      e.currentTarget.selectionStart = e.currentTarget.selectionEnd = start + 4;
+                      field.onChange(e.currentTarget.value);
+                    }
+                  }}
+                />
+              </FormControl>
+              <FormDescription className="text-xs">
+                Show an example of how to call this function. The preview below will be displayed on your function page.
+              </FormDescription>
+              {/* Always show preview with complete example */}
+              <div className="mt-2">
+                <div className="text-sm font-semibold text-gray-700">Preview:</div>
+                <SyntaxHighlighterComponent>
+                  {completeExampleText}
+                </SyntaxHighlighterComponent>
+              </div>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </div>
+
       <div className="mt-4">
-        <h2 className="mb-4 text-sm font-semibold">Function Text</h2>
+        <h2 className="mb-4 text-sm font-semibold">Original Function Text</h2>
         <SyntaxHighlighterComponent>{functionText}</SyntaxHighlighterComponent>
       </div>
     </div>

--- a/garden/src/features/gardens/components/UploadModalFormFields.tsx
+++ b/garden/src/features/gardens/components/UploadModalFormFields.tsx
@@ -67,7 +67,8 @@ export const UploadModalFormFields = () => {
             function_text: func.function_text,
             authors: [],
             tags: [],
-            test_functions: [],
+            test_functions: func.test_functions || [],
+            example_usage: func.example_usage || "",
           })),
         }
       }));
@@ -80,8 +81,8 @@ export const UploadModalFormFields = () => {
       }
       console.log(`Error validating modal file: ${error}`);
       const msg = `${error} Please see our user guide if you are having issues.`
-      form.setError("modal.file_contents", {type: "validate", message: msg});
-      form.setError("modal", {type: "validate", message: msg});
+      form.setError("modal.file_contents", { type: "validate", message: msg });
+      form.setError("modal", { type: "validate", message: msg });
     } finally {
       setIsFileUploading(false);
     }

--- a/garden/src/features/gardens/components/create/CreateGardenForm.tsx
+++ b/garden/src/features/gardens/components/create/CreateGardenForm.tsx
@@ -74,7 +74,7 @@ export const CreateGardenForm = () => {
           modal_functions: values.modal.modal_functions,
           owner_identity_id: uuid,
         });
-        gardenCreateRequest.modal_function_ids = modalAppResponse.data.modal_function_ids.map(id => parseInt(id));
+        gardenCreateRequest.modal_function_ids = modalAppResponse.data.modal_function_ids;
       }
 
       const { garden } = await createGardenAndDOI(gardenCreateRequest);

--- a/garden/src/features/gardens/types/garden.types.ts
+++ b/garden/src/features/gardens/types/garden.types.ts
@@ -49,6 +49,7 @@ export const gardenFormSchema = z
           authors: z.array(z.string()),
           tags: z.array(z.string()),
           test_functions: z.array(z.string()),
+          example_usage: z.string(),
         }),
       ),
     }),

--- a/garden/src/features/modal/components/ModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/ModalFunctionPage.tsx
@@ -101,24 +101,41 @@ const ModalFunctionBody = ({ modalFunction }: { modalFunction: ModalFunction }) 
 };
 
 const ModalFunctionExample = ({ modalFunction }: { modalFunction: ModalFunction }) => {
-  // TODO: actually use the example function text provided
-  const functionText = `from garden_ai import GardenClient
-client = GardenClient()
-garden = client.get_garden(my_garden_doi)
+  const functionText = modalFunction.function_text;
 
-input = ['Data Here']
-return garden.${modalFunction.function_name}(input)
-`;
+  // Create example text with fallback to default placeholder
+  const exampleText = `from garden_ai import GardenClient
+client = GardenClient()
+my_garden = client.get_garden(my_garden_doi)
+
+${modalFunction.example_usage || `input = ['Data Here']
+return my_garden.${modalFunction.function_name}(input)`}`;
+
 
   return (
-    <div className="mb-12 py-12">
-      <h2 className="mb-12 text-center text-2xl sm:text-3xl">Invoke this Modal Function</h2>
-      <div className=" mx-auto max-w-2xl">
-        <div className="relative">
-          <ExampleFunction functionText={functionText} />
+    <Card className="rounded-none bg-white p-4">
+      <CardHeader className="px-6 py-4">
+        <CardTitle className="text-xl font-bold text-gray-800">
+          {modalFunction.function_name}
+        </CardTitle>
+        <CardDescription className="mt-1 text-gray-600">
+          {modalFunction.description}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6 px-6 py-4">
+        <div>
+          <div className="mb-2 flex items-center justify-between">
+            <h3 className="text-lg font-semibold">Example Usage</h3>
+            <CopyButton hint="Copy example code" content={exampleText} />
+          </div>
+          <SyntaxHighlighter>{exampleText}</SyntaxHighlighter>
         </div>
-      </div>
-    </div>
+        <div>
+          <h3 className="mb-2 text-lg font-semibold">Original Function Definition</h3>
+          <SyntaxHighlighter>{functionText}</SyntaxHighlighter>
+        </div>
+      </CardContent>
+    </Card>
   );
 };
 
@@ -222,9 +239,9 @@ const DatasetsTab = ({ datasets }: { datasets?: any[] }) => {
                   className="text-blue-600 hover:underline"
                 >
                   {dataset.doi}
-                </a>
-              </div>
-            </CardContent>
+                </a >
+              </div >
+            </CardContent >
             <CardFooter className="flex justify-start ">
               <Button variant="default" size={"sm"} asChild className="text-xs">
                 <a href={dataset.url} target="_blank" rel="noopener noreferrer">
@@ -232,9 +249,9 @@ const DatasetsTab = ({ datasets }: { datasets?: any[] }) => {
                 </a>
               </Button>
             </CardFooter>
-          </Card>
+          </Card >
         ))}
-      </div>
+      </div >
     </>
   );
 };

--- a/garden/src/types/backend-schema.ts
+++ b/garden/src/types/backend-schema.ts
@@ -460,6 +460,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/load-test/{sleep_seconds}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Load Test
+         * @description Simulate a route that passes jobs to a background task
+         */
+        get: operations["load_test_load_test__sleep_seconds__get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -524,7 +544,7 @@ export interface components {
             /** Modal Function Names */
             readonly modal_function_names: string[];
             /** Modal Function Ids */
-            readonly modal_function_ids: string[];
+            readonly modal_function_ids: number[];
         };
         /**
          * AsyncModalJobStatus
@@ -1723,7 +1743,7 @@ export interface components {
             /** Modal Function Names */
             readonly modal_function_names: string[];
             /** Modal Function Ids */
-            readonly modal_function_ids: string[];
+            readonly modal_function_ids: number[];
         };
         /** ModalBlobUploadURLRequest */
         ModalBlobUploadURLRequest: {
@@ -1795,6 +1815,11 @@ export interface components {
             doi?: string | null;
             /** Conda Requirements */
             conda_requirements?: string[];
+            /**
+             * Example Usage
+             * @default
+             */
+            example_usage: string;
         };
         /** ModalFunctionMetadataResponse */
         ModalFunctionMetadataResponse: {
@@ -1835,6 +1860,11 @@ export interface components {
             doi?: string | null;
             /** Conda Requirements */
             conda_requirements?: string[];
+            /**
+             * Example Usage
+             * @default
+             */
+            example_usage: string;
             /**
              * Id
              * @description The unique identifier for the modal function
@@ -3503,6 +3533,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
+                };
+            };
+        };
+    };
+    load_test_load_test__sleep_seconds__get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                sleep_seconds: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": unknown;
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
         };


### PR DESCRIPTION
Modal Functions now have an "example usage" text box with live preview in the upload form, which also displays on the function page (like entrypoints do with `@entrypoint_test`). 

The text box is pre-filled with a plausible example invocation built from any `@app.local_entrypoint` functions found in the file that appear to call the function in question. The "plausible example" looks like garden sdk code, not modal code (i.e. `my_garden.my_func(...)` from `my_func.remote(...)`) and has a preamble that instantiates a garden client. This is built on the backend by the file validation route and persisted like the rest of the function's metadata when the garden is created.

The final version of the example usage that is displayed on the modal function page is also copyable 