### PR TITLE
Add markdown support for text descriptions

### DIFF
--- a/garden/src/components/HomePage.tsx
+++ b/garden/src/components/HomePage.tsx
@@ -12,7 +12,7 @@ import { Garden } from "@/types";
 import SyntaxHighlighter from "@/components/SyntaxHighlighter";
 
 import { Separator } from "@/components/ui/separator";
-import GardenBox from "@/components/GardenBox";
+import GardenBox from "@/features/gardens/components/GardenBox";
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area";
 import {
   SquareStack,

--- a/garden/src/components/Markdown.tsx
+++ b/garden/src/components/Markdown.tsx
@@ -1,0 +1,16 @@
+import MarkedReact from 'marked-react';
+
+interface MarkdownProps {
+  content: string;
+  className?: string;
+}
+
+const Markdown = ({ content, className = '' }: MarkdownProps) => {
+  return (
+    <div className={`prose prose-sm prose-gray max-w-none ${className}`}>
+      <MarkedReact>{content}</MarkedReact>
+    </div>
+  );
+};
+
+export default Markdown; 

--- a/garden/src/components/ui/card.tsx
+++ b/garden/src/components/ui/card.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-
+import Markdown from "@/components/Markdown";
 import { cn } from "@/utils/form.utils";
 
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
@@ -46,6 +46,19 @@ const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDi
 );
 CardContent.displayName = "CardContent";
 
+interface MarkdownCardContentProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
+  content: string;
+}
+
+const MarkdownCardContent = React.forwardRef<HTMLDivElement, MarkdownCardContentProps>(
+  ({ className, content, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6 pt-0", className)} {...props}>
+      <Markdown content={content} />
+    </div>
+  ),
+);
+MarkdownCardContent.displayName = "MarkdownCardContent";
+
 const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
     <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
@@ -53,4 +66,4 @@ const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDiv
 );
 CardFooter.displayName = "CardFooter";
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent, MarkdownCardContent };

--- a/garden/src/features/entrypoints/components/EntrypointPage.tsx
+++ b/garden/src/features/entrypoints/components/EntrypointPage.tsx
@@ -13,6 +13,7 @@ import { useSearchGardenByDOI } from "@/features/search/api/useSearchGardenByDOI
 import EntrypointTabs from "@/features/entrypoints/components/EntrypointTabs";
 import EntrypointFunction from "@/features/entrypoints/components/EntrypointFunction";
 import AssociatedMaterials from "@/features/gardens/components/AssociatedMaterials";
+import Markdown from "@/components/Markdown";
 
 const EntrypointPage = () => {
   const { doi } = useParams() as { doi: string };
@@ -87,7 +88,7 @@ const EntrypointBody = ({ garden, entrypoint }: { garden: Garden; entrypoint: En
         <Eye />
         <h2>At a glance</h2>
       </div>
-      <p className="mb-6">{entrypoint.description}</p>
+      <Markdown content={entrypoint.description || ""} className="mb-6" />
 
       <Separator className="mb-12" />
     </div>

--- a/garden/src/features/entrypoints/components/EntrypointTabs.tsx
+++ b/garden/src/features/entrypoints/components/EntrypointTabs.tsx
@@ -8,6 +8,7 @@ import {
   CardFooter,
   CardHeader,
   CardTitle,
+  MarkdownCardContent,
 } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import SyntaxHighlighter from "@/components/SyntaxHighlighter";
@@ -139,10 +140,13 @@ const DatasetsTab = ({ datasets }: { datasets?: any[] }) => {
 
 const FunctionTab = ({ entrypoint }: { entrypoint: Entrypoint }) => {
   return (
-    <Card className=" rounded-none bg-white p-4">
-      <CardHeader className=" px-6 py-4">
+    <Card className="rounded-none bg-white p-4">
+      <CardHeader className="px-6 py-4">
         <CardTitle className="text-xl font-bold text-gray-800">{entrypoint.short_name}</CardTitle>
-        <CardDescription className="mt-1 text-gray-600">{entrypoint.description}</CardDescription>
+        <MarkdownCardContent 
+          className="mt-1 text-gray-600"
+          content={entrypoint.description || ""}
+        />
       </CardHeader>
       <CardContent className="px-6 py-4">
         <SyntaxHighlighter>{entrypoint.function_text}</SyntaxHighlighter>

--- a/garden/src/features/gardens/components/EntrypointBox.tsx
+++ b/garden/src/features/gardens/components/EntrypointBox.tsx
@@ -4,7 +4,7 @@ import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/utils/form.utils";
 import { useGlobusAuth } from "@/hooks/useGlobusAuth";
 import { useGetEntrypoints } from "@/features/entrypoints/api/useGetEntrypoints";
-import Markdown from "@/components/Markdown";
+import { Card, CardHeader, CardTitle, CardFooter, MarkdownCardContent } from "@/components/ui/card";
 
 const EntrypointBox = ({ entrypoint }: { entrypoint: Entrypoint }) => {
   const navigate = useNavigate();
@@ -27,13 +27,13 @@ const EntrypointBox = ({ entrypoint }: { entrypoint: Entrypoint }) => {
   };
 
   return (
-    <div
-      className="flex flex-col justify-between rounded-lg border border-gray-200 p-5 shadow-sm hover:cursor-pointer hover:shadow-md"
+    <Card
+      className="cursor-pointer shadow-sm hover:shadow-md"
       onClick={() => navigate(`/entrypoint/${text}`)}
     >
-      <div className="flex flex-col gap-2">
+      <CardHeader>
         <div className="flex flex-row justify-between">
-          <h2 className="text-xl">{entrypoint.title || "Untitled"}</h2>
+          <CardTitle className="text-xl">{entrypoint.title || "Untitled"}</CardTitle>
           <div className="flex-end flex">
             {canEditEntrypoint && (
               <button
@@ -48,14 +48,13 @@ const EntrypointBox = ({ entrypoint }: { entrypoint: Entrypoint }) => {
             )}
           </div>
         </div>
-        <div className="max-h-[120px] overflow-y-hidden">
-          <div className="h-[160px] overflow-y-hidden bg-gradient-to-b from-black to-white bg-clip-text text-transparent">
-            <Markdown content={entrypoint.description || "No description available"} />
-          </div>
-        </div>
-      </div>
-      {entrypoint.tags && entrypoint.tags.length > 0 ? (
-        <div className="flex gap-2 text-black">
+      </CardHeader>
+      <MarkdownCardContent 
+        className="max-h-[120px] overflow-hidden"
+        content={entrypoint.description || "No description available"}
+      />
+      {entrypoint.tags && entrypoint.tags.length > 0 && (
+        <CardFooter className="flex gap-2 text-black">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -74,9 +73,9 @@ const EntrypointBox = ({ entrypoint }: { entrypoint: Entrypoint }) => {
           <div>
             <span>{entrypoint.tags?.join(", ")}</span>
           </div>
-        </div>
-      ) : null}
-    </div>
+        </CardFooter>
+      )}
+    </Card>
   );
 };
 

--- a/garden/src/features/gardens/components/EntrypointBox.tsx
+++ b/garden/src/features/gardens/components/EntrypointBox.tsx
@@ -4,6 +4,7 @@ import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/utils/form.utils";
 import { useGlobusAuth } from "@/hooks/useGlobusAuth";
 import { useGetEntrypoints } from "@/features/entrypoints/api/useGetEntrypoints";
+import Markdown from "@/components/Markdown";
 
 const EntrypointBox = ({ entrypoint }: { entrypoint: Entrypoint }) => {
   const navigate = useNavigate();
@@ -48,9 +49,9 @@ const EntrypointBox = ({ entrypoint }: { entrypoint: Entrypoint }) => {
           </div>
         </div>
         <div className="max-h-[120px] overflow-y-hidden">
-          <p className="h-[160px] overflow-y-hidden bg-gradient-to-b from-black to-white bg-clip-text text-transparent">
-            {entrypoint.description || "No description available"}
-          </p>
+          <div className="h-[160px] overflow-y-hidden bg-gradient-to-b from-black to-white bg-clip-text text-transparent">
+            <Markdown content={entrypoint.description || "No description available"} />
+          </div>
         </div>
       </div>
       {entrypoint.tags && entrypoint.tags.length > 0 ? (

--- a/garden/src/features/gardens/components/GardenBox.tsx
+++ b/garden/src/features/gardens/components/GardenBox.tsx
@@ -1,9 +1,10 @@
-import { Card, CardContent, CardHeader, CardTitle, CardFooter } from "./ui/card";
+import { Card, CardContent, CardHeader, CardTitle, CardFooter } from "../../../components/ui/card";
 import { useNavigate } from "react-router-dom";
 import { TagIcon } from "lucide-react";
 import { Garden } from "@/types";
 import { useGetUserInfo } from "@/features/users/api/useGetUserInfo";
 import { useGetGardens } from "@/features/gardens/api/useGetGardens";
+import Markdown from "@/components/Markdown";
 
 const GardenBox = ({ garden }: { garden: Garden }) => {
   const navigate = useNavigate();
@@ -36,7 +37,9 @@ const GardenBox = ({ garden }: { garden: Garden }) => {
         </CardHeader>
         <CardContent className="flex-grow overflow-hidden">
           <div className="relative h-[125px] overflow-hidden">
-            <p className="opacity-60">{description}</p>
+            <div className="opacity-60">
+              <Markdown content={description || ""} />
+            </div>
             <div className="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-white to-transparent"></div>
           </div>
         </CardContent>

--- a/garden/src/features/gardens/components/GardenBox.tsx
+++ b/garden/src/features/gardens/components/GardenBox.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, CardTitle, CardFooter } from "../../../components/ui/card";
+import { Card, CardContent, CardHeader, CardTitle, CardFooter, MarkdownCardContent } from "../../../components/ui/card";
 import { useNavigate } from "react-router-dom";
 import { TagIcon } from "lucide-react";
 import { Garden } from "@/types";
@@ -35,14 +35,10 @@ const GardenBox = ({ garden }: { garden: Garden }) => {
         <CardHeader className="">
           <CardTitle className="text-ellipsis text-xl">{title}</CardTitle>
         </CardHeader>
-        <CardContent className="flex-grow overflow-hidden">
-          <div className="relative h-[125px] overflow-hidden">
-            <div className="opacity-60">
-              <Markdown content={description || ""} />
-            </div>
-            <div className="absolute bottom-0 left-0 right-0 h-8 bg-gradient-to-t from-white to-transparent"></div>
-          </div>
-        </CardContent>
+        <MarkdownCardContent 
+          className="flex-grow overflow-hidden"
+          content={description || ""}
+        />
         <CardFooter className="relative mt-auto flex flex-wrap gap-1">
           {tags && tags.length > 0 && (
             <div>

--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -19,6 +19,7 @@ import RelatedGardens from "@/features/gardens/components/RelatedGardens";
 import ShareModal from "@/components/ShareModal";
 import TombstonePage from "@/components/TombstonePage";
 import LoadingSpinner from "@/components/LoadingSpinner";
+import Markdown from "@/components/Markdown";
 
 import { useGetGarden } from "../api/useGetGarden";
 import { usePatchGarden } from "../api/usePatchGarden";
@@ -127,7 +128,7 @@ const GardenBody = ({ garden }: { garden: Garden }) => {
       </div>
       <div>
         <h2 className="font-semibold">Description</h2>
-        <p>{garden.description}</p>
+        <Markdown content={garden.description ?? ""} />
       </div>
     </div>
   );

--- a/garden/src/features/gardens/components/ModalFunctionBox.tsx
+++ b/garden/src/features/gardens/components/ModalFunctionBox.tsx
@@ -1,6 +1,6 @@
 import { ModalFunction } from "@/types";
 import { useNavigate } from "react-router-dom";
-import Markdown from "@/components/Markdown";
+import { Card, CardHeader, CardTitle, CardFooter, MarkdownCardContent } from "@/components/ui/card";
 
 const ModalFunctionBox = ({ modalFunction }: { modalFunction: ModalFunction }) => {
   const navigate = useNavigate();
@@ -11,22 +11,19 @@ const ModalFunctionBox = ({ modalFunction }: { modalFunction: ModalFunction }) =
   }
 
   return (
-    <div
-      className="flex flex-col justify-between rounded-lg border border-gray-200 p-5 shadow-sm hover:cursor-pointer hover:shadow-md"
+    <Card
+      className="cursor-pointer shadow-sm hover:shadow-md"
       onClick={() => navigate(`/modal/${id}`)}
     >
-      <div className="flex flex-col gap-2">
-        <div className="flex flex-row justify-between">
-          <h2 className="text-xl">{modalFunction.title || "Untitled"}</h2>
-        </div>
-        <div className="max-h-[120px] overflow-y-hidden">
-          <div className="h-[160px] overflow-y-hidden bg-gradient-to-b from-black to-white bg-clip-text text-transparent">
-            <Markdown content={modalFunction.description || "No description available"} />
-          </div>
-        </div>
-      </div>
-      {modalFunction.tags && modalFunction.tags.length > 0 ? (
-        <div className="flex gap-2 text-black">
+      <CardHeader>
+        <CardTitle className="text-xl">{modalFunction.title || "Untitled"}</CardTitle>
+      </CardHeader>
+      <MarkdownCardContent 
+        className="max-h-[120px] overflow-hidden"
+        content={modalFunction.description || "No description available"}
+      />
+      {modalFunction.tags && modalFunction.tags.length > 0 && (
+        <CardFooter className="flex gap-2 text-black">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
@@ -45,10 +42,10 @@ const ModalFunctionBox = ({ modalFunction }: { modalFunction: ModalFunction }) =
           <div>
             <span>{modalFunction.tags?.join(", ")}</span>
           </div>
-        </div>
-      ) : null}
-    </div>
+        </CardFooter>
+      )}
+    </Card>
   );
-};
+}
 
 export default ModalFunctionBox;

--- a/garden/src/features/gardens/components/ModalFunctionBox.tsx
+++ b/garden/src/features/gardens/components/ModalFunctionBox.tsx
@@ -1,5 +1,6 @@
 import { ModalFunction } from "@/types";
 import { useNavigate } from "react-router-dom";
+import Markdown from "@/components/Markdown";
 
 const ModalFunctionBox = ({ modalFunction }: { modalFunction: ModalFunction }) => {
   const navigate = useNavigate();
@@ -19,9 +20,9 @@ const ModalFunctionBox = ({ modalFunction }: { modalFunction: ModalFunction }) =
           <h2 className="text-xl">{modalFunction.title || "Untitled"}</h2>
         </div>
         <div className="max-h-[120px] overflow-y-hidden">
-          <p className="h-[160px] overflow-y-hidden bg-gradient-to-b from-black to-white bg-clip-text text-transparent">
-            {modalFunction.description || "No description available"}
-          </p>
+          <div className="h-[160px] overflow-y-hidden bg-gradient-to-b from-black to-white bg-clip-text text-transparent">
+            <Markdown content={modalFunction.description || "No description available"} />
+          </div>
         </div>
       </div>
       {modalFunction.tags && modalFunction.tags.length > 0 ? (

--- a/garden/src/features/modal/components/ModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/ModalFunctionPage.tsx
@@ -22,6 +22,7 @@ import {
   CardDescription,
   CardFooter,
   CardTitle,
+  MarkdownCardContent,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
@@ -112,16 +113,16 @@ my_garden = client.get_garden(my_garden_doi)
 ${modalFunction.example_usage || `input = ['Data Here']
 return my_garden.${modalFunction.function_name}(input)`}`;
 
-
   return (
     <Card className="rounded-none bg-white p-4">
       <CardHeader className="px-6 py-4">
         <CardTitle className="text-xl font-bold text-gray-800">
           {modalFunction.function_name}
         </CardTitle>
-        <CardDescription className="mt-1 text-gray-600">
-          {modalFunction.description}
-        </CardDescription>
+        <MarkdownCardContent 
+          className="mt-1 text-gray-600"
+          content={modalFunction.description || ""}
+        />
       </CardHeader>
       <CardContent className="space-y-6 px-6 py-4">
         <div>
@@ -259,14 +260,15 @@ const DatasetsTab = ({ datasets }: { datasets?: any[] }) => {
 
 const FunctionTab = ({ modalFunction }: { modalFunction: ModalFunction }) => {
   return (
-    <Card className=" rounded-none bg-white p-4">
-      <CardHeader className=" px-6 py-4">
+    <Card className="rounded-none bg-white p-4">
+      <CardHeader className="px-6 py-4">
         <CardTitle className="text-xl font-bold text-gray-800">
           {modalFunction.function_name}
         </CardTitle>
-        <CardDescription className="mt-1 text-gray-600">
-          {modalFunction.description}
-        </CardDescription>
+        <MarkdownCardContent 
+          className="mt-1 text-gray-600"
+          content={modalFunction.description || ""}
+        />
       </CardHeader>
       <CardContent className="px-6 py-4">
         <SyntaxHighlighter>{modalFunction.function_text}</SyntaxHighlighter>

--- a/garden/src/features/modal/components/ModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/ModalFunctionPage.tsx
@@ -27,6 +27,7 @@ import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import AssociatedMaterials from "@/features/gardens/components/AssociatedMaterials";
 import { ExampleFunction } from "@/features/entrypoints/components/ExampleFunction";
+import Markdown from "@/components/Markdown";
 
 const ModalFunctionPage = () => {
   const { id } = useParams() as { id: string };
@@ -93,7 +94,7 @@ const ModalFunctionBody = ({ modalFunction }: { modalFunction: ModalFunction }) 
         <Eye />
         <h2>At a glance</h2>
       </div>
-      <p className="mb-6">{modalFunction.description}</p>
+      <Markdown content={modalFunction.description || ""} className="mb-6" />
 
       <Separator className="my-6" />
     </div>

--- a/garden/src/features/modal/components/ModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/ModalFunctionPage.tsx
@@ -119,10 +119,6 @@ return my_garden.${modalFunction.function_name}(input)`}`;
         <CardTitle className="text-xl font-bold text-gray-800">
           {modalFunction.function_name}
         </CardTitle>
-        <MarkdownCardContent 
-          className="mt-1 text-gray-600"
-          content={modalFunction.description || ""}
-        />
       </CardHeader>
       <CardContent className="space-y-6 px-6 py-4">
         <div>
@@ -131,10 +127,6 @@ return my_garden.${modalFunction.function_name}(input)`}`;
             <CopyButton hint="Copy example code" content={exampleText} />
           </div>
           <SyntaxHighlighter>{exampleText}</SyntaxHighlighter>
-        </div>
-        <div>
-          <h3 className="mb-2 text-lg font-semibold">Original Function Definition</h3>
-          <SyntaxHighlighter>{functionText}</SyntaxHighlighter>
         </div>
       </CardContent>
     </Card>

--- a/garden/src/features/search/components/SearchResult.tsx
+++ b/garden/src/features/search/components/SearchResult.tsx
@@ -12,6 +12,7 @@ import {
   CardDescription,
   CardContent,
   CardFooter,
+  MarkdownCardContent,
 } from "@/components/ui/card";
 import { Table, TableBody, TableCell, TableHeader, TableRow } from "@/components/ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -52,14 +53,16 @@ export const SearchResult = ({ garden, verbose }: { garden: Garden; verbose: boo
           </span>
         </CardDescription>
       </CardHeader>
-      <CardContent>
-        <p className="mb-6 line-clamp-3 text-gray-700">
-          {garden.description || <span className="italic">No description available</span>}
-        </p>
-        {verbose && entrypoints?.length > 0 && (
+      
+      <MarkdownCardContent 
+        className="line-clamp-3"
+        content={garden.description || "*No description available*"}
+      />
+      
+      {verbose && entrypoints?.length > 0 && (
+        <CardContent>
           <div>
             <h3 className="pb-4 font-semibold">Entrypoints</h3>
-
             <ScrollArea className="h-[250px] rounded border p-2">
               <Table className="relative w-full">
                 <TableHeader className="sticky top-0 font-semibold">
@@ -100,8 +103,8 @@ export const SearchResult = ({ garden, verbose }: { garden: Garden; verbose: boo
               </Table>
             </ScrollArea>
           </div>
-        )}
-      </CardContent>
+        </CardContent>
+      )}
       <CardFooter className="flex-col items-start gap-3">
         <div className="flex flex-wrap items-center gap-2">
           <PersonIcon className="mr-1 h-5 w-5" />


### PR DESCRIPTION
Resolves: #258 

This PR adds markdown support for the description fields in Gardens, Entrypoints, and Modal functions.

## Garden Descriptions

Before:

![image](https://github.com/user-attachments/assets/7a16eb36-4beb-479a-ad22-71c2ace417e0)

After:

![image](https://github.com/user-attachments/assets/37c959a0-2b80-4389-8ed7-a35353173e2d)


## Entrypoint/Modal Function Descriptions

Before:

![image](https://github.com/user-attachments/assets/16b2cfb2-0741-435f-941a-f8f73c1348d7)


After:

![image](https://github.com/user-attachments/assets/9a45fbca-30fa-4f2f-b198-dfd6d98dd519)
