### PR TITLE
Tighten spacing above the fold

### DIFF
--- a/garden/src/components/Breadcrumb.tsx
+++ b/garden/src/components/Breadcrumb.tsx
@@ -9,9 +9,9 @@ import {
 } from "./ui/breadcrumb";
 import React from "react";
 
-const Breadcrumb = ({ crumbs }: { crumbs: any }) => {
+const Breadcrumb = ({ crumbs, className = "" }: { crumbs: any; className?: string }) => {
   return (
-    <BreadcrumbShadcn className="mb-10 hidden md:block">
+    <BreadcrumbShadcn className={`hidden md:block ${className}`}>
       <BreadcrumbList>
         {crumbs.slice(0, crumbs.length - 1).map((crumb: any, index: number) => (
           <React.Fragment key={index}>

--- a/garden/src/components/Navbar.tsx
+++ b/garden/src/components/Navbar.tsx
@@ -31,14 +31,6 @@ const Navbar = () => {
     };
   }, []);
 
-  /*
-  useEffect(() => {
-    if (auth.isAuthenticated) {
-      toast.success("Logged in successfully!");
-    }
-  }, [auth.isAuthenticated]);
-  */
-
   const toggleMenuDropdown = () => {
     setOpenMenuDropdown(!openMenuDropdown);
   };
@@ -60,35 +52,35 @@ const Navbar = () => {
 
   return (
     <div className="relative left-0 top-0 z-10 w-full shadow-md">
-      <div className="items-center justify-between bg-white px-7 py-4 md:flex md:px-10 md:py-2">
+      <div className="items-center justify-between bg-white px-7 py-2 md:flex md:px-10 md:py-1">
         {/* logo */}
-        <Link to="/" className="py-2">
-          <div className="absolute relative inset-0 w-32">
-            <img src="img/garden-logo-small.png" alt="Garden AI Logo" className="" />
+        <Link to="/" className="py-1">
+          <div className="relative w-32">
+            <img src="img/garden-logo-small.png" alt="Garden AI Logo" className="h-8" />
           </div>
         </Link>
 
         {/* menu */}
         <div
           onClick={() => setIsOpen(!isOpen)}
-          className="absolute right-8 top-5 h-8 w-8 cursor-pointer md:hidden"
+          className="absolute right-8 top-3 h-8 w-8 cursor-pointer md:hidden"
         >
           {isOpen ? <X /> : <Menu />}
         </div>
 
         {/* links */}
 
-        <div className={`md:flex`}>
+        <div className={`md:flex md:items-center`}>
           <ul
-            className={`absolute left-0 z-[-1] w-full bg-white pb-8 pl-9 pt-12 transition-all duration-300 ease-in md:static md:z-auto md:flex md:w-auto md:items-center md:pb-0 md:pl-0 md:pt-0 ${isOpen ? "top-12" : "top-[-490px]"}`}
+            className={`absolute left-0 z-[-1] w-full bg-white pb-6 pl-9 pt-10 transition-all duration-300 ease-in md:static md:z-auto md:flex md:w-auto md:items-center md:pb-0 md:pl-0 md:pt-0 ${isOpen ? "top-10" : "top-[-490px]"}`}
           >
             <li>
-              <Link to="/search" className="my-7 no-underline hover:underline md:my-0 md:ml-8">
+              <Link to="/search" className="my-5 no-underline hover:underline md:my-0 md:ml-8">
                 Search
               </Link>
             </li>
             {Links.map((link) => (
-              <li key={link.name} className="my-7 no-underline hover:underline md:my-0 md:ml-8">
+              <li key={link.name} className="my-5 no-underline hover:underline md:my-0 md:ml-8">
                 <a href={link.link} target="_blank">
                   {link.name}
                 </a>
@@ -102,42 +94,39 @@ const Navbar = () => {
             ref={dropdownRef}
           >
             {auth.isAuthenticated ? (
-              <div className="absolute -top-8 right-12 ml-4 md:static">
+              <div className="md:ml-4 absolute right-12 top-0 md:static">
                 <button className="bg-green-500 hover:bg-green-600 px-4 py-1">
                   <div className="flex items-center space-x-2">
-                    <User size={24} />
-                    {openMenuDropdown ? <ChevronUp /> : <ChevronDown />}
+                    <User size={20} />
+                    {openMenuDropdown ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
                   </div>
                 </button>
                 <div
-                  className={`absolute ${openMenuDropdown ? "block" : "hidden"} right-0 z-50 mt-5 justify-between rounded bg-white py-5 shadow-md `}
+                  className={`absolute ${openMenuDropdown ? "block" : "hidden"} right-0 z-50 mt-1 justify-between rounded bg-white py-3 shadow-md `}
                 >
-                  <div className="flex flex-col gap-4 p-4">
+                  <div className="flex flex-col gap-3 p-3">
                     <p>{user?.email} </p>
                     <Separator />
                     <div className="flex flex-row gap-2 hover:text-green hover:underline">
-                      <User />
-                      <Link to="/user"> Your Profile </Link>{" "}
+                      <User size={18} />
+                      <Link to="/user"> Your Profile </Link>
                     </div>
                     <div className="flex flex-row gap-2 hover:text-green hover:underline">
-                      <Plus />
-                      <Link to="/garden/create">Create a Garden</Link>{" "}
-                      {/* add in actual link later once that branch is merged into staging*/}
+                      <Plus size={18} />
+                      <Link to="/garden/create">Create a Garden</Link>
                     </div>
                     <div
                       className="flex flex-row gap-2 hover:cursor-pointer hover:text-green hover:underline"
                       onClick={handleLogOut}
                     >
-                      <LogOut />
+                      <LogOut size={18} />
                       <p> Log Out </p>
                     </div>
                   </div>
                 </div>
               </div>
             ) : (
-              <div
-                className={`absolute -top-8 right-16 bg-white transition-all duration-300 ease-in md:static`}
-              >
+              <div className={`absolute right-16 top-0 bg-white transition-all duration-300 ease-in md:static`}>
                 <button
                   className="transform rounded bg-green px-4 py-1 text-white transition-all duration-300 ease-in-out hover:scale-105 hover:bg-darkgreen md:static md:ml-8"
                   onClick={handleLogin}

--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -51,7 +51,7 @@ const GardenPage = () => {
   const ownsThisGarden = auth.isAuthenticated && garden.owner_identity_id === auth?.authorization?.user?.sub;
 
   return (
-    <div className="mx-auto max-w-7xl px-8 pt-16 font-display">
+    <div className="mx-auto max-w-7xl px-4 md:px-6 pt-8 font-display">
       <Breadcrumb
         crumbs={[
           { label: "Home", link: "/" },
@@ -76,18 +76,18 @@ const GardenPage = () => {
 
 const GardenHeader = ({ garden, ownsThisGarden }: { garden: Garden, ownsThisGarden: boolean }) => {
   return (
-    <div className="my-8 flex items-center justify-between gap-2 sm:gap-4">
+    <div className="my-4 flex items-center justify-between gap-2 sm:gap-3">
       <div className="flex items-center">
-        <h1 className="text-2xl sm:text-3xl">{garden.title}</h1>
+        <h1 className="text-xl sm:text-2xl font-medium">{garden.title}</h1>
         {ownsThisGarden && garden.is_archived && (
-          <Badge className="ml-4 mt-1 px-3 text-sm" variant={"default"}>
+          <Badge className="ml-3 mt-0.5 px-2 text-xs" variant={"default"}>
             {"Archived"}
           </Badge>
         )}
       </div>
-      <div className="flex items-center">
+      <div className="flex items-center gap-1">
         <CopyButton
-          icon={<LinkIcon />}
+          icon={<LinkIcon className="h-4 w-4" />}
           content={`https://doi.org/${garden.doi}`}
           hint="Copy Link"
         />
@@ -101,14 +101,14 @@ const GardenHeader = ({ garden, ownsThisGarden }: { garden: Garden, ownsThisGard
 
 const GardenBody = ({ garden }: { garden: Garden }) => {
   return (
-    <div className="mb-5 rounded-lg border-0 bg-gray-100 p-4 text-sm text-gray-700">
+    <div className="mb-4 rounded-lg border-0 bg-gray-100 p-3 text-xs text-gray-700">
       <div className="flex w-full flex-row justify-between">
-        <div className="mb-4">
+        <div className="mb-2">
           <h2 className="font-semibold">Contributors</h2>
           <p>{garden.authors?.join(", ")}</p>
         </div>
       </div>
-      <div className="mb-4">
+      <div className="mb-2">
         <h2 className="font-semibold">DOI</h2>
         <div className="flex items-center">
           <a
@@ -119,7 +119,7 @@ const GardenBody = ({ garden }: { garden: Garden }) => {
           >
             {garden.doi}
           </a>
-          <CopyButton content={garden.doi} hint="Copy DOI" className="h-8 w-8 p-0.5" />
+          <CopyButton content={garden.doi} hint="Copy DOI" className="h-6 w-6 p-0.5" />
           <Badge 
             variant={garden.doi_is_draft ? "outline" : "default"}
             className="text-xs font-medium"
@@ -163,18 +163,18 @@ const VisibilityWarning = ({ garden, updateGarden }: { garden: Garden; updateGar
   };
 
   return (
-    <div className="mb-6 rounded-lg border-2 border-yellow-200 bg-yellow-50 p-4">
-      <div className="flex items-start gap-3">
-        <FlaskConicalIcon className="mt-1 h-5 w-5 text-yellow-600" />
+    <div className="mb-4 rounded-lg border-2 border-yellow-200 bg-yellow-50 p-3">
+      <div className="flex items-start gap-2">
+        <FlaskConicalIcon className="mt-1 h-4 w-4 text-yellow-600" />
         <div>
-          <h3 className="font-medium text-yellow-900">This is a Test Garden</h3>
-          <p className="mt-1 text-sm text-yellow-700">
+          <h3 className="font-medium text-yellow-900 text-sm">This is a Test Garden</h3>
+          <p className="mt-1 text-xs text-yellow-700">
             This garden won't show up in search results. Other users can still access it directly if you share the link.
           </p>
           <Button
             variant="outline"
             size="sm"
-            className="mt-3 border-yellow-300 text-yellow-700 hover:bg-yellow-100 hover:text-yellow-800"
+            className="mt-2 border-yellow-300 text-yellow-700 hover:bg-yellow-100 hover:text-yellow-800 h-7 text-xs"
             onClick={handleMakePublic}
             disabled={isUpdating}
           >

--- a/garden/src/features/modal/components/ModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/ModalFunctionPage.tsx
@@ -46,10 +46,13 @@ const ModalFunctionPage = () => {
   if (isError || !modalFunction) return <NotFoundPage />;
 
   return (
-    <div className="mx-auto max-w-7xl px-8 pt-16 font-display">
-      {/* TODO: I'm not really sure what makes sense to render for the Breadcrumbs component, since we don't really have a way
-       for a user to land on this page currently. Maybe the parent garden?  */}
-      <Breadcrumb crumbs={[{ label: "Home", link: "/" }, { label: modalFunction.title }]} />
+    <div className="mx-auto max-w-7xl px-4 md:px-6 pt-6 font-display">
+      <div>
+        <Breadcrumb 
+          className="mb-3" 
+          crumbs={[{ label: "Home", link: "/" }, { label: modalFunction.title }]} 
+        />
+      </div>
       <ModalFunctionHeader modalFunction={modalFunction as ModalFunctionWithOwner} />
       <ModalFunctionBody modalFunction={modalFunction} />
       <ModalFunctionExample modalFunction={modalFunction} />
@@ -65,11 +68,11 @@ const ModalFunctionHeader = ({ modalFunction }: { modalFunction: ModalFunctionWi
   const isOwner = auth.isAuthenticated && modalFunction.owner_identity_id === auth?.authorization?.user?.sub;
 
   return (
-    <div className="my-8 flex items-center justify-between gap-2 sm:gap-4">
-      <h1 className="text-xl md:text-3xl">{modalFunction.title}</h1>
-      <div className="flex items-center gap-2">
+    <div className="mb-3 flex items-center justify-between gap-2">
+      <h1 className="text-xl md:text-2xl font-medium">{modalFunction.title}</h1>
+      <div className="flex items-center gap-1">
         <CopyButton
-          icon={<LinkIcon />}
+          icon={<LinkIcon className="h-4 w-4" />}
           content={`${window.location.origin}/modal-functions/${modalFunction.id}`}
           hint="Copy Link"
           className="border-none bg-transparent"
@@ -83,7 +86,7 @@ const ModalFunctionHeader = ({ modalFunction }: { modalFunction: ModalFunctionWi
                   variant="ghost"
                   size="icon"
                   onClick={() => navigate(`/modal-functions/${modalFunction.id}/edit`)}
-                  className="h-9 w-9"
+                  className="h-8 w-8"
                 >
                   <PencilIcon className="h-4 w-4" />
                 </Button>
@@ -101,27 +104,25 @@ const ModalFunctionHeader = ({ modalFunction }: { modalFunction: ModalFunctionWi
 
 const ModalFunctionBody = ({ modalFunction }: { modalFunction: ModalFunction }) => {
   return (
-    <div className="space-y-6 py-6">
-      <div className="mb-6 flex flex-wrap items-center gap-1 text-sm text-gray-500">
+    <div className="space-y-3 py-2">
+      <div className="flex flex-wrap items-center gap-1 text-xs text-gray-500">
         <span>
           {modalFunction.doi ? `DOI: ${modalFunction.doi} | ` : ""} {modalFunction.year} |{" "}
         </span>
-        <TagIcon className="h-4 w-4" />
+        <TagIcon className="h-3.5 w-3.5" />
         <span>{modalFunction.tags?.join(", ")}</span>
       </div>
 
-      <div className="mb-6 flex items-center space-x-2 text-base md:text-lg ">
+      <div className="flex items-center space-x-2 text-sm">
         <span className="font-semibold">Contributors:</span>
         <span>{modalFunction.authors?.join(", ")}</span>
       </div>
 
-      <div className="mb-2 flex items-center gap-2 text-lg md:text-xl">
-        <Eye />
-        <h2>At a glance</h2>
+      <div className="mt-2 bg-gray-50 rounded-md p-3">
+        <Markdown content={modalFunction.description || ""} className="text-sm" />
       </div>
-      <Markdown content={modalFunction.description || ""} className="mb-6" />
 
-      <Separator className="my-6" />
+      <Separator className="my-3" />
     </div>
   );
 };
@@ -138,16 +139,16 @@ ${modalFunction.example_usage || `input = ['Data Here']
 return my_garden.${modalFunction.function_name}(input)`}`;
 
   return (
-    <Card className="rounded-none bg-white p-4">
-      <CardHeader className="px-6 py-4">
-        <CardTitle className="text-xl font-bold text-gray-800">
+    <Card className="rounded-none bg-white p-3">
+      <CardHeader className="px-4 py-2">
+        <CardTitle className="text-lg font-bold text-gray-800">
           {modalFunction.function_name}
         </CardTitle>
       </CardHeader>
-      <CardContent className="space-y-6 px-6 py-4">
+      <CardContent className="space-y-4 px-4 py-2">
         <div>
-          <div className="mb-2 flex items-center justify-between">
-            <h3 className="text-lg font-semibold">Example Usage</h3>
+          <div className="mb-1 flex items-center justify-between">
+            <h3 className="text-sm font-semibold">Example Usage</h3>
             <CopyButton hint="Copy example code" content={exampleText} />
           </div>
           <SyntaxHighlighter>{exampleText}</SyntaxHighlighter>

--- a/garden/src/features/search/components/Form.tsx
+++ b/garden/src/features/search/components/Form.tsx
@@ -33,33 +33,37 @@ export const SearchForm = ({
   };
 
   return (
-    <form onSubmit={(e) => e.preventDefault()} className="">
-      <div className="relative mb-4 flex w-full">
+    <form onSubmit={(e) => e.preventDefault()}>
+      <div className="relative flex w-full">
         <div className="relative flex w-full items-center">
-          <Search className="absolute left-3 h-5 w-5 text-gray-400" />
+          <Search className="absolute left-2.5 h-4 w-4 text-gray-400" />
           <Input
             type="text"
             placeholder="Search for a garden or function (e.g. Digit Classifier)"
             value={queryInputValue}
             onChange={(e) => setQueryInputValue(e.target.value)}
-            className="w-full rounded-l-full py-2 pl-10 pr-12 outline-none transition focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-offset-0"
+            className="h-9 w-full rounded-l-full py-1.5 pl-8 pr-10 outline-none transition focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-offset-0"
           />
           {queryInputValue && (
             <Button
               type="button"
               variant="ghost"
               onClick={handleClear}
-              className="absolute right-2 p-1 text-black"
+              className="absolute right-1 p-1 text-black"
             >
-              <X className="h-5 w-5" />
+              <X className="h-4 w-4" />
             </Button>
           )}
         </div>
 
         <div className="flex">
-          <Button onClick={handleSearch} className="rounded-l-none border-l-0 " variant="default">
-            <Search className="mr-2 h-4 w-4" />
-            Search
+          <Button 
+            onClick={handleSearch} 
+            className="h-9 rounded-l-none border-l-0 px-3 py-1.5 md:w-24" 
+            variant="default"
+          >
+            <Search className="mr-1.5 h-3.5 w-3.5 md:mr-2" />
+            <span>Search</span>
           </Button>
         </div>
       </div>

--- a/garden/src/features/search/components/SearchPage.tsx
+++ b/garden/src/features/search/components/SearchPage.tsx
@@ -52,24 +52,44 @@ const SearchPage = () => {
   );
 
   return (
-    <div className="mt-16 min-h-screen px-6 font-display md:px-12">
-      <h1 className="my-6 text-3xl">Search</h1>
-      <SearchForm query={query} setQuery={setQuery} />
-      <div className="relative my-8">
+    <div className="mt-8 min-h-screen px-4 font-display md:px-8">
+      <div className="flex flex-col space-y-3">
+        <h1 className="text-2xl font-medium">Search</h1>
+        <SearchForm query={query} setQuery={setQuery} />
+      </div>
+      <div className="relative mt-5 mb-6">
         {/* Mobile layout */}
-        <div className="flex flex-col gap-8 lg:hidden">
-          <SearchFilters
-            searchResult={searchResult}
-            selectedFilters={selectedFilters}
-            setSelectedFilters={setSelectedFilters}
-          />
+        <div className="flex flex-col gap-5 lg:hidden">
+          <div className="md:hidden">
+            <SearchFilters
+              searchResult={searchResult}
+              selectedFilters={selectedFilters}
+              setSelectedFilters={setSelectedFilters}
+            />
+          </div>
           <div>
             <SearchResultsInner />
           </div>
         </div>
 
+        {/* Medium layout (md but not lg) */}
+        <div className="hidden md:block lg:hidden">
+          <div className="grid grid-cols-3 gap-5">
+            <div className="col-span-2">
+              <SearchResultsInner />
+            </div>
+            <div className="col-span-1">
+              <SearchFilters
+                searchResult={searchResult}
+                selectedFilters={selectedFilters}
+                setSelectedFilters={setSelectedFilters}
+              />
+            </div>
+          </div>
+        </div>
+
         {/* Desktop layout */}
-        <div className="hidden lg:grid lg:grid-cols-3 lg:gap-8">
+        <div className="hidden lg:grid lg:grid-cols-3 lg:gap-6">
           <div className="lg:col-span-2">
             <SearchResultsInner />
           </div>

--- a/garden/src/features/search/components/SearchResultsHeader.tsx
+++ b/garden/src/features/search/components/SearchResultsHeader.tsx
@@ -26,15 +26,15 @@ export const SearchResultsHeader = ({
   setResultsPerPage: (value: string) => void;
 }) => {
   return (
-    <div className="mb-8 flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
-      <div className="text-sm xl:text-base">
-        <span>{searchResult?.total}</span> result
+    <div className="mb-4 flex flex-col md:flex-row md:items-center md:justify-between">
+      <div className="text-sm text-gray-600 mb-3 md:mb-0">
+        <span className="font-medium">{searchResult?.total}</span> result
         {searchResult?.total !== 1 && "s"} found
       </div>
 
-      <div className="flex flex-wrap items-center gap-4">
-        <div className="flex items-center gap-2">
-          <span className="text-foreground-primary whitespace-nowrap text-sm">
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="flex items-center gap-1.5 mr-1">
+          <span className="text-foreground-primary whitespace-nowrap text-xs">
             Show Functions
           </span>
           <Switch
@@ -43,37 +43,39 @@ export const SearchResultsHeader = ({
           />
         </div>
 
-        <Select
-          value={sortOrder ? sortOrder : "relevance"}
-          onValueChange={(value) => {
-            setSortOrder(value as SortOrder);
-          }}
-        >
-          <SelectTrigger className="w-full xl:w-48">
-            <SelectValue placeholder="Sort Order" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="relevance">Sort by Relevance</SelectItem>
-            <SelectItem value="asc">Sort by Title (A-Z)</SelectItem>
-            <SelectItem value="desc">Sort by Title (Z-A)</SelectItem>
-          </SelectContent>
-        </Select>
+        <div className="flex flex-wrap md:flex-nowrap items-center gap-2">
+          <Select
+            value={sortOrder ? sortOrder : "relevance"}
+            onValueChange={(value) => {
+              setSortOrder(value as SortOrder);
+            }}
+          >
+            <SelectTrigger className="h-8 text-xs w-[140px]">
+              <SelectValue placeholder="Sort Order" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="relevance">Sort by Relevance</SelectItem>
+              <SelectItem value="asc">Sort by Title (A-Z)</SelectItem>
+              <SelectItem value="desc">Sort by Title (Z-A)</SelectItem>
+            </SelectContent>
+          </Select>
 
-        <Select
-          value={resultsPerPage ? resultsPerPage : "10"}
-          onValueChange={(value) => {
-            setResultsPerPage(value);
-          }}
-        >
-          <SelectTrigger className="w-full xl:w-48">
-            <SelectValue placeholder="Results per page" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value={"10"}>10 results per page</SelectItem>
-            <SelectItem value="20">20 results per page</SelectItem>
-            <SelectItem value="50">50 results per page</SelectItem>
-          </SelectContent>
-        </Select>
+          <Select
+            value={resultsPerPage ? resultsPerPage : "10"}
+            onValueChange={(value) => {
+              setResultsPerPage(value);
+            }}
+          >
+            <SelectTrigger className="h-8 text-xs w-[140px]">
+              <SelectValue placeholder="Results per page" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={"10"}>10 results per page</SelectItem>
+              <SelectItem value="20">20 results per page</SelectItem>
+              <SelectItem value="50">50 results per page</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
This PR comes from a cursor session where I wanted to rein in the whitespace at the top of our main browsing pages: search, garden detail, and function detail. Here are some before-and-afters. Whitespace is good, we love whitespace. But we can't have so much spacing in our headers that you have to scroll down to get to the main content on a laptop screen. Take a look and judge for yourself.

## Search

Before
<img width="1161" alt="search-before" src="https://github.com/user-attachments/assets/d979f30c-1087-4bea-bd2f-855822483792" />

After

<img width="1168" alt="search-after" src="https://github.com/user-attachments/assets/f72db315-caff-4fde-97dc-10bb2b7fcf97" />

## Garden Detail

Before

<img width="1162" alt="garden-before" src="https://github.com/user-attachments/assets/96cd7587-6d65-4c26-8932-2d5505ca6f9c" />

After

<img width="1164" alt="garden-after" src="https://github.com/user-attachments/assets/d2118f26-667f-42e7-b0b9-496f07ddfdbc" />

## Function Detail

Before

<img width="1166" alt="function-before" src="https://github.com/user-attachments/assets/ca5c23af-a630-40f2-964e-516733148de6" />


After


<img width="1163" alt="function-after" src="https://github.com/user-attachments/assets/f86c79d4-963f-497c-9cd6-fc7f8c7eb714" />

