### PR TITLE
feat: Edit modal functions after upload

### DIFF
--- a/garden/src/app/router.tsx
+++ b/garden/src/app/router.tsx
@@ -17,6 +17,8 @@ import SearchPage from "@/features/search/components/SearchPage";
 import TeamsPage from "@/features/team/components/TeamsPage";
 import UserProfilePage from "@/features/users/components/UserProfilePage";
 import { useGlobusAuth } from "@/hooks/useGlobusAuth";
+import { EditModalFunctionForm } from "@/features/modal/components/edit/EditModalFunctionForm";
+import EditModalFunctionPage from "@/features/modal/components/edit/EditModalFunctionPage";
 
 const Router: React.FC = () => {
   return (
@@ -43,8 +45,11 @@ const Router: React.FC = () => {
         </Route>
 
         {/* Modal Routes */}
-        <Route path="modal">
+        <Route path="modal-functions">
           <Route path=":id" element={<ModalFunctionPage />} />
+          <Route element={<PrivateRoutes />}>
+            <Route path=":id/edit" element={<EditModalFunctionPage />} />
+          </Route>
         </Route>
 
         {/* Misc Routes */}

--- a/garden/src/features/gardens/components/ModalFunctionBox.tsx
+++ b/garden/src/features/gardens/components/ModalFunctionBox.tsx
@@ -13,7 +13,7 @@ const ModalFunctionBox = ({ modalFunction }: { modalFunction: ModalFunction }) =
   return (
     <Card
       className="cursor-pointer shadow-sm hover:shadow-md"
-      onClick={() => navigate(`/modal/${id}`)}
+      onClick={() => navigate(`/modal-functions/${id}`)}
     >
       <CardHeader>
         <CardTitle className="text-xl">{modalFunction.title || "Untitled"}</CardTitle>

--- a/garden/src/features/modal/api/useGetModalFunction.tsx
+++ b/garden/src/features/modal/api/useGetModalFunction.tsx
@@ -12,8 +12,18 @@ const getModalFunction = async (id: string): Promise<ModalFunction> => {
 };
 
 export const useGetModalFunction = (id: string) => {
-  return useQuery<ModalFunction, Error>({
-    queryKey: ["modal-apps", id],
-    queryFn: () => getModalFunction(id),
+  return useQuery({
+    queryKey: ["modalFunction", id],
+    queryFn: async () => {
+      const response = await axios.get(`/modal-functions/${id}`);
+      const modalFunction = response.data as ModalFunction;
+      
+      // Get the parent modal app to get ownership information
+      const modalAppResponse = await axios.get(`/modal-apps/${modalFunction.modal_app_id}`);
+      return {
+        ...modalFunction,
+        owner_identity_id: modalAppResponse.data.owner_identity_id
+      };
+    },
   });
 };

--- a/garden/src/features/modal/api/useGetUser.ts
+++ b/garden/src/features/modal/api/useGetUser.ts
@@ -1,3 +1,0 @@
-import { useGetUserInfo } from "@/features/users/api/useGetUserInfo";
-
-export const useGetUser = useGetUserInfo; 

--- a/garden/src/features/modal/api/useGetUser.ts
+++ b/garden/src/features/modal/api/useGetUser.ts
@@ -1,0 +1,3 @@
+import { useGetUserInfo } from "@/features/users/api/useGetUserInfo";
+
+export const useGetUser = useGetUserInfo; 

--- a/garden/src/features/modal/api/usePatchModalFunction.ts
+++ b/garden/src/features/modal/api/usePatchModalFunction.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ModalFunction, ModalFunctionPatchRequest } from "@/types";
+import axios from "@/lib/axios";
+
+interface PatchModalFunctionParams {
+  id: number;
+  modalFunction: ModalFunctionPatchRequest;
+}
+
+export const usePatchModalFunction = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, modalFunction }: PatchModalFunctionParams) => {
+      const response = await axios.patch(`/modal-functions/${id}`, modalFunction);
+      return response.data as ModalFunction;
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["modalFunction", data.id.toString()] });
+      
+      queryClient.invalidateQueries({ queryKey: ["gardens"] });
+      queryClient.invalidateQueries({ queryKey: ["search"] });
+    },
+  });
+}; 

--- a/garden/src/features/modal/components/ModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/ModalFunctionPage.tsx
@@ -32,6 +32,11 @@ import AssociatedMaterials from "@/features/gardens/components/AssociatedMateria
 import { ExampleFunction } from "@/features/entrypoints/components/ExampleFunction";
 import Markdown from "@/components/Markdown";
 
+// Extend ModalFunction type to include owner_identity_id
+type ModalFunctionWithOwner = ModalFunction & {
+  owner_identity_id: string;
+};
+
 const ModalFunctionPage = () => {
   const { id } = useParams() as { id: string };
   const { data: modalFunction, isError, isLoading } = useGetModalFunction(id);
@@ -45,7 +50,7 @@ const ModalFunctionPage = () => {
       {/* TODO: I'm not really sure what makes sense to render for the Breadcrumbs component, since we don't really have a way
        for a user to land on this page currently. Maybe the parent garden?  */}
       <Breadcrumb crumbs={[{ label: "Home", link: "/" }, { label: modalFunction.title }]} />
-      <ModalFunctionHeader modalFunction={modalFunction} />
+      <ModalFunctionHeader modalFunction={modalFunction as ModalFunctionWithOwner} />
       <ModalFunctionBody modalFunction={modalFunction} />
       <ModalFunctionExample modalFunction={modalFunction} />
       <AssociatedMaterials resource={modalFunction} />
@@ -54,7 +59,7 @@ const ModalFunctionPage = () => {
   );
 };
 
-const ModalFunctionHeader = ({ modalFunction }: { modalFunction: ModalFunction }) => {
+const ModalFunctionHeader = ({ modalFunction }: { modalFunction: ModalFunctionWithOwner }) => {
   const navigate = useNavigate();
   const auth = useGlobusAuth();
   const isOwner = auth.isAuthenticated && modalFunction.owner_identity_id === auth?.authorization?.user?.sub;

--- a/garden/src/features/modal/components/ModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/ModalFunctionPage.tsx
@@ -8,6 +8,7 @@ import NotFoundPage from "@/components/NotFoundPage";
 // import ModalFunctionTabs from "@/components/ModalFunctionTabs";
 import { Separator } from "@/components/ui/separator";
 import Breadcrumb from "@/components/Breadcrumb";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 import { Eye, LinkIcon, TagIcon, PencilIcon } from "lucide-react";
 import { ModalFunction } from "@/types";
@@ -59,34 +60,35 @@ const ModalFunctionHeader = ({ modalFunction }: { modalFunction: ModalFunction }
   const isOwner = auth.isAuthenticated && modalFunction.owner_identity_id === auth?.authorization?.user?.sub;
 
   return (
-    <div>
-      <div className="mb-4">
-        <div className="flex flex-row justify-between">
-          <h1 className="text-xl md:text-3xl">{modalFunction.title}</h1>
-          <div className="flex items-center gap-2">
-            {isOwner && (
-              <Button
-                variant="outline"
-                onClick={() => navigate(`/modal-functions/${modalFunction.id}/edit`)}
-                className="hidden md:flex"
-              >
-                <PencilIcon className="mr-2 h-4 w-4" />
-                Edit
-              </Button>
-            )}
-            {modalFunction.doi && (
-              <div className="hidden flex-col items-center md:flex md:flex-row">
-                <CopyButton
-                  hint="Copy Link"
-                  content={`https://doi.org/${modalFunction.doi}`}
-                  icon={<LinkIcon />}
-                  className="border-none bg-transparent"
-                />
-                <ShareModal doi={modalFunction.doi} />
-              </div>
-            )}
-          </div>
-        </div>
+    <div className="my-8 flex items-center justify-between gap-2 sm:gap-4">
+      <h1 className="text-xl md:text-3xl">{modalFunction.title}</h1>
+      <div className="flex items-center gap-2">
+        <CopyButton
+          icon={<LinkIcon />}
+          content={`${window.location.origin}/modal-functions/${modalFunction.id}`}
+          hint="Copy Link"
+          className="border-none bg-transparent"
+        />
+        {modalFunction.doi && <ShareModal doi={modalFunction.doi} />}
+        {isOwner && (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => navigate(`/modal-functions/${modalFunction.id}/edit`)}
+                  className="h-9 w-9"
+                >
+                  <PencilIcon className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Edit Function</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
       </div>
     </div>
   );

--- a/garden/src/features/modal/components/ModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/ModalFunctionPage.tsx
@@ -1,6 +1,7 @@
-import { useParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 
 import { useGetModalFunction } from "../api/useGetModalFunction";
+import { useGlobusAuth } from "@/hooks/useGlobusAuth";
 
 import NotFoundPage from "@/components/NotFoundPage";
 
@@ -8,7 +9,7 @@ import NotFoundPage from "@/components/NotFoundPage";
 import { Separator } from "@/components/ui/separator";
 import Breadcrumb from "@/components/Breadcrumb";
 
-import { Eye, LinkIcon, TagIcon } from "lucide-react";
+import { Eye, LinkIcon, TagIcon, PencilIcon } from "lucide-react";
 import { ModalFunction } from "@/types";
 import { LoadingOverlay } from "@/components/LoadingOverlay";
 import SyntaxHighlighter from "@/components/SyntaxHighlighter";
@@ -53,22 +54,38 @@ const ModalFunctionPage = () => {
 };
 
 const ModalFunctionHeader = ({ modalFunction }: { modalFunction: ModalFunction }) => {
+  const navigate = useNavigate();
+  const auth = useGlobusAuth();
+  const isOwner = auth.isAuthenticated && modalFunction.owner_identity_id === auth?.authorization?.user?.sub;
+
   return (
     <div>
       <div className="mb-4">
         <div className="flex flex-row justify-between">
           <h1 className="text-xl md:text-3xl">{modalFunction.title}</h1>
-          {modalFunction.doi && (
-            <div className="hidden flex-col items-center md:flex md:flex-row">
-              <CopyButton
-                hint="Copy Link"
-                content={`https://doi.org/${modalFunction.doi}`}
-                icon={<LinkIcon />}
-                className="border-none bg-transparent"
-              />
-              <ShareModal doi={modalFunction.doi} />
-            </div>
-          )}
+          <div className="flex items-center gap-2">
+            {isOwner && (
+              <Button
+                variant="outline"
+                onClick={() => navigate(`/modal-functions/${modalFunction.id}/edit`)}
+                className="hidden md:flex"
+              >
+                <PencilIcon className="mr-2 h-4 w-4" />
+                Edit
+              </Button>
+            )}
+            {modalFunction.doi && (
+              <div className="hidden flex-col items-center md:flex md:flex-row">
+                <CopyButton
+                  hint="Copy Link"
+                  content={`https://doi.org/${modalFunction.doi}`}
+                  icon={<LinkIcon />}
+                  className="border-none bg-transparent"
+                />
+                <ShareModal doi={modalFunction.doi} />
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/garden/src/features/modal/components/edit/EditModalFunctionForm.tsx
+++ b/garden/src/features/modal/components/edit/EditModalFunctionForm.tsx
@@ -60,27 +60,29 @@ export const EditModalFunctionForm = ({ modalFunction }: { modalFunction: ModalF
   );
 
   return (
-    <form onSubmit={form.handleSubmit(onSubmit)}>
-      <Form {...form}>
-        <div className="space-y-8">
-          <div className="rounded-lg border bg-white p-8 shadow-sm">
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+        <div className="rounded-lg border bg-white shadow-sm">
+          <div className="p-6">
             <EditModalFunctionFormFields />
           </div>
-          <div className="flex justify-end gap-4">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => navigate(`/modal-functions/${modalFunction.id}`)}
-            >
-              Cancel
-            </Button>
-            <Button type="submit">Save Changes</Button>
-          </div>
         </div>
+        
+        <div className="flex justify-end gap-4">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => navigate(`/modal-functions/${modalFunction.id}`)}
+          >
+            Cancel
+          </Button>
+          <Button type="submit">Save Changes</Button>
+        </div>
+
         <LoadingOverlay />
         <UnsavedChangesDialog blocker={blocker} />
-      </Form>
-    </form>
+      </form>
+    </Form>
   );
 };
 

--- a/garden/src/features/modal/components/edit/EditModalFunctionForm.tsx
+++ b/garden/src/features/modal/components/edit/EditModalFunctionForm.tsx
@@ -1,0 +1,97 @@
+import { ModalFunction, ModalFunctionPatchRequest } from "@/types";
+import { useForm, useFormContext } from "react-hook-form";
+import { Form } from "@/components/ui/form";
+import { modalFunctionFormSchema, ModalFunctionPatchFormData } from "../../types/modal.types";
+import { getDirtyValues } from "@/utils/form.utils";
+import { zodResolver } from "@hookform/resolvers/zod";
+import React from "react";
+import { usePatchModalFunction } from "../../api/usePatchModalFunction";
+import EditModalFunctionFormFields from "./EditModalFunctionFormFields";
+import { UnsavedChangesDialog } from "@/components/UnsavedChangesDialog";
+import { useBlocker, useNavigate } from "react-router-dom";
+import LoadingSpinner from "@/components/LoadingSpinner";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+
+export const EditModalFunctionForm = ({ modalFunction }: { modalFunction: ModalFunction }) => {
+  const { mutateAsync: patchModalFunction } = usePatchModalFunction();
+  const navigate = useNavigate();
+
+  const form = useForm<ModalFunctionPatchFormData>({
+    resolver: zodResolver(modalFunctionFormSchema),
+    mode: "onTouched",
+    defaultValues: React.useMemo(
+      () => ({
+        title: modalFunction.title || "",
+        description: modalFunction.description || "",
+        year: modalFunction.year || "",
+        authors: modalFunction.authors || [],
+        tags: modalFunction.tags || [],
+        example_usage: modalFunction.example_usage || "",
+      }),
+      [modalFunction],
+    ),
+  });
+
+  const blocker = useBlocker(
+    () => !form?.formState.isSubmitting && Object.keys(form.formState.touchedFields).length > 0,
+  );
+
+  const onSubmit = React.useCallback(
+    async (values: ModalFunctionPatchFormData) => {
+      try {
+        const modalFunctionPatchRequest: ModalFunctionPatchRequest = getDirtyValues(
+          values,
+          form.formState.dirtyFields,
+        ) as ModalFunctionPatchRequest;
+        
+        await patchModalFunction({
+          id: modalFunction.id,
+          modalFunction: modalFunctionPatchRequest,
+        });
+
+        toast.success("Modal function updated successfully");
+        navigate(`/modal-functions/${modalFunction.id}`);
+      } catch (error) {
+        toast.error("Failed to update modal function");
+      }
+    },
+    [modalFunction.id, patchModalFunction, navigate],
+  );
+
+  return (
+    <form onSubmit={form.handleSubmit(onSubmit)}>
+      <Form {...form}>
+        <div className="space-y-8">
+          <div className="rounded-lg border bg-white p-8 shadow-sm">
+            <EditModalFunctionFormFields />
+          </div>
+          <div className="flex justify-end gap-4">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => navigate(`/modal-functions/${modalFunction.id}`)}
+            >
+              Cancel
+            </Button>
+            <Button type="submit">Save Changes</Button>
+          </div>
+        </div>
+        <LoadingOverlay />
+        <UnsavedChangesDialog blocker={blocker} />
+      </Form>
+    </form>
+  );
+};
+
+const LoadingOverlay = () => {
+  const form = useFormContext();
+  const { isSubmitting } = form.formState;
+  return (
+    isSubmitting && (
+      <div className="no-doc-scroll fixed bottom-0 left-0 right-0 top-0 z-50 flex items-center justify-center bg-black/70">
+        <LoadingSpinner />
+      </div>
+    )
+  );
+}; 

--- a/garden/src/features/modal/components/edit/EditModalFunctionFormFields.tsx
+++ b/garden/src/features/modal/components/edit/EditModalFunctionFormFields.tsx
@@ -34,7 +34,7 @@ return my_garden.function_name(input)`}`;
               <FormItem>
                 <FormLabel className="font-bold text-gray-700">Function Title</FormLabel>
                 <FormControl>
-                  <Input placeholder="My Function" {...field} className="w-full max-w-2xl" />
+                  <Input placeholder="My Function" {...field} className="w-full" />
                 </FormControl>
                 <FormDescription>Your function's public display name.</FormDescription>
                 <FormMessage />
@@ -51,88 +51,13 @@ return my_garden.function_name(input)`}`;
                 <FormControl>
                   <Textarea
                     placeholder="Tell us about your function"
-                    className="min-h-[100px] w-full max-w-2xl resize-vertical"
+                    className="min-h-[100px] w-full resize-vertical"
                     {...field}
                   />
                 </FormControl>
                 <FormDescription>
                   Provide a high-level overview of your function, its purpose, and how it works.
                 </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
-      </section>
-
-      <section>
-        <h2 className="mb-6 border-b pb-2 text-xl font-bold text-gray-800">Contributors</h2>
-        <div className="space-y-6">
-          <FormField
-            control={form.control}
-            name="authors"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel className="font-bold text-gray-700">Authors</FormLabel>
-                <FormControl>
-                  <MultipleSelector
-                    {...field}
-                    placeholder="Add authors"
-                    creatable
-                    onChange={(value) => {
-                      field.onChange(value.map((v: any) => v.value));
-                    }}
-                    value={field.value.map((v: any) => ({ value: v, label: v }))}
-                    className="w-full max-w-2xl"
-                  />
-                </FormControl>
-                <FormDescription>
-                  List the main researchers involved in developing this function.
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
-      </section>
-
-      <section>
-        <h2 className="mb-6 border-b pb-2 text-xl font-bold text-gray-800">Details</h2>
-        <div className="space-y-6">
-          <FormField
-            control={form.control}
-            name="tags"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel className="font-bold text-gray-700">Tags</FormLabel>
-                <FormControl>
-                  <MultipleSelector
-                    {...field}
-                    className="w-full max-w-2xl"
-                    placeholder="Add tags"
-                    creatable
-                    onChange={(value) => {
-                      field.onChange(value.map((v: any) => v.value));
-                    }}
-                    value={field.value.map((v: any) => ({ value: v, label: v }))}
-                  />
-                </FormControl>
-                <FormDescription>Add relevant tags to improve discoverability.</FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          <FormField
-            control={form.control}
-            name="year"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel className="font-bold text-gray-700">Year</FormLabel>
-                <FormControl>
-                  <Input placeholder="2024" {...field} className="w-full max-w-xs" />
-                </FormControl>
-                <FormDescription>The year this function was created.</FormDescription>
                 <FormMessage />
               </FormItem>
             )}
@@ -147,7 +72,7 @@ return my_garden.function_name(input)`}`;
                 <FormControl>
                   <Textarea
                     placeholder="Show how to use this function"
-                    className="min-h-[150px] w-full max-w-2xl resize-vertical font-mono"
+                    className="min-h-[150px] w-full resize-vertical font-mono"
                     {...field}
                     onKeyDown={(e) => {
                       // Handle tab key for indentation
@@ -167,12 +92,84 @@ return my_garden.function_name(input)`}`;
                   Provide an example of how to use this function in Python code. The preview below will be displayed on your function page.
                 </FormDescription>
                 {/* Always show preview with complete example */}
-                <div className="mt-2">
-                  <div className="text-sm font-semibold text-gray-700">Preview:</div>
-                  <SyntaxHighlighterComponent>
-                    {completeExampleText}
-                  </SyntaxHighlighterComponent>
+                <div className="mt-4">
+                  <div className="mb-2 text-sm font-semibold text-gray-700">Preview:</div>
+                  <div className="rounded-md border bg-gray-50 p-4">
+                    <SyntaxHighlighterComponent>
+                      {completeExampleText}
+                    </SyntaxHighlighterComponent>
+                  </div>
                 </div>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="year"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="font-bold text-gray-700">Year</FormLabel>
+                <FormControl>
+                  <Input placeholder="2024" {...field} className="w-full md:w-32" />
+                </FormControl>
+                <FormDescription>The year this function was created.</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+      </section>
+
+      <section>
+        <h2 className="mb-6 border-b pb-2 text-xl font-bold text-gray-800">Details</h2>
+        <div className="space-y-6">
+          <FormField
+            control={form.control}
+            name="tags"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="font-bold text-gray-700">Tags</FormLabel>
+                <FormControl>
+                  <MultipleSelector
+                    {...field}
+                    className="w-full"
+                    placeholder="Add tags"
+                    creatable
+                    onChange={(value) => {
+                      field.onChange(value.map((v: any) => v.value));
+                    }}
+                    value={field.value.map((v: any) => ({ value: v, label: v }))}
+                  />
+                </FormControl>
+                <FormDescription>Add relevant tags to improve discoverability.</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="authors"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="font-bold text-gray-700">Authors</FormLabel>
+                <FormControl>
+                  <MultipleSelector
+                    {...field}
+                    placeholder="Add authors"
+                    creatable
+                    onChange={(value) => {
+                      field.onChange(value.map((v: any) => v.value));
+                    }}
+                    value={field.value.map((v: any) => ({ value: v, label: v }))}
+                    className="w-full"
+                  />
+                </FormControl>
+                <FormDescription>
+                  List the main researchers involved in developing this function.
+                </FormDescription>
                 <FormMessage />
               </FormItem>
             )}

--- a/garden/src/features/modal/components/edit/EditModalFunctionFormFields.tsx
+++ b/garden/src/features/modal/components/edit/EditModalFunctionFormFields.tsx
@@ -1,0 +1,186 @@
+import { useFormContext } from "react-hook-form";
+import {
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import MultipleSelector from "@/components/ui/multiple-select";
+import SyntaxHighlighterComponent from "@/components/SyntaxHighlighter";
+
+const EditModalFunctionFormFields = () => {
+  const form = useFormContext();
+  const exampleUsage = form.watch("example_usage");
+  const completeExampleText = `from garden_ai import GardenClient
+client = GardenClient()
+my_garden = client.get_garden(my_garden_doi)
+
+${exampleUsage || `input = ['Data Here']
+return my_garden.function_name(input)`}`;
+
+  return (
+    <div className="space-y-8">
+      <section>
+        <h2 className="mb-6 border-b pb-2 text-xl font-bold text-gray-800">General</h2>
+        <div className="space-y-6">
+          <FormField
+            control={form.control}
+            name="title"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="font-bold text-gray-700">Function Title</FormLabel>
+                <FormControl>
+                  <Input placeholder="My Function" {...field} className="w-full max-w-2xl" />
+                </FormControl>
+                <FormDescription>Your function's public display name.</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="description"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="font-bold text-gray-700">Description</FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder="Tell us about your function"
+                    className="min-h-[100px] w-full max-w-2xl resize-vertical"
+                    {...field}
+                  />
+                </FormControl>
+                <FormDescription>
+                  Provide a high-level overview of your function, its purpose, and how it works.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+      </section>
+
+      <section>
+        <h2 className="mb-6 border-b pb-2 text-xl font-bold text-gray-800">Contributors</h2>
+        <div className="space-y-6">
+          <FormField
+            control={form.control}
+            name="authors"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="font-bold text-gray-700">Authors</FormLabel>
+                <FormControl>
+                  <MultipleSelector
+                    {...field}
+                    placeholder="Add authors"
+                    creatable
+                    onChange={(value) => {
+                      field.onChange(value.map((v: any) => v.value));
+                    }}
+                    value={field.value.map((v: any) => ({ value: v, label: v }))}
+                    className="w-full max-w-2xl"
+                  />
+                </FormControl>
+                <FormDescription>
+                  List the main researchers involved in developing this function.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+      </section>
+
+      <section>
+        <h2 className="mb-6 border-b pb-2 text-xl font-bold text-gray-800">Details</h2>
+        <div className="space-y-6">
+          <FormField
+            control={form.control}
+            name="tags"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="font-bold text-gray-700">Tags</FormLabel>
+                <FormControl>
+                  <MultipleSelector
+                    {...field}
+                    className="w-full max-w-2xl"
+                    placeholder="Add tags"
+                    creatable
+                    onChange={(value) => {
+                      field.onChange(value.map((v: any) => v.value));
+                    }}
+                    value={field.value.map((v: any) => ({ value: v, label: v }))}
+                  />
+                </FormControl>
+                <FormDescription>Add relevant tags to improve discoverability.</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="year"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="font-bold text-gray-700">Year</FormLabel>
+                <FormControl>
+                  <Input placeholder="2024" {...field} className="w-full max-w-xs" />
+                </FormControl>
+                <FormDescription>The year this function was created.</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="example_usage"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="font-bold text-gray-700">Example Usage</FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder="Show how to use this function"
+                    className="min-h-[150px] w-full max-w-2xl resize-vertical font-mono"
+                    {...field}
+                    onKeyDown={(e) => {
+                      // Handle tab key for indentation
+                      if (e.key === 'Tab') {
+                        e.preventDefault();
+                        const start = e.currentTarget.selectionStart;
+                        const end = e.currentTarget.selectionEnd;
+                        const value = e.currentTarget.value;
+                        e.currentTarget.value = value.substring(0, start) + '    ' + value.substring(end);
+                        e.currentTarget.selectionStart = e.currentTarget.selectionEnd = start + 4;
+                        field.onChange(e.currentTarget.value);
+                      }
+                    }}
+                  />
+                </FormControl>
+                <FormDescription>
+                  Provide an example of how to use this function in Python code. The preview below will be displayed on your function page.
+                </FormDescription>
+                {/* Always show preview with complete example */}
+                <div className="mt-2">
+                  <div className="text-sm font-semibold text-gray-700">Preview:</div>
+                  <SyntaxHighlighterComponent>
+                    {completeExampleText}
+                  </SyntaxHighlighterComponent>
+                </div>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default EditModalFunctionFormFields; 

--- a/garden/src/features/modal/components/edit/EditModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/edit/EditModalFunctionPage.tsx
@@ -17,7 +17,7 @@ const EditModalFunctionPage = () => {
   if (!isOwner) return <Navigate to={`/modal-functions/${id}`} replace />;
 
   return (
-    <div className="mx-auto max-w-7xl px-8 pt-16 font-display">
+    <div className="mx-auto max-w-7xl px-8 py-4 font-display md:py-16">
       <Breadcrumb
         crumbs={[
           { label: "Home", link: "/" },
@@ -25,10 +25,13 @@ const EditModalFunctionPage = () => {
           { label: "Edit" },
         ]}
       />
-      <div className="my-8">
-        <h1 className="text-2xl sm:text-3xl">Edit Modal Function Metadata</h1>
+      <div className="mb-8 mt-4">
+        <h1 className="text-2xl font-semibold text-gray-900 sm:text-3xl">Edit Modal Function</h1>
       </div>
-      <EditModalFunctionForm modalFunction={modalFunction} />
+
+      <div className="pb-8">
+        <EditModalFunctionForm modalFunction={modalFunction} />
+      </div>
     </div>
   );
 };

--- a/garden/src/features/modal/components/edit/EditModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/edit/EditModalFunctionPage.tsx
@@ -1,0 +1,36 @@
+import { useParams, Navigate } from "react-router-dom";
+import { useGetModalFunction } from "../../api/useGetModalFunction";
+import { useGlobusAuth } from "@/hooks/useGlobusAuth";
+import { LoadingOverlay } from "@/components/LoadingOverlay";
+import NotFoundPage from "@/components/NotFoundPage";
+import { EditModalFunctionForm } from "./EditModalFunctionForm";
+import Breadcrumb from "@/components/Breadcrumb";
+
+const EditModalFunctionPage = () => {
+  const { id } = useParams() as { id: string };
+  const { data: modalFunction, isError, isLoading } = useGetModalFunction(id);
+  const auth = useGlobusAuth();
+  const isOwner = auth.isAuthenticated && modalFunction?.owner_identity_id === auth?.authorization?.user?.sub;
+
+  if (isLoading) return <LoadingOverlay />;
+  if (isError || !modalFunction) return <NotFoundPage />;
+  if (!isOwner) return <Navigate to={`/modal-functions/${id}`} replace />;
+
+  return (
+    <div className="mx-auto max-w-7xl px-8 pt-16 font-display">
+      <Breadcrumb
+        crumbs={[
+          { label: "Home", link: "/" },
+          { label: modalFunction.title, link: `/modal-functions/${modalFunction.id}` },
+          { label: "Edit" },
+        ]}
+      />
+      <div className="my-8">
+        <h1 className="text-2xl sm:text-3xl">Edit Modal Function Metadata</h1>
+      </div>
+      <EditModalFunctionForm modalFunction={modalFunction} />
+    </div>
+  );
+};
+
+export default EditModalFunctionPage; 

--- a/garden/src/features/modal/types/modal.types.ts
+++ b/garden/src/features/modal/types/modal.types.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+
+export const modalFunctionFormSchema = z.object({
+  title: z
+    .string()
+    .min(1, { message: "Title is required" })
+    .min(8, { message: "Title must be at least 8 characters" })
+    .max(100, { message: "Title must not exceed 100 characters" }),
+
+  description: z
+    .string()
+    .min(1, { message: "Description is required" })
+    .min(10, { message: "Description must be at least 10 characters" })
+    .max(1000, { message: "Description must not exceed 1000 characters" }),
+
+  authors: z.array(z.string()).min(1, { message: "Please add at least one author." }),
+  tags: z.array(z.string()),
+  year: z
+    .string()
+    .regex(/^\d{4}$/, { message: "Invalid year" })
+    .optional(),
+  example_usage: z
+    .string()
+    .max(2000, { message: "Example usage must not exceed 2000 characters" })
+    .optional()
+    .default(""),
+});
+
+export type ModalFunctionPatchFormData = z.infer<typeof modalFunctionFormSchema>; 

--- a/garden/src/types/backend-schema.ts
+++ b/garden/src/types/backend-schema.ts
@@ -1885,6 +1885,8 @@ export interface components {
             year?: string | null;
             /** Function Text */
             function_text?: string | null;
+            /** Example Usage */
+            example_usage?: string | null;
             /** Authors */
             authors?: string[] | null;
             /** Tags */

--- a/garden/src/types/index.ts
+++ b/garden/src/types/index.ts
@@ -12,6 +12,7 @@ type EntrypointPatchRequest = components["schemas"]["EntrypointPatchRequest"];
 type ModalAppCreateRequest = components["schemas"]["ModalAppCreateRequest"];
 type ModalAppMetadataResponse = components["schemas"]["ModalAppMetadataResponse"];
 type ModalFunction = components["schemas"]["ModalFunctionMetadataResponse"];
+type ModalFunctionPatchRequest = components["schemas"]["ModalFunctionPatchRequest"];
 
 type AsyncModalAppMetadataResponse = components["schemas"]["AsyncModalAppMetadataResponse"];
 type AsyncModalJobStatus = components["schemas"]["AsyncModalJobStatus"];
@@ -45,6 +46,7 @@ export type {
   ModalAppCreateRequest,
   ModalAppMetadataResponse,
   ModalFunction,
+  ModalFunctionPatchRequest,
   User,
   UpdateUserSchema,
   Dataset,


### PR DESCRIPTION
This PR adds functionality allowing users to edit modal function metadata on modal functions that they own.

A new edit button (plus bonus copy button):
![image](https://github.com/user-attachments/assets/a4dd2f21-aeb5-420a-8426-374dff8232ee)

The edit form:

![image](https://github.com/user-attachments/assets/fc11e6e2-8399-407a-9235-c827386d8085)

Featuring @OwenPriceSkelly 's example usage preview:
![image](https://github.com/user-attachments/assets/b35dea9c-95c4-4cdd-9e08-5217e7033ecf)
