### PR TITLE
add existing modalfunctions to a garden

### DIFF
--- a/garden/public/mockServiceWorker.js
+++ b/garden/public/mockServiceWorker.js
@@ -8,8 +8,8 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.3.5'
-const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
+const PACKAGE_VERSION = '2.7.0'
+const INTEGRITY_CHECKSUM = '00729d72e3b82faf54ca8b9621dbb96f'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()
 
@@ -62,7 +62,12 @@ self.addEventListener('message', async function (event) {
 
       sendToClient(client, {
         type: 'MOCKING_ENABLED',
-        payload: true,
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
       })
       break
     }
@@ -155,6 +160,10 @@ async function handleRequest(event, requestId) {
 async function resolveMainClient(event) {
   const client = await self.clients.get(event.clientId)
 
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
   if (client?.frameType === 'top-level') {
     return client
   }
@@ -183,12 +192,26 @@ async function getResponse(event, client, requestId) {
   const requestClone = request.clone()
 
   function passthrough() {
-    const headers = Object.fromEntries(requestClone.headers.entries())
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
 
-    // Remove internal MSW request header so the passthrough request
-    // complies with any potential CORS preflight checks on the server.
-    // Some servers forbid unknown request headers.
-    delete headers['x-msw-intention']
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
 
     return fetch(requestClone, { headers })
   }

--- a/garden/public/mockServiceWorker.js
+++ b/garden/public/mockServiceWorker.js
@@ -8,8 +8,8 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.7.0'
-const INTEGRITY_CHECKSUM = '00729d72e3b82faf54ca8b9621dbb96f'
+const PACKAGE_VERSION = '2.3.5'
+const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()
 
@@ -62,12 +62,7 @@ self.addEventListener('message', async function (event) {
 
       sendToClient(client, {
         type: 'MOCKING_ENABLED',
-        payload: {
-          client: {
-            id: client.id,
-            frameType: client.frameType,
-          },
-        },
+        payload: true,
       })
       break
     }
@@ -160,10 +155,6 @@ async function handleRequest(event, requestId) {
 async function resolveMainClient(event) {
   const client = await self.clients.get(event.clientId)
 
-  if (activeClientIds.has(event.clientId)) {
-    return client
-  }
-
   if (client?.frameType === 'top-level') {
     return client
   }
@@ -192,26 +183,12 @@ async function getResponse(event, client, requestId) {
   const requestClone = request.clone()
 
   function passthrough() {
-    // Cast the request headers to a new Headers instance
-    // so the headers can be manipulated with.
-    const headers = new Headers(requestClone.headers)
+    const headers = Object.fromEntries(requestClone.headers.entries())
 
-    // Remove the "accept" header value that marked this request as passthrough.
-    // This prevents request alteration and also keeps it compliant with the
-    // user-defined CORS policies.
-    const acceptHeader = headers.get('accept')
-    if (acceptHeader) {
-      const values = acceptHeader.split(',').map((value) => value.trim())
-      const filteredValues = values.filter(
-        (value) => value !== 'msw/passthrough',
-      )
-
-      if (filteredValues.length > 0) {
-        headers.set('accept', filteredValues.join(', '))
-      } else {
-        headers.delete('accept')
-      }
-    }
+    // Remove internal MSW request header so the passthrough request
+    // complies with any potential CORS preflight checks on the server.
+    // Some servers forbid unknown request headers.
+    delete headers['x-msw-intention']
 
     return fetch(requestClone, { headers })
   }

--- a/garden/src/features/entrypoints/components/modals/NotebookModal.tsx
+++ b/garden/src/features/entrypoints/components/modals/NotebookModal.tsx
@@ -54,6 +54,7 @@ const NotebookModal = ({ edit, onSave, initialData, trigger }: NotebookModalProp
     try {
       onSave({
         ...data,
+        description: data.description ?? null,
         type: 'jupyter' // Default to jupyter, or you may want to add a type selector in your form
       });
       setOpen(false);

--- a/garden/src/features/gardens/components/EditGardenschemas.ts
+++ b/garden/src/features/gardens/components/EditGardenschemas.ts
@@ -23,6 +23,7 @@ export const formSchema = z.object({
   contributors: z.array(z.string()),
   tags: z.array(z.string()),
   entrypoint_ids: z.array(z.string()),
+  modal_function_ids: z.array(z.number()).optional().default([]),
 });
 
 export type GardenPatchFormData = z.infer<typeof formSchema>;

--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -1,7 +1,7 @@
 import { useParams, useSearchParams } from "react-router-dom";
 import { Card, CardContent } from "@/components/shadcn/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/shadcn/tabs";
-import { DatabaseIcon, BookIcon, ClipboardIcon, FolderGit2, Laptop, CodeIcon, ScrollTextIcon } from "lucide-react";
+import { DatabaseIcon, BookIcon, ClipboardIcon, FolderGit2, Laptop, CodeIcon, ScrollTextIcon, FunctionSquare } from "lucide-react";
 import { useState, useCallback, useMemo } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
@@ -36,6 +36,7 @@ import {
   EditableTitle,
   ReviewNotice,
   AddMaterialWithFunctionSelect,
+  AddModalFunctionSelector,
   DatasetCard,
   PaperCard,
   RepositoryCard,
@@ -155,19 +156,35 @@ const GardenContent = ({ garden, ownsThisGarden, isNewlyCreated, updateGarden }:
                 <TabsContent value="functions" className="mt-0 relative">
                   <Card className="border-0 shadow-none bg-transparent">
                     <CardContent className="pt-6">
-                      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                        {garden.entrypoints?.map((entrypoint, index) => (
-                          <EntrypointBox
-                            key={index}
-                            entrypoint={entrypoint}
-                          />
-                        ))}
-                        {garden.modal_functions?.map((modalFunction, index) => (
-                          <ModalFunctionBox
-                            key={index}
-                            modalFunction={modalFunction}
-                          />
-                        ))}
+                      <div>
+                        <div className="flex items-center justify-between mb-3">
+                          <h3 className="text-lg font-medium flex items-center">
+                            <FunctionSquare className="h-5 w-5 mr-2 text-green" />
+                            Functions
+                          </h3>
+                          
+                          {ownsThisGarden && (
+                            <AddModalFunctionSelector
+                              garden={garden}
+                              onSuccess={handleMaterialAdded}
+                            />
+                          )}
+                        </div>
+                        
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                          {garden.entrypoints?.map((entrypoint, index) => (
+                            <EntrypointBox
+                              key={index}
+                              entrypoint={entrypoint}
+                            />
+                          ))}
+                          {garden.modal_functions?.map((modalFunction, index) => (
+                            <ModalFunctionBox
+                              key={index}
+                              modalFunction={modalFunction}
+                            />
+                          ))}
+                        </div>
                       </div>
                     </CardContent>
                   </Card>

--- a/garden/src/features/gardens/components/SelectModalFunctionsTable.tsx
+++ b/garden/src/features/gardens/components/SelectModalFunctionsTable.tsx
@@ -74,65 +74,67 @@ export const SelectModalFunctionsTable = ({
           </WithTooltip>
         </div>
       </div>
-      <div className="relative mb-4 min-h-[250px] overflow-x-auto rounded-md border bg-white">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead className="w-1/12"></TableHead>
-              <TableHead className="w-1/4">Name</TableHead>
-              <TableHead className="w-1/2">Description</TableHead>
-              <TableHead className="w-1/6 text-center"></TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {isLoading ? (
+      <div className="relative mb-4 rounded-md border bg-white">
+        <div className="max-h-[480px] overflow-y-auto">
+          <Table>
+            <TableHeader className="sticky top-0 bg-white z-10">
               <TableRow>
-                <TableCell colSpan={4} className="text-center">
-                  <div className="flex h-24 items-center justify-center">
-                    <LoadingSpinner />
-                  </div>
-                </TableCell>
+                <TableHead className="w-1/12"></TableHead>
+                <TableHead className="w-1/4">Name</TableHead>
+                <TableHead className="w-1/2">Description</TableHead>
+                <TableHead className="w-1/6 text-center"></TableHead>
               </TableRow>
-            ) : functions?.length === 0 ? (
-              <TableRow>
-                <TableCell colSpan={4} className="text-center text-gray-500">
-                  No additional modal functions available
-                </TableCell>
-              </TableRow>
-            ) : (
-              functions?.map((func) => (
-                <TableRow key={func.id}>
-                  <TableCell className="w-1/12 text-center">
-                    <Checkbox
-                      checked={selectedIds.includes(func.id)}
-                      onCheckedChange={() => handleCheckboxChange(func.id)}
-                      value={func.id}
-                      disabled={published}
-                    />
-                  </TableCell>
-                  <TableCell className="w-1/4 truncate whitespace-normal break-words">
-                    {func.title || func.function_name}
-                  </TableCell>
-                  <TableCell className="w-1/2 truncate whitespace-normal break-words">
-                    {func.description || "No description available"}
-                  </TableCell>
-                  <TableCell className="w-1/6 text-center">
-                    <Link
-                      to={`/modal-functions/${func.id}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <Button variant="outline" size="sm" type="button">
-                        View
-                        <ExternalLink size={14} className="mb-0.5 ml-1" />
-                      </Button>
-                    </Link>
+            </TableHeader>
+            <TableBody>
+              {isLoading ? (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-center">
+                    <div className="flex h-24 items-center justify-center">
+                      <LoadingSpinner />
+                    </div>
                   </TableCell>
                 </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
+              ) : functions?.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-center text-gray-500">
+                    No additional modal functions available
+                  </TableCell>
+                </TableRow>
+              ) : (
+                functions?.map((func) => (
+                  <TableRow key={func.id}>
+                    <TableCell className="w-1/12 text-center">
+                      <Checkbox
+                        checked={selectedIds.includes(func.id)}
+                        onCheckedChange={() => handleCheckboxChange(func.id)}
+                        value={func.id}
+                        disabled={published}
+                      />
+                    </TableCell>
+                    <TableCell className="w-1/4 truncate whitespace-normal break-words">
+                      {func.title || func.function_name}
+                    </TableCell>
+                    <TableCell className="w-1/2 truncate whitespace-normal break-words">
+                      {func.description || "No description available"}
+                    </TableCell>
+                    <TableCell className="w-1/6 text-center">
+                      <Link
+                        to={`/modal-functions/${func.id}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <Button variant="outline" size="sm" type="button">
+                          View
+                          <ExternalLink size={14} className="mb-0.5 ml-1" />
+                        </Button>
+                      </Link>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
         {published && (
           <div className="absolute inset-0 flex items-center justify-center bg-gray-100 bg-opacity-75 backdrop-blur-sm">
             <div className="max-w-md rounded-lg bg-white p-6 text-center shadow-lg">

--- a/garden/src/features/gardens/components/create/CreateGardenForm.tsx
+++ b/garden/src/features/gardens/components/create/CreateGardenForm.tsx
@@ -78,8 +78,14 @@ export const CreateGardenForm = ({ modalAppId }: CreateGardenFormProps = {}) => 
       };
 
       if (modalAppId && modalApp) {
-        // Use the pre-deployed modal app
-        gardenCreateRequest.modal_function_ids = modalApp.modal_function_ids;
+        // Use the pre-deployed modal app, but preserve user selections for additional functions
+        gardenCreateRequest.modal_function_ids = [
+          ...(modalApp.modal_function_ids || []),
+          ...(values.modal_function_ids || [])
+        ];
+        
+        // Remove duplicates if any
+        gardenCreateRequest.modal_function_ids = [...new Set(gardenCreateRequest.modal_function_ids)];
       }
 
       const { garden } = await createGardenAndDOI(gardenCreateRequest);

--- a/garden/src/features/gardens/components/create/CreateGardenFormFields.tsx
+++ b/garden/src/features/gardens/components/create/CreateGardenFormFields.tsx
@@ -178,36 +178,39 @@ export const CreateGardenFormFields = ({ hideModalUpload = false }: CreateGarden
                   </ul>
                 </div>
               )}
-              
-              {/* Wrap the modal functions selector in a Collapsible component */}
-              <div className="mt-6">
-                <Collapsible className="w-full">
-                  <div className="flex items-center justify-between">
-                    <h3 className="text-lg font-semibold">Add Additional Functions</h3>
-                    <CollapsibleTrigger asChild>
-                      <Button variant="ghost" className="p-1 hover:bg-gray-100">
-                        <ChevronDown className="h-5 w-5" />
-                        <span className="sr-only">Toggle</span>
-                      </Button>
-                    </CollapsibleTrigger>
-                  </div>
-                  <p className="mt-1 text-sm text-gray-600">
-                    Optionally add other Modal functions you've created to this Garden.
-                  </p>
-                  
-                  <CollapsibleContent className="mt-2">
-                    <SelectModalFunctionsTable 
-                      currentFunctionIds={currentModalFunctionIds}
-                      published={isPublished}
-                    />
-                  </CollapsibleContent>
-                </Collapsible>
-              </div>
-        </div>
+            </div>
         ) : (
         <UploadModalFormFields />
         )}
+      </div>
+
+      {/* Additional Functions Section - Moved outside the Modal App box */}
+      {hideModalUpload && (
+        <div className="space-y-8">
+          <Collapsible className="w-full space-y-4">
+            <div className="flex items-center justify-between">
+              <div className="space-y-2">
+                <h2 className="text-2xl font-semibold">(Optional) Include Additional Functions</h2>
+                <p className="text-sm text-gray-700">
+                  Add other Modal functions you've already created to this Garden. 
+                </p>
+              </div>
+              <CollapsibleTrigger asChild>
+                <Button variant="ghost" className="p-1 hover:bg-gray-100">
+                  <ChevronDown className="h-5 w-5" />
+                  <span className="sr-only">Toggle</span>
+                </Button>
+              </CollapsibleTrigger>
+            </div>
+            <CollapsibleContent className="mt-4">
+              <SelectModalFunctionsTable 
+                currentFunctionIds={currentModalFunctionIds}
+                published={isPublished}
+              />
+            </CollapsibleContent>
+          </Collapsible>
         </div>
+      )}
 
       <div className="space-y-8">
         <h2 className="text-2xl font-semibold">Visibility Settings</h2>

--- a/garden/src/features/gardens/components/create/CreateGardenFormFields.tsx
+++ b/garden/src/features/gardens/components/create/CreateGardenFormFields.tsx
@@ -37,7 +37,11 @@ export const CreateGardenFormFields = ({ hideModalUpload = false }: CreateGarden
 
   const isTestGarden = form.watch("is_test");
   const modalApp = form.watch("modal");
-  const currentModalFunctionIds = form.watch("modal_function_ids") || [];
+  
+  // Extract only the function IDs from the main modal app - these should be excluded from the selection table
+  // as they're already part of the garden. We don't want to exclude functions that are being selected
+  // in the modal_function_ids field.
+  const modalAppFunctionIds = modalApp.modal_functions?.map((func: any) => func.id) || [];
   
   // Check if garden is published to disable modal function selection
   const isPublished = form.watch("doi_is_draft") === false && form.watch("is_archived") === false;
@@ -204,7 +208,7 @@ export const CreateGardenFormFields = ({ hideModalUpload = false }: CreateGarden
             </div>
             <CollapsibleContent className="mt-4">
               <SelectModalFunctionsTable 
-                currentFunctionIds={currentModalFunctionIds}
+                currentFunctionIds={modalAppFunctionIds}
                 published={isPublished}
               />
             </CollapsibleContent>

--- a/garden/src/features/gardens/components/edit/EditGardenForm.tsx
+++ b/garden/src/features/gardens/components/edit/EditGardenForm.tsx
@@ -28,6 +28,7 @@ export const EditGardenForm = ({ garden }: { garden: Garden }) => {
         contributors: garden.contributors || [],
         tags: garden.tags || [],
         entrypoint_ids: garden.entrypoints?.map((entrypoint) => entrypoint.doi) || [],
+        modal_function_ids: garden.modal_functions?.map((func) => func.id) || [],
         is_archived: garden.is_archived,
         doi_is_draft: garden.doi_is_draft,
       }),

--- a/garden/src/features/gardens/components/edit/EditGardenFormFields.tsx
+++ b/garden/src/features/gardens/components/edit/EditGardenFormFields.tsx
@@ -12,7 +12,7 @@ import {
 import { Input } from "@/components/shadcn/input";
 import { Textarea } from "@/components/shadcn/textarea";
 import MultipleSelector from "@/components/shadcn/multiple-select";
-import { SelectEntrypointsTable } from "../SelectEntrypointsTable";
+import { EditModalFunctionsTable } from "./EditModalFunctionsTable";
 
 const EditGardenFormFields = () => {
   const navigate = useNavigate();
@@ -124,12 +124,14 @@ const EditGardenFormFields = () => {
       </section>
 
       <section>
-        <h2 className="mb-6 border-b  text-2xl font-bold text-gray-800">Entrypoints</h2>
+        <h2 className="mb-6 border-b  text-2xl font-bold text-gray-800">Modal Functions</h2>
         <p className="mb-8 text-sm text-muted-foreground">
-          Select the functions that are part of your garden. These functions will be displayed
+          Select the modal functions that are part of your garden. These functions will be displayed
           on the Garden page. Only unpublished gardens can modify their functions.
         </p>
-        <SelectEntrypointsTable />
+        <EditModalFunctionsTable 
+          published={form.getValues("doi_is_draft") === false && form.getValues("is_archived") === false}
+        />
       </section>
 
       <section>

--- a/garden/src/features/gardens/components/edit/EditModalFunctionsTable.tsx
+++ b/garden/src/features/gardens/components/edit/EditModalFunctionsTable.tsx
@@ -1,0 +1,153 @@
+import { Button } from "@/components/shadcn/button";
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from "@/components/shadcn/table";
+import { Checkbox } from "@/components/shadcn/checkbox";
+import { ExternalLink, RefreshCcwIcon } from "lucide-react";
+import { useFormContext } from "react-hook-form";
+import { Link } from "react-router-dom";
+import WithTooltip from "@/components/WithTooltip";
+import { cn } from "@/utils/form.utils";
+import { useGetUserModalFunctions } from "../../../modal/api/useGetUserModalFunctions";
+import { GardenPatchFormData } from "../EditGardenschemas";
+import LoadingSpinner from "@/components/LoadingSpinner";
+import { useGlobusAuth } from "@globus/react-auth-context";
+
+interface EditModalFunctionsTableProps {
+  published?: boolean;
+}
+
+/**
+ * Component for editing modal functions in a garden
+ * Unlike SelectModalFunctionsTable, this shows ALL user functions with garden functions pre-checked
+ */
+export const EditModalFunctionsTable = ({ 
+  published = false 
+}: EditModalFunctionsTableProps) => {
+  const { watch, setValue } = useFormContext<GardenPatchFormData>();
+  const auth = useGlobusAuth();
+  
+  // Get the selected modal function IDs from the form
+  const selectedIds = watch("modal_function_ids") || [];
+  
+  // Fetch ALL user's modal functions (without exclusion)
+  const {
+    data: functions,
+    refetch,
+    isFetching,
+    isLoading
+  } = useGetUserModalFunctions({
+    enabled: !!auth?.authorization?.user?.sub,
+  });
+
+  const handleCheckboxChange = (id: number) => {
+    if (published) return; // Prevent changes if published
+    
+    const updatedIds = selectedIds.includes(id)
+      ? selectedIds.filter((selectedId: number) => selectedId !== id)
+      : [...selectedIds, id];
+    
+    setValue("modal_function_ids", updatedIds, { shouldValidate: true, shouldDirty: true });
+  };
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="mb-4 text-xl font-bold">Your Modal Functions</h3>
+        <div className="flex items-center pr-4 text-sm">
+          <span className="text-gray-500">{isFetching && "Refreshing..."}</span>
+          <WithTooltip hint="Refresh">
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => refetch()}
+              type="button"
+              disabled={isFetching}
+              className={cn(
+                "border-none bg-transparent p-2 hover:bg-transparent",
+                isFetching && "cursor-not-allowed opacity-50",
+              )}
+            >
+              <RefreshCcwIcon className={cn("h-5 w-5", isFetching && "animate-spin")} />
+            </Button>
+          </WithTooltip>
+        </div>
+      </div>
+      <div className="relative mb-4 rounded-md border bg-white">
+        <div className="max-h-[480px] overflow-y-auto">
+          <Table>
+            <TableHeader className="sticky top-0 bg-white z-10">
+              <TableRow>
+                <TableHead className="w-1/12"></TableHead>
+                <TableHead className="w-1/4">Name</TableHead>
+                <TableHead className="w-1/2">Description</TableHead>
+                <TableHead className="w-1/6 text-center"></TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading ? (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-center">
+                    <div className="flex h-24 items-center justify-center">
+                      <LoadingSpinner />
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ) : functions?.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-center text-gray-500">
+                    No modal functions available
+                  </TableCell>
+                </TableRow>
+              ) : (
+                functions?.map((func) => (
+                  <TableRow key={func.id}>
+                    <TableCell className="w-1/12 text-center">
+                      <Checkbox
+                        checked={selectedIds.includes(func.id)}
+                        onCheckedChange={() => handleCheckboxChange(func.id)}
+                        value={func.id}
+                        disabled={published}
+                      />
+                    </TableCell>
+                    <TableCell className="w-1/4 truncate whitespace-normal break-words">
+                      {func.title || func.function_name}
+                    </TableCell>
+                    <TableCell className="w-1/2 truncate whitespace-normal break-words">
+                      {func.description || "No description available"}
+                    </TableCell>
+                    <TableCell className="w-1/6 text-center">
+                      <Link
+                        to={`/modal-functions/${func.id}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <Button variant="outline" size="sm" type="button">
+                          View
+                          <ExternalLink size={14} className="mb-0.5 ml-1" />
+                        </Button>
+                      </Link>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+        {published && (
+          <div className="absolute inset-0 flex items-center justify-center bg-gray-100 bg-opacity-75 backdrop-blur-sm">
+            <div className="max-w-md rounded-lg bg-white p-6 text-center shadow-lg">
+              <h3 className="mb-2 text-xl font-semibold text-gray-900">Garden is Published</h3>
+              <p className="text-gray-600">Modal functions cannot be edited in a published garden.</p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}; 

--- a/garden/src/features/gardens/components/garden-page/AddModalFunctionSelector.tsx
+++ b/garden/src/features/gardens/components/garden-page/AddModalFunctionSelector.tsx
@@ -1,0 +1,219 @@
+import React, { useState } from 'react';
+import { PlusCircle, RefreshCcwIcon } from 'lucide-react';
+import { Button } from '@/components/shadcn/button';
+import { Garden, ModalFunction } from '@/types';
+import { Checkbox } from '@/components/shadcn/checkbox';
+import { Label } from '@/components/shadcn/label';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/shadcn/dialog';
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from "@/components/shadcn/table";
+import { toast } from 'sonner';
+import { useGetUserModalFunctions } from '@/features/modal/api/useGetUserModalFunctions';
+import { usePatchGarden } from '@/features/gardens/api/usePatchGarden';
+import { Link } from 'react-router-dom';
+import { ExternalLink } from 'lucide-react';
+import LoadingSpinner from '@/components/LoadingSpinner';
+import WithTooltip from '@/components/WithTooltip';
+import { cn } from '@/utils/form.utils';
+
+interface AddModalFunctionSelectorProps {
+  garden: Garden;
+  onSuccess?: () => void;
+}
+
+const AddModalFunctionSelector: React.FC<AddModalFunctionSelectorProps> = ({
+  garden,
+  onSuccess
+}) => {
+  // Get current function IDs to exclude from the selection
+  const currentFunctionIds = garden.modal_functions?.map(f => f.id) || [];
+  
+  // State for selected function IDs
+  const [selectedFunctionIds, setSelectedFunctionIds] = useState<number[]>([]);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  
+  // Get user's modal functions
+  const {
+    data: functions,
+    refetch,
+    isFetching,
+    isLoading
+  } = useGetUserModalFunctions({
+    excludeFunctionIds: currentFunctionIds,
+  });
+  
+  const { mutateAsync: patchGarden } = usePatchGarden();
+  
+  // Handle checkbox change
+  const handleFunctionToggle = (functionId: number) => {
+    setSelectedFunctionIds(prev => 
+      prev.includes(functionId)
+        ? prev.filter(id => id !== functionId)
+        : [...prev, functionId]
+    );
+  };
+  
+  // Handle saving functions to the garden
+  const handleSave = async () => {
+    if (selectedFunctionIds.length === 0) {
+      toast.error("Please select at least one function");
+      return;
+    }
+    
+    try {
+      // Get the selected functions
+      const selectedFunctions = functions?.filter(f => selectedFunctionIds.includes(f.id)) || [];
+      
+      // Get current modal functions from garden
+      const currentFunctions = garden.modal_functions || [];
+      
+      // Add new functions to existing ones
+      const updatedFunctions = [...currentFunctions, ...selectedFunctions];
+      
+      // Update the garden with the new functions
+      await patchGarden({
+        doi: garden.doi,
+        garden: {
+          modal_function_ids: updatedFunctions.map(f => f.id)
+        }
+      });
+      
+      toast.success("Functions added to garden successfully");
+      setIsDialogOpen(false);
+      setSelectedFunctionIds([]);
+      
+      // Call onSuccess callback if provided
+      if (onSuccess) onSuccess();
+    } catch (error) {
+      toast.error("Failed to add functions to garden");
+      console.error('Error adding functions to garden:', error);
+    }
+  };
+  
+  // Don't render if there are no available functions to add
+  if ((functions?.length || 0) === 0 && !isLoading && !isFetching) return null;
+  
+  return (
+    <>
+      <Button 
+        type="button" 
+        variant="outline"
+        onClick={() => setIsDialogOpen(true)}
+      >
+        <PlusCircle className="mr-2 h-4 w-4" />
+        Add function
+      </Button>
+      
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent className="max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>Add Functions to Garden</DialogTitle>
+          </DialogHeader>
+          
+          <div className="mb-2 flex items-center justify-between">
+            <p className="text-sm text-gray-500">
+              Select functions to add to this garden:
+            </p>
+            <div className="flex items-center pr-4 text-sm">
+              <span className="text-gray-500">{isFetching && "Refreshing..."}</span>
+              <WithTooltip hint="Refresh functions list">
+                <Button
+                  variant="outline"
+                  size="icon"
+                  onClick={() => refetch()}
+                  type="button"
+                  disabled={isFetching}
+                  className={cn(
+                    "border-none bg-transparent p-2 hover:bg-transparent",
+                    isFetching && "cursor-not-allowed opacity-50",
+                  )}
+                >
+                  <RefreshCcwIcon className={cn("h-5 w-5", isFetching && "animate-spin")} />
+                </Button>
+              </WithTooltip>
+            </div>
+          </div>
+          
+          <div className="relative mb-4 rounded-md border bg-white">
+            <div className="max-h-[420px] overflow-y-auto">
+              <Table>
+                <TableHeader className="sticky top-0 bg-white z-10">
+                  <TableRow>
+                    <TableHead className="w-1/12"></TableHead>
+                    <TableHead className="w-1/4">Name</TableHead>
+                    <TableHead className="w-1/2">Description</TableHead>
+                    <TableHead className="w-1/6 text-center"></TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {isLoading ? (
+                    <TableRow>
+                      <TableCell colSpan={4} className="text-center">
+                        <div className="flex h-24 items-center justify-center">
+                          <LoadingSpinner />
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ) : functions?.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={4} className="text-center text-gray-500">
+                        No additional modal functions available
+                      </TableCell>
+                    </TableRow>
+                  ) : (
+                    functions?.map((func) => (
+                      <TableRow key={func.id}>
+                        <TableCell className="w-1/12 text-center">
+                          <Checkbox
+                            checked={selectedFunctionIds.includes(func.id)}
+                            onCheckedChange={() => handleFunctionToggle(func.id)}
+                            value={func.id}
+                          />
+                        </TableCell>
+                        <TableCell className="w-1/4 truncate whitespace-normal break-words">
+                          {func.title || func.function_name}
+                        </TableCell>
+                        <TableCell className="w-1/2 truncate whitespace-normal break-words">
+                          {func.description || "No description available"}
+                        </TableCell>
+                        <TableCell className="w-1/6 text-center">
+                          <Link
+                            to={`/modal-functions/${func.id}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            <Button variant="outline" size="sm" type="button">
+                              View
+                              <ExternalLink size={14} className="mb-0.5 ml-1" />
+                            </Button>
+                          </Link>
+                        </TableCell>
+                      </TableRow>
+                    ))
+                  )}
+                </TableBody>
+              </Table>
+            </div>
+          </div>
+          
+          <div className="flex justify-end space-x-2 mt-4">
+            <Button variant="outline" onClick={() => setIsDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave} disabled={selectedFunctionIds.length === 0}>
+              Add to Garden
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+};
+
+export default AddModalFunctionSelector; 

--- a/garden/src/features/gardens/components/garden-page/index.ts
+++ b/garden/src/features/gardens/components/garden-page/index.ts
@@ -8,5 +8,6 @@ export { default as ReviewNotice } from "./ReviewNotice";
 export { default as GardenAssociatedMaterialsSection } from "./GardenAssociatedMaterialsSection";
 export { default as ShowAllMaterialsToggle } from "./ShowAllMaterialsToggle";
 export { default as AddMaterialWithFunctionSelect } from "./AddMaterialWithFunctionSelect";
+export { default as AddModalFunctionSelector } from "./AddModalFunctionSelector";
 export { PaperCard, DatasetCard, RepositoryCard } from "./MaterialCards";
 export { NotebookCard } from "./components/NotebookCard";

--- a/garden/src/features/materials/components/cards/MaterialCards.tsx
+++ b/garden/src/features/materials/components/cards/MaterialCards.tsx
@@ -309,12 +309,10 @@ export const NotebookCard = ({
       >
         <div className="space-y-2.5 py-1">
           {notebook.description ? (
-            typeof notebook.description === 'string' && (
-              <div className="flex items-baseline">
-                <span className="w-24 text-gray-500 text-xs font-medium">Description</span>
-                <div className="flex-1 line-clamp-2">{notebook.description}</div>
-              </div>
-            )
+            <div className="flex items-baseline">
+              <span className="w-24 text-gray-500 text-xs font-medium">Description</span>
+              <div className="flex-1 line-clamp-2">{String(notebook.description)}</div>
+            </div>
           ) : null}
           
           {notebook.url && (
@@ -331,7 +329,7 @@ export const NotebookCard = ({
             </div>
           )}
           
-          {notebook.type && (
+          {typeof notebook.type === 'string' && (
             <div className="flex items-baseline">
               <span className="w-24 text-gray-500 text-xs font-medium">Type</span>
               <div className="flex-1 capitalize">{notebook.type}</div>

--- a/garden/src/features/materials/components/modals/NotebookModal.tsx
+++ b/garden/src/features/materials/components/modals/NotebookModal.tsx
@@ -54,6 +54,7 @@ const NotebookModal = ({ edit, onSave, initialData, trigger }: NotebookModalProp
     try {
       onSave({
         ...data,
+        description: data.description ?? null,
         type: 'jupyter' // Default to jupyter, or you may want to add a type selector in your form
       });
       setOpen(false);

--- a/garden/src/features/modal/api/useGetUserModalFunctions.tsx
+++ b/garden/src/features/modal/api/useGetUserModalFunctions.tsx
@@ -22,31 +22,18 @@ export const useGetUserModalFunctions = (options: UseGetUserModalFunctionsOption
   return useQuery<ModalFunction[]>({
     queryKey: ["userModalFunctions", userUuid, excludeFunctionIds],
     queryFn: async () => {
-      // First fetch the user's modal apps
-      const appsResponse = await axios.get(`/modal-apps`, {
+      // Get all modal functions for the user
+      const response = await axios.get(`/modal-functions`, {
         params: { owner_uuid: userUuid }
       });
       
-      const apps = appsResponse.data || [];
+      const allFunctions = response.data || [];
       
-      // Then fetch the details of each function
-      let allFunctions: ModalFunction[] = [];
-      
-      for (const app of apps) {
-        // Skip if the app has no functions
-        if (!app.modal_function_ids?.length) continue;
-        
-        // For each function ID, fetch the function details if not excluded
-        for (const functionId of app.modal_function_ids) {
-          if (excludeFunctionIds.includes(functionId)) continue;
-          
-          try {
-            const functionResponse = await axios.get(`/modal-functions/${functionId}`);
-            allFunctions.push(functionResponse.data);
-          } catch (error) {
-            console.error(`Failed to fetch modal function ${functionId}:`, error);
-          }
-        }
+      // Filter out excluded function IDs if any
+      if (excludeFunctionIds.length > 0) {
+        return allFunctions.filter((func: ModalFunction) => 
+          !excludeFunctionIds.includes(func.id)
+        );
       }
       
       return allFunctions;

--- a/garden/src/types/backend-schema.ts
+++ b/garden/src/types/backend-schema.ts
@@ -401,6 +401,26 @@ export interface paths {
         patch: operations["update_modal_function_modal_functions__id__patch"];
         trace?: never;
     };
+    "/modal-functions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get Modal Functions
+         * @description Fetch multiple modal functions according to query parameters.
+         */
+        get: operations["get_modal_functions_modal_functions_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/modal-file-metadata": {
         parameters: {
             query?: never;
@@ -906,6 +926,8 @@ export interface components {
             papers?: components["schemas"]["_PaperMetadata"][];
             /** Datasets */
             datasets?: components["schemas"]["_DatasetMetadata"][];
+            /** Notebooks */
+            notebooks?: components["schemas"]["_NotebookMetadata"][];
             /** Doi */
             doi: string;
             /** Doi Is Draft */
@@ -965,6 +987,8 @@ export interface components {
             papers?: components["schemas"]["_PaperMetadata"][];
             /** Datasets */
             datasets?: components["schemas"]["_DatasetMetadata"][];
+            /** Notebooks */
+            notebooks?: components["schemas"]["_NotebookMetadata"][];
             /** Doi */
             doi: string;
             /** Doi Is Draft */
@@ -1028,6 +1052,8 @@ export interface components {
             papers?: components["schemas"]["_PaperMetadata"][] | null;
             /** Datasets */
             datasets?: components["schemas"]["_DatasetMetadata"][] | null;
+            /** Notebooks */
+            notebooks?: components["schemas"]["_NotebookMetadata"][] | null;
             /** Doi Is Draft */
             doi_is_draft?: boolean | null;
             /** Func Uuid */
@@ -1474,13 +1500,15 @@ export interface components {
             /** Entrypoint Aliases */
             entrypoint_aliases?: {
                 [key: string]: string;
-            };
+            } | null;
             /** Is Archived */
             is_archived?: boolean | null;
             /** Is Test */
             is_test?: boolean | null;
             /** Entrypoint Ids */
             entrypoint_ids?: string[] | null;
+            /** Modal Function Ids */
+            modal_function_ids?: number[] | null;
         };
         /** GardenSearchFacets */
         GardenSearchFacets: {
@@ -2372,6 +2400,20 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        /** _NotebookMetadata */
+        _NotebookMetadata: {
+            /** Title */
+            title: string;
+            /** Description */
+            description: string | null;
+            /**
+             * Url
+             * Format: uri
+             */
+            url: string;
+        } & {
+            [key: string]: unknown;
+        };
         /** _PaperMetadata */
         _PaperMetadata: {
             /** Title */
@@ -2400,22 +2442,6 @@ export interface components {
             url: string;
             /** Contributors */
             contributors?: string[];
-        } & {
-            [key: string]: unknown;
-        };
-        /** _NotebookMetadata */
-        _NotebookMetadata: {
-            /** Title */
-            title: string;
-            /** Description */
-            description?: string | null;
-            /**
-             * Url
-             * Format: uri
-             */
-            url: string;
-            /** Type */
-            type: "colab" | "jupyter";
         } & {
             [key: string]: unknown;
         };
@@ -3484,6 +3510,44 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ModalFunctionMetadataResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    get_modal_functions_modal_functions_get: {
+        parameters: {
+            query?: {
+                id?: number[] | null;
+                doi?: string[] | null;
+                tags?: string[] | null;
+                authors?: string[] | null;
+                owner_uuid?: string | null;
+                draft?: boolean | null;
+                year?: string | null;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ModalFunctionMetadataResponse"][];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
This will (mostly) close #233. Mostly looking for feedback/advice before I lose my mind sinking another day into this. 

## Overview

This allows users to link any of their existing modal functions to their gardens. This includes: 
  - when creating a garden, I can select modal functions other than the ones from my newly deployed app. 
  - when editing a garden in-place, there's a new "add function" button just like the "add dataset" etc buttons, which pops up a similar checklist to the one when creating the garden in the first place.
  - when editing a garden from the "edit garden" page, the modal functions checklist is a little different -- this one has all the garden's functions included but pre-checked. this way, we also have a way for users to remove functions they no longer want to include in their garden 
  
This does not include: 
  - a new flow for uploading a modal app directly to an existing garden 
  - the ability to add someone else's functions to your garden 

## Context 
this is probably my third or fourth pass at this and this is a good point to get feedback / stop the scope creep I've been struggling with for this one -- I think it's _minimally viable_ but I'm not feeling much better about it than I was for my earlier passes. 

