### PR TITLE
Show contributors in metadata sidebar on Garden and Function pages

### DIFF
--- a/garden/src/features/gardens/api/usePatchGarden.ts
+++ b/garden/src/features/gardens/api/usePatchGarden.ts
@@ -21,11 +21,41 @@ const patchGarden = async ({ doi, garden }: PatchGardenProps): Promise<Garden> =
 export const usePatchGarden = () => {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  return useMutation<Garden, Error, PatchGardenProps, unknown>({
+  return useMutation<Garden, Error, PatchGardenProps, { previousGarden: Garden | undefined }>({
     mutationFn: patchGarden,
+    onMutate: async ({ doi, garden }) => {
+      // Cancel any outgoing refetches
+      await queryClient.cancelQueries({ queryKey: ["garden", doi] });
+
+      // Snapshot the previous value
+      const previousGarden = queryClient.getQueryData<Garden>(["garden", doi]);
+
+      // Optimistically update to the new value
+      if (previousGarden) {
+        queryClient.setQueryData<Garden>(["garden", doi], {
+          ...previousGarden,
+          ...garden
+        });
+      }
+
+      return { previousGarden };
+    },
+    onError: (err, { doi }, context) => {
+      // If the mutation fails, use the context to roll back
+      if (context?.previousGarden) {
+        queryClient.setQueryData(["garden", doi], context.previousGarden);
+      }
+      toast.error("Failed to update garden");
+    },
     onSuccess: (data) => {
-      queryClient.setQueryData(["garden", data.doi], (oldData: Garden) => data);
-      navigate(`/garden/${encodeURIComponent(data.doi)}`);
+      // Update the cache with the new data
+      queryClient.setQueryData(["garden", data.doi], data);
+      
+      // Invalidate related queries
+      queryClient.invalidateQueries({ queryKey: ["garden", data.doi] });
+      queryClient.invalidateQueries({ queryKey: ["gardens"] });
+      queryClient.invalidateQueries({ queryKey: ["search"] });
+      
       toast.success("Garden updated successfully!");
     },
   });

--- a/garden/src/features/gardens/api/usePatchGarden.ts
+++ b/garden/src/features/gardens/api/usePatchGarden.ts
@@ -32,10 +32,27 @@ export const usePatchGarden = () => {
 
       // Optimistically update to the new value
       if (previousGarden) {
-        queryClient.setQueryData<Garden>(["garden", doi], {
+        // Handle arrays that might be null in the patch but can't be null in the Garden type
+        const updatedGarden = {
           ...previousGarden,
-          ...garden
-        });
+          // Keep required fields from previous garden
+          doi: previousGarden.doi,
+          owner_identity_id: previousGarden.owner_identity_id,
+          // Handle optional arrays that can't be null
+          authors: garden.authors ?? previousGarden.authors ?? [],
+          contributors: garden.contributors ?? previousGarden.contributors ?? [],
+          // Handle other fields from the patch
+          title: garden.title ?? previousGarden.title,
+          description: garden.description ?? previousGarden.description,
+          year: garden.year ?? previousGarden.year,
+          version: garden.version ?? previousGarden.version,
+          is_test: garden.is_test ?? previousGarden.is_test,
+          is_archived: garden.is_archived ?? previousGarden.is_archived,
+          doi_is_draft: garden.doi_is_draft ?? previousGarden.doi_is_draft,
+          tags: garden.tags ?? previousGarden.tags ?? [],
+        };
+
+        queryClient.setQueryData<Garden>(["garden", doi], updatedGarden);
       }
 
       return { previousGarden };

--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -369,6 +369,15 @@ const GardenContent = ({ garden, ownsThisGarden, isNewlyCreated, updateGarden }:
                 ownsThisGarden={ownsThisGarden}
                 isArray={true}
               />
+
+              <EditableMetadataField
+                label="Contributors"
+                value={garden.contributors}
+                fieldName="contributors"
+                garden={garden}
+                ownsThisGarden={ownsThisGarden}
+                isArray={true}
+              />
               
               <EditableMetadataField
                 label="Year"

--- a/garden/src/features/gardens/components/garden-page/EditableMetadataField.tsx
+++ b/garden/src/features/gardens/components/garden-page/EditableMetadataField.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { EditIcon, SaveIcon, XIcon, PlusIcon } from "lucide-react";
 import { Button } from "@/components/shadcn/button";
 import { Input } from "@/components/shadcn/input";
@@ -51,7 +51,12 @@ const EditableMetadataField = ({
   const [isEditing, setIsEditing] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [inputValue, setInputValue] = useState<string | string[]>(value || (isArray ? [] : ""));
-  const { mutate: updateGarden } = usePatchGarden();
+  const { mutateAsync: updateGarden } = usePatchGarden();
+  
+  // Update inputValue when value prop changes
+  useEffect(() => {
+    setInputValue(value || (isArray ? [] : ""));
+  }, [value, isArray]);
   
   // Create a displayable value for the field
   const displayValue = React.useMemo(() => {
@@ -86,7 +91,6 @@ const EditableMetadataField = ({
         garden: updateData
       });
       
-      toast.success(`${label} updated successfully`);
       setIsEditing(false);
       setIsSaving(false);
       if (onSave) onSave();
@@ -196,9 +200,19 @@ const EditableMetadataField = ({
           <Button 
             size="sm" 
             onClick={handleSave}
+            disabled={isSaving}
             className="h-7 text-xs bg-blue-600 hover:bg-blue-700"
           >
-            <SaveIcon className="h-3.5 w-3.5 mr-1" /> Save
+            {isSaving ? (
+              <>
+                <span className="mr-2">Saving...</span>
+                <span className="animate-spin">⌛</span>
+              </>
+            ) : (
+              <>
+                <SaveIcon className="h-3.5 w-3.5 mr-1" /> Save
+              </>
+            )}
           </Button>
         </div>
       </div>
@@ -209,7 +223,6 @@ const EditableMetadataField = ({
   return (
     <div
       className="group border border-transparent hover:border-gray-200 bg-white rounded-md py-1.5 px-2.5 transition-all hover:shadow-sm"
-      style={undefined}
     >
       <div className="flex justify-between items-center">
         <p className="text-sm text-gray-500 font-medium">

--- a/garden/src/features/modal/components/ModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/ModalFunctionPage.tsx
@@ -319,6 +319,16 @@ const ModalFunctionPage = () => {
               ownsThisFunction={ownsThisFunction}
               isArray={true}
             />
+
+            <EditableMetadataField
+              label="Contributors"
+              value={modalFunction.contributors}
+              fieldName="contrubutors"
+              modalFunction={modalFunction}
+              ownsThisFunction={ownsThisFunction}
+              isArray={true}
+            />
+
             <EditableMetadataField
               label="Year"
               value={modalFunction.year}

--- a/garden/src/features/modal/components/ModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/ModalFunctionPage.tsx
@@ -322,8 +322,8 @@ const ModalFunctionPage = () => {
 
             <EditableMetadataField
               label="Contributors"
-              value={modalFunction.contributors}
-              fieldName="contrubutors"
+              value={modalFunction.contributors ?? []}
+              fieldName="contributors"
               modalFunction={modalFunction}
               ownsThisFunction={ownsThisFunction}
               isArray={true}

--- a/garden/src/types/index.ts
+++ b/garden/src/types/index.ts
@@ -16,9 +16,12 @@ type BaseModalFunction = components["schemas"]["ModalFunctionMetadataResponse"];
 // Extended interface for UI-specific properties
 interface ModalFunction extends BaseModalFunction {
   already_has_material?: boolean;
+  contributors?: string[];
 }
 
-type ModalFunctionPatchRequest = components["schemas"]["ModalFunctionPatchRequest"];
+type ModalFunctionPatchRequest = components["schemas"]["ModalFunctionPatchRequest"] & {
+  contributors?: string[] | null;
+};
 
 type AsyncModalAppMetadataResponse = components["schemas"]["AsyncModalAppMetadataResponse"];
 type AsyncModalJobStatus = components["schemas"]["AsyncModalJobStatus"];


### PR DESCRIPTION
This PR adds the contributors field to the Garden and Function pages. Editable in-place like the other metadata fields.

<img width="402" alt="image" src="https://github.com/user-attachments/assets/3f39aa0b-b41b-418f-8fd7-98e3f6402201" />
