### PR TITLE
Another batch of style tweaks/fixes

### DIFF
--- a/garden/src/components/EditableCodeField.tsx
+++ b/garden/src/components/EditableCodeField.tsx
@@ -5,7 +5,7 @@ import { python } from '@codemirror/lang-python';
 import { defaultKeymap, indentWithTab } from '@codemirror/commands';
 import { syntaxHighlighting, defaultHighlightStyle } from '@codemirror/language';
 import { Button } from './shadcn/button';
-import { XIcon, CheckIcon, PencilIcon, Loader2Icon } from 'lucide-react';
+import { XIcon, CheckIcon, PencilIcon, Loader2Icon, EditIcon } from 'lucide-react';
 import CopyButton from './CopyButton';
 import SyntaxHighlighter from './SyntaxHighlighter';
 
@@ -125,9 +125,8 @@ export const EditableCodeField = ({
                 variant="ghost"
                 size="icon"
                 onClick={() => setIsEditing(true)}
-                className="h-6 w-6 opacity-0 group-hover:opacity-100 transition-opacity"
-              >
-                <PencilIcon className="h-3 w-3" />
+                className="h-6 w-6">
+                <EditIcon className="text-green hover:text-dark-green h-3.5 w-3.5" />
               </Button>
             )}
           </div>

--- a/garden/src/components/shared/metadata/EditableMetadataField.tsx
+++ b/garden/src/components/shared/metadata/EditableMetadataField.tsx
@@ -185,7 +185,7 @@ const EditableMetadataField = ({
             <TooltipProvider delayDuration={50}>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <InfoIcon className="text-gray-500 opacity-0 group-hover:opacity-100 transition-opacity m-1.5 h-3 w-3" />
+                  <InfoIcon className="text-gray-500 m-1.5 h-3 w-3" />
                 </TooltipTrigger>
                 <TooltipContent className="p-2">
                   {helpText}
@@ -200,7 +200,7 @@ const EditableMetadataField = ({
               <TooltipTrigger asChild>
                 <button
                   onClick={() => setIsEditing(true)}
-                  className="opacity-0 group-hover:opacity-100 transition-opacity text-green hover:text-darkgreen"
+                  className="text-green hover:text-darkgreen"
                   aria-label={`Edit ${label.toLowerCase()}`}
                 >
                   <EditIcon className="h-3.5 w-3.5" />

--- a/garden/src/features/gardens/components/GardenMetadataSidebar.tsx
+++ b/garden/src/features/gardens/components/GardenMetadataSidebar.tsx
@@ -1,0 +1,110 @@
+import CopyButton from "@/components/CopyButton";
+import { ClipboardIcon, } from "lucide-react";
+import { Garden } from "@/types";
+import { usePatchGarden } from "../api/usePatchGarden";
+import { Metadata, EditableMetadataField } from "@/components/shared/metadata";
+import { CitationBlock } from "./garden-page";
+
+export const GardenMetadataSidebar = ({garden, ownsThisGarden}: {garden: Garden, ownsThisGarden: boolean}) => {
+    const { mutate: patchGarden } = usePatchGarden();
+    const updateGarden = async (updateData: Partial<Garden>) => {
+        await patchGarden({
+            doi: garden.doi,
+            garden: updateData
+        });
+    };
+
+    return (
+        <Metadata entity={garden} ownsThisEntity={ownsThisGarden}>
+            {/* DOI Field */}
+            <div className="group border border-transparent bg-white rounded-md py-1.5 px-2.5 shadow-sm">
+                <div className="flex items-center justify-between">
+                    <p className="text-sm text-gray-500 font-medium">
+                        DOI
+                    </p>
+                    <CopyButton
+                        content={garden.doi}
+                        hint="Copy DOI"
+                        className="ml-2"
+                        icon={<ClipboardIcon className="h-4 w-4" />}
+                    />
+                </div>
+                <div className="mt-0.5">
+                    <p className="font-medium font-mono text-gray-800 overflow-hidden overflow-ellipsis">
+                        {garden.doi}
+                    </p>
+                </div>
+            </div>
+
+            <EditableMetadataField
+                label="Model Authors"
+                helpText="Original authors of the models in this Garden"
+                value={garden.authors}
+                fieldName="authors"
+                entity={garden}
+                ownsThisEntity={ownsThisGarden}
+                isArray={true}
+                onUpdate={updateGarden}
+            />
+
+            <EditableMetadataField
+                label="Gardeners"
+                helpText="Creator and contributors to this Garden"
+                value={[garden.owner, ...(garden.contributors || [])]}
+                fieldName="contributors"
+                entity={garden}
+                ownsThisEntity={ownsThisGarden}
+                isArray={true}
+                onUpdate={updateGarden}
+            />
+
+            <EditableMetadataField
+                label="Year"
+                helpText="Year this Garden was created"
+                value={garden.year}
+                fieldName="year"
+                entity={garden}
+                ownsThisEntity={ownsThisGarden}
+                onUpdate={updateGarden}
+            />
+
+            <EditableMetadataField
+                label="Version"
+                helpText="Garden version"
+                value={garden.version}
+                fieldName="version"
+                entity={garden}
+                ownsThisEntity={ownsThisGarden}
+                onUpdate={updateGarden}
+            />
+
+            <EditableMetadataField
+                label="Tags"
+                helpText="Tags help users discover this Garden"
+                value={garden.tags}
+                fieldName="tags"
+                entity={garden}
+                ownsThisEntity={ownsThisGarden}
+                isArray={true}
+                onUpdate={updateGarden}
+            />
+
+            {/* Citation */}
+            <div className="mt-4 bg-white rounded-md p-3 shadow-sm">
+                <div className="flex items-center justify-between">
+                    <p className="text-sm text-gray-500 font-medium">Cite this Garden</p>
+                    <CopyButton
+                        content={`@software{
+  title = {${garden.title}},
+  year = {${garden.year || 'n.d.'}},
+  publisher = {Garden AI},
+  doi = {${garden.doi}}
+}`}
+                        hint="Copy Citation"
+                        icon={<ClipboardIcon className="h-4 w-4" />}
+                    />
+                </div>
+                <CitationBlock garden={garden} />
+            </div>
+        </Metadata>)
+};

--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -1,13 +1,6 @@
 import { useParams, useSearchParams } from "react-router-dom";
-import { Card, CardContent } from "@/components/shadcn/card";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/shadcn/tabs";
-import { DatabaseIcon, BookIcon, ClipboardIcon, CodeIcon, FunctionSquare, ScrollTextIcon } from "lucide-react";
-import { useCallback } from 'react';
 
 import Breadcrumb from "@/components/Breadcrumb";
-import CopyButton from "@/components/CopyButton";
-import EntrypointBox from "./EntrypointBox";
-import ModalFunctionBox from "./ModalFunctionBox";
 import GardenDropdownOptions from "@/features/gardens/components/GardenDropdownOptions";
 import { LoadingOverlay } from "@/components/LoadingOverlay";
 import NotFoundPage from "@/components/NotFoundPage";
@@ -19,25 +12,18 @@ import { usePatchGarden } from "../api/usePatchGarden";
 import { useGlobusAuth } from "@globus/react-auth-context";
 
 import { MaterialsProvider } from '@/features/materials/contexts/MaterialsContext';
-import { useDatasetManagement, usePaperManagement, useRepositoryManagement, useNotebookManagement } from '@/features/materials/hooks/useMaterialManagement';
 
 import { Garden } from "@/types";
 
 import {
   GardenDescription,
-  CitationBlock,
   VisibilityWarning,
   EditableTitle,
   ReviewNotice,
-  AddMaterialWithFunctionSelect,
-  AddModalFunctionSelector,
-  DatasetCard,
-  PaperCard,
-  RepositoryCard,
-  NotebookCard
 } from "./garden-page";
+import { GardenTabbedSection } from "./GardenTabbedSection";
+import { GardenMetadataSidebar } from "./GardenMetadataSidebar";
 
-import { Metadata, EditableMetadataField } from "@/components/shared/metadata";
 
 interface GardenContentProps {
   garden: Garden;
@@ -46,34 +32,7 @@ interface GardenContentProps {
 }
 
 const GardenContent = ({ garden, ownsThisGarden, isNewlyCreated }: GardenContentProps) => {
-  const { materials: datasets, refreshMaterials: refreshDatasets, findFunctionsWithMaterial: findDatasetFunctions } = useDatasetManagement(garden);
-  const { materials: papers, refreshMaterials: refreshPapers, findFunctionsWithMaterial: findPaperFunctions } = usePaperManagement(garden);
-  const { materials: repositories, refreshMaterials: refreshRepositories, findFunctionsWithMaterial: findRepositoryFunctions } = useRepositoryManagement(garden);
-  const { materials: notebooks, refreshMaterials: refreshNotebooks, findFunctionsWithMaterial: findNotebookFunctions } = useNotebookManagement(garden);
   const { mutateAsync: patchGarden } = usePatchGarden();
-
-  // Callback to refresh all materials after adding/updating/removing
-  const handleMaterialsChange = useCallback(async () => {
-    await Promise.all([
-      refreshDatasets(),
-      refreshPapers(),
-      refreshRepositories(),
-      refreshNotebooks()
-    ]);
-  }, [refreshDatasets, refreshPapers, refreshRepositories, refreshNotebooks]);
-
-  const handleMaterialAdded = useCallback(async () => {
-    await handleMaterialsChange();
-  }, [handleMaterialsChange]);
-
-  const handleMaterialUpdated = useCallback(async () => {
-    await handleMaterialsChange();
-  }, [handleMaterialsChange]);
-
-  const handleMaterialRemoved = useCallback(async () => {
-    await handleMaterialsChange();
-  }, [handleMaterialsChange]);
-
   return (
     <div className="container max-w-7xl">
       <div className="mt-2 mb-4">
@@ -107,364 +66,28 @@ const GardenContent = ({ garden, ownsThisGarden, isNewlyCreated }: GardenContent
               </div>
             </div>
 
-            {/* Description with Markdown */}
             <GardenDescription garden={garden} />
 
-            {/* Functions, Datasets, Papers, and Notebooks tabs */}
-            <div className="mt-6">
-              <Tabs
-                defaultValue={
-                  garden.modal_functions?.length ? "functions" :
-                    datasets.length ? "datasets" :
-                      papers.length ? "papers" :
-                        notebooks.length ? "notebooks" :
-                          "functions"
-                }
-                className="w-full"
-              >
-                <TabsList className="mb-2 bg-gray-100 p-0.5">
-                  <TabsTrigger value="functions" className="data-[state=active]:bg-white data-[state=active]:shadow-sm">
-                    Functions {((garden.entrypoints?.length || 0) + (garden.modal_functions?.length || 0)) > 0 &&
-                      `(${(garden.entrypoints?.length || 0) + (garden.modal_functions?.length || 0)})`}
-                  </TabsTrigger>
-                  <TabsTrigger value="datasets" className="data-[state=active]:bg-white data-[state=active]:shadow-sm">
-                    Datasets {datasets.length > 0 && `(${datasets.length})`}
-                  </TabsTrigger>
-                  <TabsTrigger value="papers" className="data-[state=active]:bg-white data-[state=active]:shadow-sm">
-                    Papers {papers.length > 0 && `(${papers.length})`}
-                  </TabsTrigger>
-                  <TabsTrigger value="repositories" className="data-[state=active]:bg-white data-[state=active]:shadow-sm">
-                    Repositories {repositories.length > 0 && `(${repositories.length})`}
-                  </TabsTrigger>
-                  <TabsTrigger value="notebooks" className="data-[state=active]:bg-white data-[state=active]:shadow-sm">
-                    Notebooks {notebooks.length > 0 && `(${notebooks.length})`}
-                  </TabsTrigger>
-                </TabsList>
-
-                <TabsContent value="functions" className="mt-0 relative">
-                  <Card className="border-0 shadow-none bg-transparent">
-                    <CardContent className="pt-6">
-                      <div>
-                        <div className="flex items-center justify-between mb-3">
-                          <h3 className="text-lg font-medium flex items-center">
-                            <FunctionSquare className="h-5 w-5 mr-2 text-green" />
-                            Functions
-                          </h3>
-                          
-                          {ownsThisGarden && (
-                            <AddModalFunctionSelector
-                              garden={garden}
-                              onSuccess={handleMaterialAdded}
-                            />
-                          )}
-                        </div>
-                        
-                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                          {garden.entrypoints?.map((entrypoint, index) => (
-                            <EntrypointBox
-                              key={index}
-                              entrypoint={entrypoint}
-                            />
-                          ))}
-                          {garden.modal_functions?.map((modalFunction, index) => (
-                            <ModalFunctionBox
-                              key={index}
-                              modalFunction={modalFunction}
-                              gardenDoi={garden.doi}
-                            />
-                          ))}
-                        </div>
-                      </div>
-                    </CardContent>
-                  </Card>
-                </TabsContent>
-
-                <TabsContent value="datasets" className="mt-0 relative">
-                  <Card className="border-0 shadow-none bg-transparent">
-                    <CardContent className="pt-6">
-                      <div>
-                        <div className="flex items-center justify-between mb-3">
-                          <h3 className="text-lg font-medium flex items-center">
-                            <DatabaseIcon className="h-5 w-5 mr-2 text-green" />
-                            Datasets
-                          </h3>
-
-                          {ownsThisGarden && (garden.modal_functions?.length ?? 0) > 0 && (
-                            <AddMaterialWithFunctionSelect
-                              garden={garden}
-                              materialType="datasets"
-                              onSuccess={handleMaterialAdded}
-                            />
-                          )}
-                        </div>
-
-                        {datasets.length > 0 ? (
-                          <div className="grid grid-cols-1 gap-8 py-2">
-                            {datasets.map((dataset) => (
-                              <DatasetCard
-                                key={dataset.doi}
-                                dataset={dataset}
-                                isOwner={ownsThisGarden}
-                                garden={garden}
-                                findAffectedFunctions={findDatasetFunctions}
-                                onUpdate={handleMaterialUpdated}
-                              />
-                            ))}
-                          </div>
-                        ) : (
-                          <p className="text-gray-500 italic">No datasets associated with the functions in this garden</p>
-                        )}
-                      </div>
-                    </CardContent>
-                  </Card>
-                </TabsContent>
-
-                <TabsContent value="papers" className="mt-0 relative">
-                  <Card className="border-0 shadow-none bg-transparent">
-                    <CardContent className="pt-6">
-                      <div>
-                        <div className="flex items-center justify-between mb-3">
-                          <h3 className="text-lg font-medium flex items-center">
-                            <BookIcon className="h-5 w-5 mr-2 text-green" />
-                            Papers
-                          </h3>
-
-                          {ownsThisGarden && (garden.modal_functions?.length ?? 0) > 0 && (
-                            <AddMaterialWithFunctionSelect
-                              garden={garden}
-                              materialType="papers"
-                              onSuccess={handleMaterialAdded}
-                            />
-                          )}
-                        </div>
-
-                        {papers.length > 0 ? (
-                          <div className="grid grid-cols-1 gap-8 py-2">
-                            {papers.map((paper) => (
-                              <PaperCard
-                                key={paper.doi || paper.title}
-                                paper={paper}
-                                isOwner={ownsThisGarden}
-                                garden={garden}
-                                findAffectedFunctions={findPaperFunctions}
-                                onUpdate={handleMaterialUpdated}
-                              />
-                            ))}
-                          </div>
-                        ) : (
-                          <p className="text-gray-500 italic">No papers associated with the functions in this garden</p>
-                        )}
-                      </div>
-                    </CardContent>
-                  </Card>
-                </TabsContent>
-
-                <TabsContent value="repositories" className="mt-0 relative">
-                  <Card className="border-0 shadow-none bg-transparent">
-                    <CardContent className="pt-6">
-                      <div>
-                        <div className="flex items-center justify-between mb-3">
-                          <h3 className="text-lg font-medium flex items-center">
-                            <CodeIcon className="h-5 w-5 mr-2 text-green" />
-                            Code Repositories
-                          </h3>
-
-                          {ownsThisGarden && (garden.modal_functions?.length ?? 0) > 0 && (
-                            <AddMaterialWithFunctionSelect
-                              garden={garden}
-                              materialType="repositories"
-                              onSuccess={handleMaterialAdded}
-                            />
-                          )}
-                        </div>
-
-                        {repositories.length > 0 ? (
-                          <div className="grid grid-cols-1 gap-8 py-2">
-                            {repositories.map((repo) => (
-                              <RepositoryCard
-                                key={repo.url}
-                                repository={repo}
-                                isOwner={ownsThisGarden}
-                                garden={garden}
-                                findAffectedFunctions={findRepositoryFunctions}
-                                onUpdate={handleMaterialUpdated}
-                              />
-                            ))}
-                          </div>
-                        ) : (
-                          <p className="text-gray-500 italic">No repositories associated with the functions in this garden</p>
-                        )}
-                      </div>
-                    </CardContent>
-                  </Card>
-                </TabsContent>
-
-                <TabsContent value="notebooks" className="mt-0 relative">
-                  <Card className="border-0 shadow-none bg-transparent">
-                    <CardContent className="pt-6">
-                      <div>
-                        <div className="flex items-center justify-between mb-3">
-                          <h3 className="text-lg font-medium flex items-center">
-                            <ScrollTextIcon className="h-5 w-5 mr-2 text-green" />
-                            Notebooks
-                          </h3>
-
-                          {ownsThisGarden && (garden.modal_functions?.length ?? 0) > 0 && (
-                            <AddMaterialWithFunctionSelect
-                              garden={garden}
-                              materialType="notebooks"
-                              onSuccess={handleMaterialAdded}
-                            />
-                          )}
-                        </div>
-
-                        {notebooks.length > 0 ? (
-                          <div className="grid grid-cols-1 gap-8 py-2">
-                            {notebooks.map((notebook) => (
-                              <NotebookCard
-                                key={notebook.url}
-                                notebook={notebook}
-                                isOwner={ownsThisGarden}
-                                garden={garden}
-                                findAffectedFunctions={findNotebookFunctions}
-                                onUpdate={handleMaterialUpdated}
-                              />
-                            ))}
-                          </div>
-                        ) : (
-                          <p className="text-gray-500 italic">No notebooks associated with the functions in this garden</p>
-                        )}
-                      </div>
-                    </CardContent>
-                  </Card>
-                </TabsContent>
-              </Tabs>
+            {/* Tabbed Section */}
+            <div className="mt-4">
+              <GardenTabbedSection 
+                garden={garden}
+                ownsThisGarden={ownsThisGarden}
+              />
             </div>
+
+            {/* Metadata Details */}
+            <GardenMetadataSidebar 
+              garden={garden}
+              ownsThisGarden={ownsThisGarden}
+            />
           </div>
-
-          {/* Metadata Details */}
-          <Metadata entity={garden} ownsThisEntity={ownsThisGarden}>
-            {/* DOI Field */}
-            <div className="group border border-transparent bg-white rounded-md py-1.5 px-2.5 shadow-sm">
-              <div className="flex items-center justify-between">
-                <p className="text-sm text-gray-500 font-medium">
-                  DOI
-                </p>
-                <CopyButton
-                  content={garden.doi}
-                  hint="Copy DOI"
-                  className="ml-2"
-                  icon={<ClipboardIcon className="h-4 w-4" />}
-                />
-              </div>
-              <div className="mt-0.5">
-                <p className="font-medium font-mono text-gray-800 overflow-hidden overflow-ellipsis">
-                  {garden.doi}
-                </p>
-              </div>
-            </div>
-
-            <EditableMetadataField
-              label="Model Authors"
-              helpText="Orginial authors of the models in this Garden"
-              value={garden.authors}
-              fieldName="authors"
-              entity={garden}
-              ownsThisEntity={ownsThisGarden}
-              isArray={true}
-              onUpdate={async (updateData) => {
-                await patchGarden({
-                  doi: garden.doi,
-                  garden: updateData
-                });
-              }}
-            />
-
-            <EditableMetadataField
-              label="Gardeners"
-              helpText="Creator and contributors to this Garden"
-              value={[garden.owner, ...(garden.contributors || [])]}
-              fieldName="contributors"
-              entity={garden}
-              ownsThisEntity={ownsThisGarden}
-              isArray={true}
-              onUpdate={async (updateData) => {
-                await patchGarden({
-                  doi: garden.doi,
-                  garden: updateData
-                });
-              }}
-            />
-
-            <EditableMetadataField
-              label="Year"
-              helpText="Year this Garden was created"
-              value={garden.year}
-              fieldName="year"
-              entity={garden}
-              ownsThisEntity={ownsThisGarden}
-              onUpdate={async (updateData) => {
-                await patchGarden({
-                  doi: garden.doi,
-                  garden: updateData
-                });
-              }}
-            />
-
-            <EditableMetadataField
-              label="Version"
-              helpText="Garden version"
-              value={garden.version}
-              fieldName="version"
-              entity={garden}
-              ownsThisEntity={ownsThisGarden}
-              onUpdate={async (updateData) => {
-                await patchGarden({
-                  doi: garden.doi,
-                  garden: updateData
-                });
-              }}
-            />
-
-            <EditableMetadataField
-              label="Tags"
-              helpText="Tags help users discover this Garden"
-              value={garden.tags}
-              fieldName="tags"
-              entity={garden}
-              ownsThisEntity={ownsThisGarden}
-              isArray={true}
-              onUpdate={async (updateData) => {
-                await patchGarden({
-                  doi: garden.doi,
-                  garden: updateData
-                });
-              }}
-            />
-
-            {/* Citation */}
-            <div className="mt-4 bg-white rounded-md p-3 shadow-sm">
-              <div className="flex items-center justify-between">
-                <p className="text-sm text-gray-500 font-medium">Cite this Garden</p>
-                <CopyButton
-                  content={`@software{
-  title = {${garden.title}},
-  year = {${garden.year || 'n.d.'}},
-  publisher = {Garden AI},
-  doi = {${garden.doi}}
-}`}
-                  hint="Copy Citation"
-                  icon={<ClipboardIcon className="h-4 w-4" />}
-                />
-              </div>
-              <CitationBlock garden={garden} />
-            </div>
-          </Metadata>
         </div>
       </div>
-    </div>
-  );
+      </div>
+      );
 };
+
 
 const GardenPage = () => {
   const { doi } = useParams();

--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -55,7 +55,7 @@ const GardenContent = ({ garden, ownsThisGarden, isNewlyCreated }: GardenContent
 
       {/* Hero Metadata Section */}
       <div className="bg-gradient-to-b from-white to-gray-50 rounded-lg shadow-md border border-gray-100 p-6 mb-6">
-        <div className="flex flex-col-reverse lg:flex-row gap-6">
+        <div className="flex flex-col lg:flex-row gap-6">
           {/* Title, Description & Core Metadata */}
           <div className="lg:w-2/3">
             <div className="flex justify-between items-start mb-4">
@@ -76,12 +76,12 @@ const GardenContent = ({ garden, ownsThisGarden, isNewlyCreated }: GardenContent
               />
             </div>
 
+          </div>
             {/* Metadata Details */}
             <GardenMetadataSidebar 
               garden={garden}
               ownsThisGarden={ownsThisGarden}
             />
-          </div>
         </div>
       </div>
       </div>

--- a/garden/src/features/gardens/components/GardenTabbedSection.tsx
+++ b/garden/src/features/gardens/components/GardenTabbedSection.tsx
@@ -1,0 +1,310 @@
+import { useCallback } from "react";
+import { Card, CardContent } from "@/components/shadcn/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/shadcn/tabs";
+import { DatabaseIcon, BookIcon, CodeIcon, FunctionSquare, ScrollTextIcon, LucideIcon } from "lucide-react";
+import { Garden } from "@/types";
+import EntrypointBox from "./EntrypointBox";
+import ModalFunctionBox from "./ModalFunctionBox";
+import { useDatasetManagement, usePaperManagement, useRepositoryManagement, useNotebookManagement } from '@/features/materials/hooks/useMaterialManagement';
+import {
+    AddMaterialWithFunctionSelect,
+    AddModalFunctionSelector,
+    DatasetCard,
+    PaperCard,
+    RepositoryCard,
+    NotebookCard
+} from "./garden-page";
+
+
+const TabTrigger = ({ icon: Icon, garden, name, value }: { icon: LucideIcon, garden: Garden, name: string, value: string }) => {
+    return (
+        <TabsTrigger
+            value={value}
+            className="data-[state=active]:bg-white data-[state=active]:shadow-sm text-sm"
+        >
+            <div className="flex items-center justify-center">
+                <Icon className="h-4 w-4" />
+                <span className="hidden lg:block ml-1.5">{name}</span>
+                {((garden.entrypoints?.length || 0) + (garden.modal_functions?.length || 0)) > 0 && (
+                    <span className="hidden sm:inline ml-1">
+                        ({(garden.entrypoints?.length || 0) + (garden.modal_functions?.length || 0)})
+                    </span>
+                )}
+            </div>
+        </TabsTrigger>
+    );
+};
+
+
+export const GardenTabbedSection = ({ garden, ownsThisGarden }: { garden: Garden, ownsThisGarden: boolean }) => {
+    const { materials: datasets, refreshMaterials: refreshDatasets, findFunctionsWithMaterial: findDatasetFunctions } = useDatasetManagement(garden);
+    const { materials: papers, refreshMaterials: refreshPapers, findFunctionsWithMaterial: findPaperFunctions } = usePaperManagement(garden);
+    const { materials: repositories, refreshMaterials: refreshRepositories, findFunctionsWithMaterial: findRepositoryFunctions } = useRepositoryManagement(garden);
+    const { materials: notebooks, refreshMaterials: refreshNotebooks, findFunctionsWithMaterial: findNotebookFunctions } = useNotebookManagement(garden);
+
+    // Callback to refresh all materials after adding/updating/removing
+    const handleMaterialsChange = useCallback(async () => {
+        await Promise.all([
+            refreshDatasets(),
+            refreshPapers(),
+            refreshRepositories(),
+            refreshNotebooks()
+        ]);
+    }, [refreshDatasets, refreshPapers, refreshRepositories, refreshNotebooks]);
+
+    const handleMaterialAdded = useCallback(async () => {
+        await handleMaterialsChange();
+    }, [handleMaterialsChange]);
+
+    const handleMaterialUpdated = useCallback(async () => {
+        await handleMaterialsChange();
+    }, [handleMaterialsChange]);
+
+    const handleMaterialRemoved = useCallback(async () => {
+        await handleMaterialsChange();
+    }, [handleMaterialsChange]);
+
+    return (
+        <Tabs
+            defaultValue={
+                garden.modal_functions?.length ? "functions" :
+                    datasets.length ? "datasets" :
+                        papers.length ? "papers" :
+                            notebooks.length ? "notebooks" :
+                                "functions"
+            }
+            className="flex flex-col w-full"
+        >
+            <TabsList className="bg-gray-200 flex flex-row justify-around">
+                <TabTrigger
+                    icon={FunctionSquare}
+                    garden={garden}
+                    name="Functions"
+                    value="functions"
+                />
+                <TabTrigger
+                    icon={DatabaseIcon}
+                    garden={garden}
+                    name="Datasets"
+                    value="datasets"
+                />
+                <TabTrigger
+                    icon={ScrollTextIcon}
+                    garden={garden}
+                    name="Papers"
+                    value="papers"
+                />
+                <TabTrigger
+                    icon={CodeIcon}
+                    garden={garden}
+                    name="Repos"
+                    value="repositories"
+                />
+                <TabTrigger
+                    icon={BookIcon}
+                    garden={garden}
+                    name="Notebooks"
+                    value="notebooks"
+                />
+            </TabsList>
+
+            <TabsContent value="functions" className="mt-0 relative">
+                <Card className="border-0 shadow-none bg-transparent">
+                    <CardContent className="pt-6">
+                        <div>
+                            <div className="flex items-center justify-between mb-3">
+                                <h3 className="text-lg font-medium flex items-center">
+                                    <FunctionSquare className="h-5 w-5 mr-2 text-green" />
+                                    Functions
+                                </h3>
+
+                                {ownsThisGarden && (
+                                    <AddModalFunctionSelector
+                                        garden={garden}
+                                        onSuccess={handleMaterialAdded}
+                                    />
+                                )}
+                            </div>
+
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                {garden.entrypoints?.map((entrypoint, index) => (
+                                    <EntrypointBox
+                                        key={index}
+                                        entrypoint={entrypoint}
+                                    />
+                                ))}
+                                {garden.modal_functions?.map((modalFunction, index) => (
+                                    <ModalFunctionBox
+                                        key={index}
+                                        modalFunction={modalFunction}
+                                        gardenDoi={garden.doi}
+                                    />
+                                ))}
+                            </div>
+                        </div>
+                    </CardContent>
+                </Card>
+            </TabsContent>
+
+            <TabsContent value="datasets" className="mt-0 relative">
+                <Card className="border-0 shadow-none bg-transparent">
+                    <CardContent className="pt-6">
+                        <div>
+                            <div className="flex items-center justify-between mb-3">
+                                <h3 className="text-lg font-medium flex items-center">
+                                    <DatabaseIcon className="h-5 w-5 mr-2 text-green" />
+                                    Datasets
+                                </h3>
+
+                                {ownsThisGarden && (garden.modal_functions?.length ?? 0) > 0 && (
+                                    <AddMaterialWithFunctionSelect
+                                        garden={garden}
+                                        materialType="datasets"
+                                        onSuccess={handleMaterialAdded}
+                                    />
+                                )}
+                            </div>
+
+                            {datasets.length > 0 ? (
+                                <div className="grid grid-cols-1 gap-8 py-2">
+                                    {datasets.map((dataset) => (
+                                        <DatasetCard
+                                            key={dataset.doi}
+                                            dataset={dataset}
+                                            isOwner={ownsThisGarden}
+                                            garden={garden}
+                                            findAffectedFunctions={findDatasetFunctions}
+                                            onUpdate={handleMaterialUpdated}
+                                        />
+                                    ))}
+                                </div>
+                            ) : (
+                                <p className="text-gray-500 italic">No datasets associated with the functions in this garden</p>
+                            )}
+                        </div>
+                    </CardContent>
+                </Card>
+            </TabsContent>
+
+            <TabsContent value="papers" className="mt-0 relative">
+                <Card className="border-0 shadow-none bg-transparent">
+                    <CardContent className="pt-6">
+                        <div>
+                            <div className="flex items-center justify-between mb-3">
+                                <h3 className="text-lg font-medium flex items-center">
+                                    <BookIcon className="h-5 w-5 mr-2 text-green" />
+                                    Papers
+                                </h3>
+
+                                {ownsThisGarden && (garden.modal_functions?.length ?? 0) > 0 && (
+                                    <AddMaterialWithFunctionSelect
+                                        garden={garden}
+                                        materialType="papers"
+                                        onSuccess={handleMaterialAdded}
+                                    />
+                                )}
+                            </div>
+
+                            {papers.length > 0 ? (
+                                <div className="grid grid-cols-1 gap-8 py-2">
+                                    {papers.map((paper) => (
+                                        <PaperCard
+                                            key={paper.doi || paper.title}
+                                            paper={paper}
+                                            isOwner={ownsThisGarden}
+                                            garden={garden}
+                                            findAffectedFunctions={findPaperFunctions}
+                                            onUpdate={handleMaterialUpdated}
+                                        />
+                                    ))}
+                                </div>
+                            ) : (
+                                <p className="text-gray-500 italic">No papers associated with the functions in this garden</p>
+                            )}
+                        </div>
+                    </CardContent>
+                </Card>
+            </TabsContent>
+
+            <TabsContent value="repositories" className="mt-0 relative">
+                <Card className="border-0 shadow-none bg-transparent">
+                    <CardContent className="pt-6">
+                        <div>
+                            <div className="flex items-center justify-between mb-3">
+                                <h3 className="text-lg font-medium flex items-center">
+                                    <CodeIcon className="h-5 w-5 mr-2 text-green" />
+                                    Code Repositories
+                                </h3>
+
+                                {ownsThisGarden && (garden.modal_functions?.length ?? 0) > 0 && (
+                                    <AddMaterialWithFunctionSelect
+                                        garden={garden}
+                                        materialType="repositories"
+                                        onSuccess={handleMaterialAdded}
+                                    />
+                                )}
+                            </div>
+
+                            {repositories.length > 0 ? (
+                                <div className="grid grid-cols-1 gap-8 py-2">
+                                    {repositories.map((repo) => (
+                                        <RepositoryCard
+                                            key={repo.url}
+                                            repository={repo}
+                                            isOwner={ownsThisGarden}
+                                            garden={garden}
+                                            findAffectedFunctions={findRepositoryFunctions}
+                                            onUpdate={handleMaterialUpdated}
+                                        />
+                                    ))}
+                                </div>
+                            ) : (
+                                <p className="text-gray-500 italic">No repositories associated with the functions in this garden</p>
+                            )}
+                        </div>
+                    </CardContent>
+                </Card>
+            </TabsContent>
+
+            <TabsContent value="notebooks" className="mt-0 relative">
+                <Card className="border-0 shadow-none bg-transparent">
+                    <CardContent className="pt-6">
+                        <div>
+                            <div className="flex items-center justify-between mb-3">
+                                <h3 className="text-lg font-medium flex items-center">
+                                    <ScrollTextIcon className="h-5 w-5 mr-2 text-green" />
+                                    Notebooks
+                                </h3>
+
+                                {ownsThisGarden && (garden.modal_functions?.length ?? 0) > 0 && (
+                                    <AddMaterialWithFunctionSelect
+                                        garden={garden}
+                                        materialType="notebooks"
+                                        onSuccess={handleMaterialAdded}
+                                    />
+                                )}
+                            </div>
+
+                            {notebooks.length > 0 ? (
+                                <div className="grid grid-cols-1 gap-8 py-2">
+                                    {notebooks.map((notebook) => (
+                                        <NotebookCard
+                                            key={notebook.url}
+                                            notebook={notebook}
+                                            isOwner={ownsThisGarden}
+                                            garden={garden}
+                                            findAffectedFunctions={findNotebookFunctions}
+                                            onUpdate={handleMaterialUpdated}
+                                        />
+                                    ))}
+                                </div>
+                            ) : (
+                                <p className="text-gray-500 italic">No notebooks associated with the functions in this garden</p>
+                            )}
+                        </div>
+                    </CardContent>
+                </Card>
+            </TabsContent>
+        </Tabs>
+    );
+}

--- a/garden/src/features/materials/components/ModalAssociatedMaterials.tsx
+++ b/garden/src/features/materials/components/ModalAssociatedMaterials.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { ModalFunction, Dataset, Paper, Repository, Notebook } from "@/types";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/shadcn/tabs";
 import { Card, CardContent, CardHeader, CardTitle, MarkdownCardContent } from "@/components/shadcn/card";

--- a/garden/src/features/materials/components/ModalAssociatedMaterials.tsx
+++ b/garden/src/features/materials/components/ModalAssociatedMaterials.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { ModalFunction, Dataset, Paper, Repository, Notebook } from "@/types";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/shadcn/tabs";
 import { Card, CardContent, CardHeader, CardTitle, MarkdownCardContent } from "@/components/shadcn/card";
-import { DatabaseIcon, BookIcon, CodeIcon, ScrollTextIcon, FileTextIcon, AppWindowIcon, PlusCircle } from "lucide-react";
+import { DatabaseIcon, BookIcon, CodeIcon, ScrollTextIcon, FileTextIcon, AppWindowIcon, PlusCircle, LucideIcon, FunctionSquare } from "lucide-react";
 import { useModalFunctionMaterials } from "../hooks/useModalFunctionMaterials";
 import SyntaxHighlighter from "@/components/SyntaxHighlighter";
 import CopyButton from "@/components/CopyButton";
@@ -23,6 +23,23 @@ interface AssociatedMaterialsProps {
   resource: ModalFunction;
   ownsThisFunction: boolean;
 }
+
+const TabTrigger = ({ icon: Icon, name, value, count }: { icon: LucideIcon, name: string, value: string, count?: number }) => {
+  return (
+    <TabsTrigger
+      value={value}
+      className="data-[state=active]:bg-white data-[state=active]:shadow-sm text-sm"
+    >
+      <div className="flex items-center justify-center">
+        <Icon className="h-4 w-4" />
+        <span className="hidden lg:block ml-1.5">{name}</span>
+        {count !== undefined && count > 0 && (
+          <span className="hidden sm:inline ml-1">({count})</span>
+        )}
+      </div>
+    </TabsTrigger>
+  );
+};
 
 const AssociatedMaterials = ({ resource, ownsThisFunction }: AssociatedMaterialsProps) => {
   // Get all materials from the modal function
@@ -94,24 +111,40 @@ const AssociatedMaterials = ({ resource, ownsThisFunction }: AssociatedMaterials
         className="w-full min-h-[400px]"
       >
         <TabsList className="mb-2 bg-gray-100 p-0.5 grid grid-cols-6">
-          <TabsTrigger value="function" className="data-[state=active]:bg-white data-[state=active]:shadow-sm">
-            Function
-          </TabsTrigger>
-          <TabsTrigger value="apptext" className="data-[state=active]:bg-white data-[state=active]:shadow-sm">
-            App Text
-          </TabsTrigger>
-          <TabsTrigger value="datasets" className="data-[state=active]:bg-white data-[state=active]:shadow-sm">
-            Datasets {datasets.length > 0 && `(${datasets.length})`}
-          </TabsTrigger>
-          <TabsTrigger value="papers" className="data-[state=active]:bg-white data-[state=active]:shadow-sm">
-            Papers {papers.length > 0 && `(${papers.length})`}
-          </TabsTrigger>
-          <TabsTrigger value="repositories" className="data-[state=active]:bg-white data-[state=active]:shadow-sm">
-            Repositories {repositories.length > 0 && `(${repositories.length})`}
-          </TabsTrigger>
-          <TabsTrigger value="notebooks" className="data-[state=active]:bg-white data-[state=active]:shadow-sm">
-            Notebooks {notebooks.length > 0 && `(${notebooks.length})`}
-          </TabsTrigger>
+          <TabTrigger
+            icon={FunctionSquare}
+            name="Function"
+            value="function"
+          />
+          <TabTrigger
+            icon={FileTextIcon}
+            name="App Text"
+            value="apptext"
+          />
+          <TabTrigger
+            icon={DatabaseIcon}
+            name="Datasets"
+            value="datasets"
+            count={datasets.length}
+          />
+          <TabTrigger
+            icon={ScrollTextIcon}
+            name="Papers"
+            value="papers"
+            count={papers.length}
+          />
+          <TabTrigger
+            icon={CodeIcon}
+            name="Repos"
+            value="repositories"
+            count={repositories.length}
+          />
+          <TabTrigger
+            icon={BookIcon}
+            name="Notebooks"
+            value="notebooks"
+            count={notebooks.length}
+          />
         </TabsList>
 
         {/* Function Tab */}
@@ -271,7 +304,7 @@ const AssociatedMaterials = ({ resource, ownsThisFunction }: AssociatedMaterials
                 <div className="flex items-center justify-between mb-3">
                   <h3 className="text-lg font-medium flex items-center">
                     <CodeIcon className="h-5 w-5 mr-2 text-green" />
-                    Code Repositories
+                    Repositories
                   </h3>
                   {ownsThisFunction && (
                     <RepositoryModal

--- a/garden/src/features/modal/components/FunctionMetadataSidebar.tsx
+++ b/garden/src/features/modal/components/FunctionMetadataSidebar.tsx
@@ -1,0 +1,86 @@
+import { LinkIcon } from "lucide-react";
+import CopyButton from "@/components/CopyButton";
+import { Metadata, EditableMetadataField } from "@/components/shared/metadata";
+import { usePatchModalFunction } from "../api/usePatchModalFunction";
+import { ModalFunction } from "@/types";
+
+interface FunctionMetadataSidebarProps {
+    modalFunction: ModalFunction,
+    ownsThisFunction: boolean,
+}
+
+export const FunctionMetadataSidebar = ({
+    modalFunction,
+    ownsThisFunction,
+}: FunctionMetadataSidebarProps) => {
+    const { mutate: patchModalFunction } = usePatchModalFunction();
+    const updateFunction = async (updateData: Partial<ModalFunction>) => {
+        await patchModalFunction({
+            id: modalFunction.id,
+            modalFunction: updateData,
+        });
+    };
+    return (
+        <Metadata entity={modalFunction} ownsThisEntity={ownsThisFunction}>
+          <div className="group border border-transparent bg-white rounded-md py-1.5 px-2.5 shadow-sm">
+            <div className="flex items-center justify-between">
+              <p className="text-sm text-gray-500 font-medium">DOI</p>
+              <CopyButton 
+                content={modalFunction.doi || ""} 
+                hint="Copy DOI" 
+                className="ml-2" 
+                icon={<LinkIcon className="h-4 w-4" />}
+              />
+            </div>
+            <div className="mt-0.5">
+              <p className="font-medium font-mono text-gray-800 overflow-hidden overflow-ellipsis">
+                {modalFunction.doi || "No DOI"}
+              </p>
+            </div>
+          </div>
+
+          <EditableMetadataField
+            label="Model Authors"
+            helpText="Original authors of the models used by this function"
+            value={modalFunction.authors}
+            fieldName="authors"
+            entity={modalFunction}
+            ownsThisEntity={ownsThisFunction}
+            isArray={true}
+            onUpdate={updateFunction}
+          />
+
+          <EditableMetadataField
+            label="Gardeners"
+            helpText="Creator and contriubtors to this function and related materials"
+            value={[modalFunction.owner, ...(modalFunction.contributors || [])]}
+            fieldName="contributors"
+            entity={modalFunction}
+            ownsThisEntity={ownsThisFunction}
+            isArray={true}
+            onUpdate={updateFunction}
+          />
+
+          <EditableMetadataField
+            label="Year"
+            helpText="Year this function was published"
+            value={modalFunction.year}
+            fieldName="year"
+            entity={modalFunction}
+            ownsThisEntity={ownsThisFunction}
+            onUpdate={updateFunction}
+          />
+
+          <EditableMetadataField
+            label="Tags"
+            helpText="Tags help users discover your functions"
+            value={modalFunction.tags}
+            fieldName="tags"
+            entity={modalFunction}
+            ownsThisEntity={ownsThisFunction}
+            isArray={true}
+            onUpdate={updateFunction}
+          />
+        </Metadata>
+    );
+}

--- a/garden/src/features/modal/components/ModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/ModalFunctionPage.tsx
@@ -16,8 +16,9 @@ import { LoadingOverlay } from "@/components/LoadingOverlay";
 
 import CopyButton from "@/components/CopyButton";
 import ModalAssociatedMaterials from "@/features/materials/components/ModalAssociatedMaterials";
+import { FunctionMetadataSidebar } from "./FunctionMetadataSidebar";
 import { EditableCodeField } from "@/components/EditableCodeField";
-import { Metadata, EditableMetadataField } from "@/components/shared/metadata";
+import { EditableMetadataField } from "@/components/shared/metadata";
 
 // Extend ModalFunction type to include owner_identity_id
 type ModalFunctionWithOwner = ModalFunction & {
@@ -29,7 +30,6 @@ const ModalFunctionPage = () => {
   const { data: modalFunction, isError, isLoading } = useGetModalFunction(id);
   const { data: garden, isLoading: isGardenLoading } = gardenDOI ? useGetGarden(gardenDOI) : { data: undefined, isLoading: false };
   const auth = useGlobusAuth();
-  const { mutateAsync: patchModalFunction } = usePatchModalFunction();
   const ownsThisFunction = auth.isAuthenticated && modalFunction?.owner_identity_id === auth?.authorization?.user?.sub;
 
   if (isLoading || (gardenDOI && isGardenLoading)) return <LoadingOverlay />;
@@ -50,7 +50,7 @@ const ModalFunctionPage = () => {
 
   return (
     <div className="container max-w-7xl mx-auto px-4 md:px-6 pt-6 font-display">
-      <div className="flex flex-col-reverse lg:flex-row gap-6">
+      <div className="flex flex-col lg:flex-row gap-6">
         {/* Main Content */}
         <div className="lg:w-2/3">
           <Breadcrumb 
@@ -59,7 +59,6 @@ const ModalFunctionPage = () => {
           />
           <ModalFunctionHeader 
             modalFunction={modalFunction as ModalFunctionWithOwner} 
-            ownsThisFunction={ownsThisFunction} 
             gardenDOI={gardenDOI}
           />
           <ModalFunctionBody modalFunction={modalFunction} ownsThisFunction={ownsThisFunction} />
@@ -71,93 +70,16 @@ const ModalFunctionPage = () => {
         </div>
 
         {/* Sidebar */}
-        <Metadata entity={modalFunction} ownsThisEntity={ownsThisFunction}>
-          <div className="group border border-transparent bg-white rounded-md py-1.5 px-2.5 shadow-sm">
-            <div className="flex items-center justify-between">
-              <p className="text-sm text-gray-500 font-medium">DOI</p>
-              <CopyButton 
-                content={modalFunction.doi || ""} 
-                hint="Copy DOI" 
-                className="ml-2" 
-                icon={<LinkIcon className="h-4 w-4" />}
-              />
-            </div>
-            <div className="mt-0.5">
-              <p className="font-medium font-mono text-gray-800 overflow-hidden overflow-ellipsis">
-                {modalFunction.doi || "No DOI"}
-              </p>
-            </div>
-          </div>
-
-          <EditableMetadataField
-            label="Model Authors"
-            helpText="Original authors of the models used by this function"
-            value={modalFunction.authors}
-            fieldName="authors"
-            entity={modalFunction}
-            ownsThisEntity={ownsThisFunction}
-            isArray={true}
-            onUpdate={async (updateData) => {
-              await patchModalFunction({
-                id: modalFunction.id,
-                modalFunction: updateData
-              });
-            }}
-          />
-
-          <EditableMetadataField
-            label="Gardeners"
-            helpText="Creator and contriubtors to this function and related materials"
-            value={[modalFunction.owner, ...(modalFunction.contributors || [])]}
-            fieldName="contributors"
-            entity={modalFunction}
-            ownsThisEntity={ownsThisFunction}
-            isArray={true}
-            onUpdate={async (updateData) => {
-              await patchModalFunction({
-                id: modalFunction.id,
-                modalFunction: updateData
-              });
-            }}
-          />
-
-          <EditableMetadataField
-            label="Year"
-            helpText="Year this function was published"
-            value={modalFunction.year}
-            fieldName="year"
-            entity={modalFunction}
-            ownsThisEntity={ownsThisFunction}
-            onUpdate={async (updateData) => {
-              await patchModalFunction({
-                id: modalFunction.id,
-                modalFunction: updateData
-              });
-            }}
-          />
-
-          <EditableMetadataField
-            label="Tags"
-            helpText="Tags help users discover your functions"
-            value={modalFunction.tags}
-            fieldName="tags"
-            entity={modalFunction}
-            ownsThisEntity={ownsThisFunction}
-            isArray={true}
-            onUpdate={async (updateData) => {
-              await patchModalFunction({
-                id: modalFunction.id,
-                modalFunction: updateData
-              });
-            }}
-          />
-        </Metadata>
+        <FunctionMetadataSidebar
+          modalFunction={modalFunction}    
+          ownsThisFunction={ownsThisFunction}
+        />
       </div>
     </div>
   );
 };
 
-const ModalFunctionHeader = ({ modalFunction, ownsThisFunction, gardenDOI }: { modalFunction: ModalFunctionWithOwner; ownsThisFunction: boolean; gardenDOI?: string }) => {
+const ModalFunctionHeader = ({ modalFunction, gardenDOI }: { modalFunction: ModalFunctionWithOwner; gardenDOI?: string }) => {
   return (
     <div className="mb-3 flex items-center justify-between gap-2">
       <h1 className="text-xl md:text-2xl font-medium">{modalFunction.title}</h1>

--- a/garden/src/features/search/components/SearchPage.tsx
+++ b/garden/src/features/search/components/SearchPage.tsx
@@ -59,14 +59,12 @@ const SearchPage = () => {
       </div>
       <div className="relative mt-5 mb-6">
         {/* Mobile layout */}
-        <div className="flex flex-col gap-5 lg:hidden">
-          <div className="md:hidden">
-            <SearchFilters
-              searchResult={searchResult}
-              selectedFilters={selectedFilters}
-              setSelectedFilters={setSelectedFilters}
-            />
-          </div>
+        <div className="flex flex-col gap-5 md:hidden lg:hidden">
+          <SearchFilters
+            searchResult={searchResult}
+            selectedFilters={selectedFilters}
+            setSelectedFilters={setSelectedFilters}
+          />
           <div>
             <SearchResultsInner />
           </div>

--- a/garden/src/features/users/components/UserProfileCard.tsx
+++ b/garden/src/features/users/components/UserProfileCard.tsx
@@ -1,103 +1,20 @@
-import React, { useEffect, useState } from "react";
-import PfpSelectionModal from "./PfpSelectionModal";
-import { icons, IconType } from "./icons";
-import RenderTags from "@/components/shadcn/renderTags";
 import { useGetUserInfo } from "../api/useGetUserInfo";
-import UserProfileShareModal from "./UserProfileShareModal";
 import { useGetGardens } from "@/features/gardens/api/useGetGardens";
 
-type UserProfileCardProps = {
-  pfp: JSX.Element | null;
-  setPfp: React.Dispatch<React.SetStateAction<JSX.Element | null>>;
-};
-
-const UserProfileCard = ({ pfp, setPfp }: UserProfileCardProps) => {
-  const [show, setShow] = useState(false);
-  const [tooltipVisible, setTooltipVisible] = useState(false);
-  // const [profileIcon, setProfileIcon] = useState<JSX.Element | null>(null);
-
-  const [showIconSelector, setShowIconSelector] = useState(false);
+const UserProfileCard = () => {
 
   const { data: currUserInfo } = useGetUserInfo();
 
   const { data: userGardens } = useGetGardens({ owner_uuid: currUserInfo?.identity_id });
 
-  useEffect(() => {
-    if (currUserInfo && currUserInfo.profile_pic_id) {
-      const selectedIcon = icons.find((icon) => icon.id === currUserInfo.profile_pic_id);
-      setPfp(selectedIcon ? selectedIcon.svg : pfp);
-    }
-  }, [currUserInfo, setPfp, pfp]);
-
-  const copy = async () => {
-    await navigator.clipboard.writeText(window.location.href);
-    showTooltip();
-  };
-
-  const showTooltip = () => {
-    if (!tooltipVisible) {
-      setTooltipVisible(true);
-      setTimeout(() => {
-        setTooltipVisible(false);
-      }, 3000);
-    }
-  };
-
-  const showModal = () => {
-    setShow(true);
-  };
-
-  const closeModal = () => {
-    setShow(false);
-  };
-
-  const handleIconClick = () => {
-    setShowIconSelector(true);
-  };
-
-  const closeIconSelector = () => {
-    setShowIconSelector(false);
-  };
-
-  const defaultProfileIcon = (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      width="100"
-      height="100"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="white"
-      stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
-      className="lucide lucide-pencil"
-    >
-      <path d="M21.174 6.812a1 1 0 0 0-3.986-3.987L3.842 16.174a2 2 0 0 0-.5.83l-1.321 4.352a.5.5 0 0 0 .623.622l4.353-1.32a2 2 0 0 0 .83-.497z" />
-      <path d="m15 5 4 4" />
-    </svg>
-  );
-
   return (
     <div className="flex w-3/12 flex-col justify-between rounded-lg border border-gray-200 p-4 shadow-sm hover:shadow-md">
       <div className="dark:bg-navy-800 shadow-shadow-500 shadow-3xl rounded-primary relative mx-auto flex h-full w-full max-w-[550px] flex-col items-center bg-white bg-cover bg-clip-border p-4 dark:shadow-none">
-        <div className="mt-8 flex flex-col items-center px-2">
-          <div className="relative h-[150px] w-[150px] overflow-hidden">
-            <div
-              className="relative block flex h-full w-full cursor-pointer items-center justify-center rounded-full bg-primary"
-              onClick={handleIconClick}
-            >
-              {pfp || defaultProfileIcon}
-            </div>
-          </div>
-        </div>
         <div className="mt-6 flex flex-col items-center space-y-1">
           <h4 className="text-bluePrimary mb-1 mt-1 text-3xl">{currUserInfo?.name ?? "No Name"}</h4>
           <p className="text-lightSecondary mb-1 font-normal">{currUserInfo?.email}</p>
           <p className="font-style: text-sm italic text-gray-400">
             {currUserInfo?.affiliations?.join(", ")}
-          </p>
-          <p className="font-style: text-sm italic text-gray-400">
-            {currUserInfo?.domains?.join(", ")}
           </p>
         </div>
         <div className="mb-4 mt-6 flex flex-col text-gray-600">
@@ -114,41 +31,7 @@ const UserProfileCard = ({ pfp, setPfp }: UserProfileCardProps) => {
             <p className="text-lightSecondary ml-2 text-base font-normal">Gardens Saved</p>
           </div>
           <hr className="h-0.5 border-t-0 bg-neutral-100 opacity-100 dark:opacity-50" />
-          <div className="mb-8 flex flex-col items-center gap-2 text-base">
-            <p className="text-lightSecondary mt-4 font-normal">Skills</p>
-            <RenderTags items={currUserInfo?.skills ?? []} title="" customBgColor="bg-indigo-300" />
-          </div>
         </div>
-        {/*hide button for now
-                <button 
-                    onClick={showModal}
-                    title="Share" 
-                    className="absolute bottom-2 right-2 flex flex-row items-center gap-2 rounded-lg border border-gray-200 px-2 py-1 text-sm"
-                >
-                    Share Profile
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor" className="h-4 w-4">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z" />
-                    </svg>
-                </button>
-                */}
-        <UserProfileShareModal
-          show={show}
-          close={closeModal}
-          copy={copy}
-          showTooltip={showTooltip}
-        />
-        {showIconSelector && (
-          <PfpSelectionModal
-            setSelectedIcon={(icon) => {
-              if (icon) {
-                setPfp(icon.svg);
-              } else {
-                setPfp(null);
-              }
-            }}
-            closeModal={closeIconSelector}
-          />
-        )}
       </div>
     </div>
   );

--- a/garden/src/features/users/components/UserProfileInfo.tsx
+++ b/garden/src/features/users/components/UserProfileInfo.tsx
@@ -4,7 +4,6 @@ import { buttonVariants } from "@/components/shadcn/button";
 import { cn } from "@/utils/form.utils";
 import { toast } from "sonner";
 import MultipleSelector from "@/components/shadcn/multiple-select";
-import InputMask from "react-input-mask";
 import { UpdateUserSchema } from "@/types";
 import { useGetUserInfo } from "../api/useGetUserInfo";
 import LoadingSpinner from "@/components/LoadingSpinner";
@@ -140,28 +139,6 @@ const UserProfileInfo = () => {
             <p>{currUserInfo?.name ?? "No name entered yet."}</p>
           )}
         </div>
-        <div className="space-y-2">
-          <p className="text-gray-600">Phone Number</p>
-          {edit ? (
-            <div className="relative">
-              <InputMask
-                mask="+9 999 999 9999"
-                value={userInfo.phone_number ?? ""}
-                onChange={handleInputChange}
-                maskChar=""
-                name="phone_number"
-                type="text"
-                placeholder="+x xxx xxx xxxx"
-                className="w-full rounded border border-gray-300 px-2 py-1 focus:border-2 focus:border-green focus:outline-none focus:ring-0"
-              />
-              <div className="absolute right-0 top-0 mr-2 mt-1 text-xs text-gray-500">
-                Format: +(country code) xxx-xxx-xxxx
-              </div>
-            </div>
-          ) : (
-            <p>{currUserInfo?.phone_number ?? "No phone number entered yet."}</p>
-          )}
-        </div>
         <div className="space-y-2 ">
           <p className="text-gray-600">Email Address</p>
           {edit ? (
@@ -197,43 +174,6 @@ const UserProfileInfo = () => {
             />
           ) : (
             <RenderTags items={userInfo?.affiliations ?? []} title="Affiliations" />
-          )}
-        </div>
-        <div className="space-y-2 ">
-          {edit ? (
-            <MultipleSelector
-              placeholder="Edit skills"
-              creatable
-              value={userInfo.skills?.map((skill) => ({ label: skill, value: skill }))}
-              onChange={(newValue: any) =>
-                setUserInfo({
-                  ...userInfo,
-                  skills: newValue.map((item: any) => item.value),
-                })
-              }
-              className="bg-white"
-              maxSelected={10}
-            />
-          ) : (
-            <RenderTags items={userInfo?.skills ?? []} title="Skills" />
-          )}
-        </div>
-        <div className="space-y-2 ">
-          {edit ? (
-            <MultipleSelector
-              placeholder="Edit domains"
-              creatable
-              value={userInfo.domains?.map((domain) => ({ label: domain, value: domain }))}
-              onChange={(newValue: any) =>
-                setUserInfo({
-                  ...userInfo,
-                  domains: newValue.map((item: any) => item.value),
-                })
-              }
-              className="bg-white"
-            />
-          ) : (
-            <RenderTags items={userInfo?.domains ?? []} title="Domains" />
           )}
         </div>
       </div>

--- a/garden/src/features/users/components/UserProfilePage.tsx
+++ b/garden/src/features/users/components/UserProfilePage.tsx
@@ -50,7 +50,7 @@ const UserProfilePage = () => {
 
   return (
     <div className="mt-16 flex h-full min-h-[80vh] w-full flex-row justify-center gap-10 p-10">
-      <UserProfileCard pfp={pfp} setPfp={setPfp} />
+      <UserProfileCard />
       <UserProfileTabs />
     </div>
   );


### PR DESCRIPTION
Another batch of UI tweaks part of #285 

- Fixed duplicate search results on small screen sizes
- move metadata sidebar to the bottom of the page on small screens
- fix overflow issues on the tabbed section of the garden and function pages

<img width="584" alt="image" src="https://github.com/user-attachments/assets/8e8ae1f8-9483-4792-a518-bc404f8b455c" />

- clean up profile page
<img width="1115" alt="image" src="https://github.com/user-attachments/assets/059ecbb3-2ed6-4ff1-bbfd-99fa6aa8ec30" />
