### PR TITLE
Refresh featured gardens, other misc tweaks

### DIFF
--- a/garden/src/components/Footer.tsx
+++ b/garden/src/components/Footer.tsx
@@ -104,6 +104,18 @@ const Footer = () => {
             </section>
 
             <section className="place-self-center">
+              <a target="blank" href="https://foundry-ml.org/#/">
+                <div className="grayscale">
+                  <img
+                    src="img/extern-logos/foundry.png"
+                    alt="Foundry logo"
+                    className="max-w-[150px] hover:opacity-75"
+                  />
+                </div>
+              </a>
+            </section>
+
+            <section className="place-self-center">
               <a target="blank" href="https://www.globus.org/">
                 <div className="grayscale">
                   <img

--- a/garden/src/components/Footer.tsx
+++ b/garden/src/components/Footer.tsx
@@ -28,11 +28,6 @@ const Footer = () => {
           <div className="mr-8 md:mr-16">
             <p className="font-bold uppercase text-gray-600">About</p>
             <div>
-              <Link to="/terms" className="no-underline hover:underline">
-                Terms
-              </Link>
-            </div>
-            <div>
               <Link to="/team" className="no-underline hover:underline">
                 Team
               </Link>
@@ -102,18 +97,6 @@ const Footer = () => {
                   <img
                     src="img/extern-logos/mdf.png"
                     alt="MDF logo"
-                    className="max-w-[150px] hover:opacity-75"
-                  />
-                </div>
-              </a>
-            </section>
-
-            <section className="place-self-center">
-              <a target="blank" href="https://foundry-ml.org/#/">
-                <div className="grayscale">
-                  <img
-                    src="img/extern-logos/foundry.png"
-                    alt="Foundry logo"
                     className="max-w-[150px] hover:opacity-75"
                   />
                 </div>

--- a/garden/src/components/HomePage.tsx
+++ b/garden/src/components/HomePage.tsx
@@ -53,11 +53,11 @@ const HomePage = () => {
 
   const gardens: Garden[] = [
     {
-      title: "Garden of assorted materials properties",
+      title: "FairChem/OpenCatalyst OC20 Models",
       description:
-        "Garden containing random forest models of 33 materials properties to provide predictions, error bars, and domain of applicability guidance",
-      doi: "10.26311/ep98-br79",
-      publisher: "Ryan Jacobs",
+        "This Garden contains models trained on the OC20 dataset published by FairChem and the Open Catalyst Project. The models in this Garden are full-sized and trained on the full OC20 dataset. Both S2EF and IS2RE models ...",
+      doi: "10.26311/65ez-ew73",
+      publisher: "Hayden Holbrook",
       language: "English",
       version: "1.0",
       is_archived: false,
@@ -68,11 +68,11 @@ const HomePage = () => {
       is_test: false,
     },
     {
-      title: "Atom segmentation deep learning models",
+      title: "AtomGPT Examples",
       description:
-        "A collection of models that identify atomic column coordinates in scanning transmission electron microscopy (STEM) images.",
-      doi: "10.26311/naqk-9p91",
-      publisher: "Will Engler",
+        "This garden lets you try out AtomGPT, a generative materials model developed by Kamal Choudhary at NIST.",
+      doi: "10.26311/vprp-1t41",
+      publisher: "Kamal Choudhary",
       language: "English",
       version: "1.0",
       is_archived: false,
@@ -83,11 +83,11 @@ const HomePage = () => {
       is_test: false,
     },
     {
-      title: "Transmission electron microscopy (TEM) video analysis models",
+      title: "Conservative to Primitive Conversion in Relativistic Hydrodynamics",
       description:
-        "This garden just hosts the DefectTrack model for now, and may host other TEM video processing models in the future.",
-      doi: "10.26311/frce-y203",
-      publisher: "Will Engler",
+        "This garden hosts a suite of PyTorch models (and corresponding TensorRT engines) trained for conservative-to-primitive variable recovery in numerical relativity simulations, specifically tailored ...",
+      doi: "10.26311/hhwc-0v60",
+      publisher: "Semih Kacmaz",
       language: "English",
       version: "1.0",
       is_archived: false,
@@ -98,54 +98,11 @@ const HomePage = () => {
       is_test: false,
     },
     {
-      title: "Models for processing position-averaged convergent beam electron diffraction images",
+      title: "Chemeleon Examples",
       description:
-        "This garden just hosts the PACBED-CNN model for now, and may host other position-averaged convergent beam electron diffraction models in the future.",
-      doi: "10.26311/hqgg-7m42",
-      publisher: "Will Engler",
-      language: "English",
-      version: "1.0",
-      is_archived: false,
-      entrypoint_ids: ["entrypoint1", "entrypoint2"],
-      owner_identity_id: "100",
-      id: 100,
-      modal_function_ids: [],
-      is_test: false,
-    },
-    {
-      title: "Semiconductor property prediction models",
-      description: "A collection of models for predicting properties of semiconductors",
-      doi: "10.26311/bg7s-v305",
-      publisher: "Will Engler",
-      language: "English",
-      version: "1.0",
-      is_archived: false,
-      entrypoint_ids: ["entrypoint1", "entrypoint2"],
-      owner_identity_id: "100",
-      id: 100,
-      modal_function_ids: [],
-      is_test: false,
-    },
-    {
-      title: "Materials Screening Performance Tests",
-      description: "Figuring out how to run millions of materials property predictions quickly",
-      doi: "10.23677/m4ek-bd27",
-      publisher: "Will Engler",
-      language: "English",
-      version: "1.0",
-      is_archived: false,
-      entrypoint_ids: ["entrypoint1", "entrypoint2"],
-      owner_identity_id: "100",
-      id: 100,
-      modal_function_ids: [],
-      is_test: false,
-    },
-    {
-      title: "Framework example garden",
-      description:
-        "This garden contains entrypoints showing how to use different popular AI frameworks in Garden",
-      doi: "10.26311/b74a-5c58",
-      publisher: "Will Engler",
+        "This is a Garden that runs variants of Chemeleon, a generative materials model by Hyunsoo Park and Aron Walsh at University College London.",
+      doi: "10.26311/6phn-gv02",
+      publisher: "Hyunsoo Park",
       language: "English",
       version: "1.0",
       is_archived: false,
@@ -401,7 +358,7 @@ predictions = predict_properties()`}
       </div>
 
       <div className="bg-green pt-6">
-        <div className="mx-auto max-w-5xl px-4">
+        <div className="mx-auto max-w-5xl px-4 pb-2">
           <div className="text-white">
             <h1 className="text-left text-3xl font-semibold">
               <div className="flex space-x-4">
@@ -413,7 +370,7 @@ predictions = predict_properties()`}
         </div>
 
         <ScrollArea className="w-full">
-          <div className="flex space-x-4 p-4 ">
+          <div className="flex justify-center space-x-4 p-4 ">
             {gardens?.map((res: any, index: any) => (
               <div className="h-[300px] w-[300px]" key={index}>
                 <GardenBox garden={res} />

--- a/garden/src/components/HomePage.tsx
+++ b/garden/src/components/HomePage.tsx
@@ -400,21 +400,15 @@ predictions = predict_properties()`}
         </div>
       </div>
 
-      <div className="bg-green pt-12">
+      <div className="bg-green pt-6">
         <div className="mx-auto max-w-5xl px-4">
           <div className="text-white">
             <h1 className="text-left text-3xl font-semibold">
               <div className="flex space-x-4">
                 <Rocket size={35} className="my-auto" />
-                <h3>Explore Featured Gardens </h3>
+                <h3>Featured Gardens </h3>
               </div>
             </h1>
-            <p className="mt-4 text-lg">
-              Take a look at some popular gardens that have been getting a lot of attention! You can
-              view the models, datasets, papers, and anything else associated with the garden.
-              Additionally, you can run the models to optimize your own workflow, gain inspiration,
-              or for any other reason you see fit.
-            </p>
           </div>
         </div>
 

--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -77,7 +77,7 @@ const GardenPage = () => {
         <Breadcrumb
           crumbs={[
             { label: "Home", link: "/" },
-            { label: "Gardens", link: "/gardens" },
+            { label: "Gardens", link: "/search" },
             { label: garden.title, link: `/garden/${garden.doi}` },
           ]}
         />

--- a/garden/src/features/search/components/SearchResult.tsx
+++ b/garden/src/features/search/components/SearchResult.tsx
@@ -48,7 +48,7 @@ export const SearchResult = ({ garden, verbose }: { garden: Garden; verbose: boo
           <span>{garden.year}</span>
           <BookOpenIcon className="ml-2 h-4 w-4" />
           <span>
-            {entrypoints?.length} entrypoint
+            {entrypoints?.length} function
             {entrypoints?.length !== 1 && <span>s</span>}
           </span>
         </CardDescription>


### PR DESCRIPTION
The main change in this PR is refreshing the Featured Gardens section on the home page.

_Before_

![Screenshot 2025-03-10 at 12 54 40 PM](https://github.com/user-attachments/assets/fbeabb50-3fca-4fc0-9e1d-f301f33efc41)

_After_

![Screenshot 2025-03-10 at 12 54 12 PM](https://github.com/user-attachments/assets/6f0da46d-4f00-441f-87a9-bb344d2dc1d4)

I think the copy was a little odd and it's good to err on the side of saying less. (But if there's something really compelling we want to say, we can always add something back.) This also points to newer examples of Gardens with Modal functions.

### Other Changes
- Remove a "Terms" link to nowhere in the footer
- Fix a breadcrumb that was 404'ing
- Change a straggling mention of "entrypoint" to "function"