### PR TITLE
Style polish

### DIFF
--- a/garden/src/components/HomePage.tsx
+++ b/garden/src/components/HomePage.tsx
@@ -381,7 +381,7 @@ predictions = predict_properties()`}
           <div className="flex justify-center space-x-4 p-4 ">
             {gardens?.map((res: any, index: any) => (
               <div className="h-[300px] w-[300px]" key={index}>
-                <GardenBox garden={res} />
+                <GardenBox garden={res} allowEdits={false} />
               </div>
             ))}
           </div>

--- a/garden/src/components/HomePage.tsx
+++ b/garden/src/components/HomePage.tsx
@@ -250,7 +250,7 @@ garden = garden_client.get_garden("10.26311/ep98-br79")
 
 def predict_properties():
     materials = ['AgI', 'CdTe', 'BN']
-    result = garden.predict_piezoelectric(materials)
+    result = garden.predict_piezoelectric_displacement(materials)
     return result
 
 # Run the model and get results

--- a/garden/src/components/shared/metadata/EditableTitle.tsx
+++ b/garden/src/components/shared/metadata/EditableTitle.tsx
@@ -1,70 +1,68 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { EditIcon, SaveIcon, XIcon } from "lucide-react";
 import { Button } from "@/components/shadcn/button";
 import { Input } from "@/components/shadcn/input";
 import { toast } from "sonner";
-import { Garden } from "@/types";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/tooltip";
-import { usePatchGarden } from "../../api/usePatchGarden";
-import { z } from "zod";
-import { formSchema } from "../EditGardenschemas";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/shadcn/tooltip";
+import { Garden, ModalFunction } from "@/types";
+
+type Entity = Garden | ModalFunction;
 
 export interface EditableTitleProps {
-  garden: Garden;
-  ownsThisGarden: boolean;
+  entity: Entity;
+  ownsThisEntity: boolean;
+  onUpdate: (updateData: any) => Promise<void>;
 }
 
-const EditableTitle = ({ garden, ownsThisGarden }: EditableTitleProps) => {
+const EditableTitle = ({ entity, ownsThisEntity, onUpdate }: EditableTitleProps) => {
   const [isEditing, setIsEditing] = useState(false);
-  const [inputValue, setInputValue] = useState(garden.title);
-  const { mutate: updateGarden } = usePatchGarden();
+  const [inputValue, setInputValue] = useState(entity.title);
 
-  const handleSave = () => {
-    // Validate using the schema
-    const schema = formSchema.shape.title;
-    const result = schema.safeParse(inputValue);
-    
-    if (!result.success) {
-      // Display the first validation error
-      const errorMessage = result.error.errors[0]?.message || "Invalid title";
-      toast.error(errorMessage);
+  const handleSave = async () => {
+    if (!inputValue.trim()) {
+      toast.error("Title cannot be empty");
       return;
     }
-    
-    updateGarden({
-      doi: garden.doi,
-      garden: { title: inputValue }
-    });
-    
-    setIsEditing(false);
-    toast.success("Title updated");
+
+    try {
+      await onUpdate({ title: inputValue });
+      toast.success("Title updated successfully");
+      setIsEditing(false);
+    } catch (error: any) {
+      toast.error(`Error updating title: ${error.message}`);
+    }
   };
-  
+
   const handleCancel = () => {
-    setInputValue(garden.title);
+    setInputValue(entity.title);
     setIsEditing(false);
   };
 
-  if (isEditing && ownsThisGarden) {
+  if (isEditing && ownsThisEntity) {
     return (
       <div className="flex flex-col gap-2">
-        <Input 
+        <Input
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
-          className="text-2xl font-bold w-full"
-          placeholder="Garden Title"
+          className="text-xl md:text-2xl font-medium"
+          placeholder="Title"
         />
         <div className="flex gap-2">
-          <Button 
-            size="sm" 
-            onClick={handleSave} 
+          <Button
+            size="sm"
+            onClick={handleSave}
             className="flex items-center gap-1"
           >
             <SaveIcon className="h-3.5 w-3.5" /> Save
           </Button>
-          <Button 
-            size="sm" 
-            variant="outline" 
+          <Button
+            size="sm"
+            variant="outline"
             onClick={handleCancel}
             className="flex items-center gap-1"
           >
@@ -74,16 +72,16 @@ const EditableTitle = ({ garden, ownsThisGarden }: EditableTitleProps) => {
       </div>
     );
   }
-  
+
   return (
     <div className="flex items-center gap-2 group">
-      <h1 className="text-2xl font-bold">{garden.title}</h1>
-      {ownsThisGarden && (
+      <h1 className="text-xl md:text-2xl font-medium">{entity.title}</h1>
+      {ownsThisEntity && (
         <div className="flex items-center gap-1 h-8">
           <TooltipProvider delayDuration={150}>
             <Tooltip>
               <TooltipTrigger asChild>
-                <button 
+                <button
                   onClick={() => setIsEditing(true)}
                   className="text-green hover:text-darkgreen"
                   aria-label="Edit title"

--- a/garden/src/components/shared/metadata/index.ts
+++ b/garden/src/components/shared/metadata/index.ts
@@ -1,2 +1,3 @@
 export { default as Metadata } from './Metadata';
-export { default as EditableMetadataField } from './EditableMetadataField'; 
+export { default as EditableMetadataField } from './EditableMetadataField';
+export { default as EditableTitle } from './EditableTitle'; 

--- a/garden/src/features/gardens/components/GardenBox.tsx
+++ b/garden/src/features/gardens/components/GardenBox.tsx
@@ -5,7 +5,7 @@ import { Garden } from "@/types";
 import { useGetUserInfo } from "@/features/users/api/useGetUserInfo";
 import { useGetGardens } from "@/features/gardens/api/useGetGardens";
 
-const GardenBox = ({ garden }: { garden: Garden }) => {
+const GardenBox = ({ garden, allowEdits }: { garden: Garden, allowEdits: boolean }) => {
   const navigate = useNavigate();
 
   const { data: currUserInfo } = useGetUserInfo();
@@ -53,7 +53,7 @@ const GardenBox = ({ garden }: { garden: Garden }) => {
             </div>
           )}
           <div className="ml-auto flex items-center">
-            {canEditGarden && (
+            {canEditGarden && allowEdits && (
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 width="24"

--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -18,12 +18,11 @@ import { Garden } from "@/types";
 import {
   GardenDescription,
   VisibilityWarning,
-  EditableTitle,
   ReviewNotice,
 } from "./garden-page";
 import { GardenTabbedSection } from "./GardenTabbedSection";
 import { GardenMetadataSidebar } from "./GardenMetadataSidebar";
-
+import { EditableTitle } from "@/components/shared/metadata";
 
 interface GardenContentProps {
   garden: Garden;
@@ -59,7 +58,16 @@ const GardenContent = ({ garden, ownsThisGarden, isNewlyCreated }: GardenContent
           {/* Title, Description & Core Metadata */}
           <div className="lg:w-2/3">
             <div className="flex justify-between items-start mb-4">
-              <EditableTitle garden={garden} ownsThisGarden={ownsThisGarden} />
+              <EditableTitle 
+                entity={garden}
+                ownsThisEntity={ownsThisGarden}
+                onUpdate={async (updateData) => {
+                  await patchGarden({
+                    doi: garden.doi,
+                    garden: updateData
+                  });
+                }}
+              />
               <div className="flex">
                 <SaveGardenButton garden={garden} />
                 <GardenDropdownOptions garden={garden} />
@@ -87,7 +95,6 @@ const GardenContent = ({ garden, ownsThisGarden, isNewlyCreated }: GardenContent
       </div>
       );
 };
-
 
 const GardenPage = () => {
   const { doi } = useParams();

--- a/garden/src/features/gardens/components/GardenTabbedSection.tsx
+++ b/garden/src/features/gardens/components/GardenTabbedSection.tsx
@@ -22,7 +22,7 @@ const TabTrigger = ({ icon: Icon, garden, name, value }: { icon: LucideIcon, gar
             value={value}
             className="data-[state=active]:bg-white data-[state=active]:shadow-sm text-sm"
         >
-            <div className="flex items-center justify-center">
+            <div className="flex items-center justify-between">
                 <Icon className="h-4 w-4" />
                 <span className="hidden lg:block ml-1.5">{name}</span>
                 {((garden.entrypoints?.length || 0) + (garden.modal_functions?.length || 0)) > 0 && (
@@ -75,7 +75,7 @@ export const GardenTabbedSection = ({ garden, ownsThisGarden }: { garden: Garden
             }
             className="flex flex-col w-full"
         >
-            <TabsList className="bg-gray-200 flex flex-row justify-around">
+            <TabsList className="mb-2 bg-gray-200 p-0.5 grid grid-cols-5">
                 <TabTrigger
                     icon={FunctionSquare}
                     garden={garden}

--- a/garden/src/features/gardens/components/garden-page/EditableTitle.tsx
+++ b/garden/src/features/gardens/components/garden-page/EditableTitle.tsx
@@ -85,7 +85,7 @@ const EditableTitle = ({ garden, ownsThisGarden }: EditableTitleProps) => {
               <TooltipTrigger asChild>
                 <button 
                   onClick={() => setIsEditing(true)}
-                  className="opacity-0 group-hover:opacity-100 transition-opacity text-green hover:text-darkgreen"
+                  className="text-green hover:text-darkgreen"
                   aria-label="Edit title"
                 >
                   <EditIcon className="h-4 w-4" />

--- a/garden/src/features/gardens/components/garden-page/GardenDescription.tsx
+++ b/garden/src/features/gardens/components/garden-page/GardenDescription.tsx
@@ -1,139 +1,33 @@
-import React, { useState } from "react";
-import { EditIcon, SaveIcon, XIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
-import { Button } from "@/components/shadcn/button";
-import { Textarea } from "@/components/shadcn/textarea";
-import { toast } from "sonner";
 import { Garden } from "@/types";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/tooltip";
-import Markdown from "@/components/Markdown";
 import { usePatchGarden } from "../../api/usePatchGarden";
-import { z } from "zod";
-import { formSchema } from "../EditGardenschemas";
 import { useGlobusAuth } from "@globus/react-auth-context";
+import { EditableMetadataField } from "@/components/shared/metadata";
 
 interface GardenDescriptionProps {
   garden: Garden;
 }
 
 const GardenDescription = ({ garden }: GardenDescriptionProps) => {
-  const [isEditing, setIsEditing] = useState(false);
-  const [inputValue, setInputValue] = useState(garden.description || "");
-  const [isExpanded, setIsExpanded] = useState(false);
-  const { mutate: updateGarden } = usePatchGarden();
+  const { mutateAsync: updateGarden } = usePatchGarden();
   const auth = useGlobusAuth();
   const ownsThisGarden = auth.isAuthenticated && garden.owner_identity_id === auth?.authorization?.user?.sub;
-  
-  const descriptionText = garden.description || "No description provided.";
-  const truncateLength = 150;
-  const shouldTruncate = descriptionText.length > truncateLength;
-  
-  const handleSave = () => {
-    // Validate using the schema
-    const schema = formSchema.shape.description;
-    const result = schema.safeParse(inputValue);
-    
-    if (!result.success) {
-      // Display the first validation error
-      const errorMessage = result.error.errors[0]?.message || "Invalid description";
-      toast.error(errorMessage);
-      return;
-    }
-    
-    updateGarden({
-      doi: garden.doi,
-      garden: { description: inputValue }
-    });
-    
-    setIsEditing(false);
-  };
-  
-  const handleCancel = () => {
-    setInputValue(garden.description || "");
-    setIsEditing(false);
-  };
 
-  if (isEditing && ownsThisGarden) {
-    return (
-      <div className="mt-2 space-y-2 border border-gray-200 rounded-md p-3 bg-gray-50 shadow-inner">
-        <p className="text-sm font-medium text-gray-700 mb-1">Edit Description</p>
-        <Textarea 
-          value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
-          placeholder="Tell us about your garden"
-          className="w-full min-h-[120px] bg-white"
-        />
-        
-        <div className="flex gap-2">
-          <Button 
-            size="sm" 
-            onClick={handleSave} 
-            className="flex items-center gap-1 bg-blue-600 hover:bg-blue-700"
-          >
-            <SaveIcon className="h-3.5 w-3.5" /> Save
-          </Button>
-          <Button 
-            size="sm" 
-            variant="outline" 
-            onClick={handleCancel}
-            className="flex items-center gap-1"
-          >
-            <XIcon className="h-3.5 w-3.5" /> Cancel
-          </Button>
-        </div>
-      </div>
-    );
-  }
-  
   return (
-    <div className="relative group rounded-lg border border-gray-200 p-4 hover:border-blue-200 bg-gradient-to-b from-white to-gray-50 shadow-sm">
-      {ownsThisGarden && (
-        <div className="absolute right-3 top-3 flex gap-1">
-          <TooltipProvider delayDuration={150}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button 
-                  onClick={() => setIsEditing(true)}
-                  className="text-green hover:text-darkgreen"
-                  aria-label="Edit description"
-                >
-                  <EditIcon className="h-4 w-4" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent className="p-2">
-                <p className="text-sm">Edit description</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </div>
-      )}
-      
-      <div className="mt-1">
-        {garden.description && garden.description.length > 300 ? (
-          <>
-            <div className={`${isExpanded ? "" : "line-clamp-3"} prose prose-sm max-w-none prose-p:text-gray-700 prose-headings:text-gray-800`}>
-              <Markdown content={garden.description} />
-            </div>
-            <button
-              onClick={() => setIsExpanded(!isExpanded)}
-              className="mt-2 text-sm text-blue-600 hover:text-blue-800 flex items-center"
-            >
-              {isExpanded ? (
-                <>
-                  <ChevronUpIcon className="h-4 w-4 mr-1" /> Show Less
-                </>
-              ) : (
-                <>
-                  <ChevronDownIcon className="h-4 w-4 mr-1" /> Show More
-                </>
-              )}
-            </button>
-          </>
-        ) : (
-          <div className="prose prose-sm max-w-none prose-p:text-gray-700 prose-headings:text-gray-800">
-            <Markdown content={garden.description || ""} />
-          </div>
-        )}
-      </div>
+    <div className="space-y-3 py-2">
+      <EditableMetadataField
+        label="Description"
+        value={garden.description || ""}
+        fieldName="description"
+        entity={garden}
+        ownsThisEntity={ownsThisGarden}
+        onUpdate={async (updateData) => {
+          await updateGarden({
+            doi: garden.doi,
+            garden: updateData
+          });
+        }}
+        placeholder="Tell us about your garden"
+      />
     </div>
   );
 };

--- a/garden/src/features/gardens/components/garden-page/GardenDescription.tsx
+++ b/garden/src/features/gardens/components/garden-page/GardenDescription.tsx
@@ -93,7 +93,7 @@ const GardenDescription = ({ garden }: GardenDescriptionProps) => {
               <TooltipTrigger asChild>
                 <button 
                   onClick={() => setIsEditing(true)}
-                  className="opacity-0 group-hover:opacity-100 transition-opacity text-green hover:text-darkgreen"
+                  className="text-green hover:text-darkgreen"
                   aria-label="Edit description"
                 >
                   <EditIcon className="h-4 w-4" />

--- a/garden/src/features/gardens/components/garden-page/index.ts
+++ b/garden/src/features/gardens/components/garden-page/index.ts
@@ -1,9 +1,8 @@
 export { default as AddModalFunctionSelector } from "./AddModalFunctionSelector";
 export { default as GardenDescription } from "./GardenDescription";
-export { default as CitationBlock } from "./CitationBlock";
 export { default as VisibilityWarning } from "./VisibilityWarning";
-export { default as EditableTitle } from "./EditableTitle";
 export { default as ReviewNotice } from "./ReviewNotice";
+export { default as CitationBlock } from "./CitationBlock";
 export { default as GardenAssociatedMaterialsSection } from "./GardenAssociatedMaterialsSection";
 export { default as ShowAllMaterialsToggle } from "./ShowAllMaterialsToggle";
 export { default as AddMaterialWithFunctionSelect } from "./AddMaterialWithFunctionSelect"

--- a/garden/src/features/materials/components/ModalAssociatedMaterials.tsx
+++ b/garden/src/features/materials/components/ModalAssociatedMaterials.tsx
@@ -104,7 +104,7 @@ const AssociatedMaterials = ({ resource, ownsThisFunction }: AssociatedMaterials
   };
 
   return (
-    <div className="mt-6 mb-6">
+    <div className="mt-6">
       <Tabs 
         defaultValue="function" 
         className="w-full min-h-[400px]"

--- a/garden/src/features/materials/components/ModalAssociatedMaterials.tsx
+++ b/garden/src/features/materials/components/ModalAssociatedMaterials.tsx
@@ -109,7 +109,7 @@ const AssociatedMaterials = ({ resource, ownsThisFunction }: AssociatedMaterials
         defaultValue="function" 
         className="w-full min-h-[400px]"
       >
-        <TabsList className="mb-2 bg-gray-100 p-0.5 grid grid-cols-6">
+        <TabsList className="mb-2 bg-gray-200 p-0.5 grid grid-cols-6">
           <TabTrigger
             icon={FunctionSquare}
             name="Function"

--- a/garden/src/features/modal/components/ModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/ModalFunctionPage.tsx
@@ -10,7 +10,7 @@ import NotFoundPage from "@/components/NotFoundPage";
 import { Separator } from "@/components/shadcn/separator";
 import Breadcrumb from "@/components/Breadcrumb";
 
-import { LinkIcon } from "lucide-react";
+import { LinkIcon, EditIcon, SaveIcon, XIcon } from "lucide-react";
 import { ModalFunction } from "@/types";
 import { LoadingOverlay } from "@/components/LoadingOverlay";
 
@@ -18,7 +18,7 @@ import CopyButton from "@/components/CopyButton";
 import ModalAssociatedMaterials from "@/features/materials/components/ModalAssociatedMaterials";
 import { FunctionMetadataSidebar } from "./FunctionMetadataSidebar";
 import { EditableCodeField } from "@/components/EditableCodeField";
-import { EditableMetadataField } from "@/components/shared/metadata";
+import { EditableMetadataField, EditableTitle } from "@/components/shared/metadata";
 
 // Extend ModalFunction type to include owner_identity_id
 type ModalFunctionWithOwner = ModalFunction & {
@@ -60,6 +60,7 @@ const ModalFunctionPage = () => {
           <ModalFunctionHeader 
             modalFunction={modalFunction as ModalFunctionWithOwner} 
             gardenDOI={gardenDOI}
+            ownsThisFunction={ownsThisFunction}
           />
           <ModalFunctionBody modalFunction={modalFunction} ownsThisFunction={ownsThisFunction} />
           <ModalFunctionExample modalFunction={modalFunction} ownsThisFunction={ownsThisFunction} gardenDOI={gardenDOI} />
@@ -79,10 +80,25 @@ const ModalFunctionPage = () => {
   );
 };
 
-const ModalFunctionHeader = ({ modalFunction, gardenDOI }: { modalFunction: ModalFunctionWithOwner; gardenDOI?: string }) => {
+const ModalFunctionHeader = ({ modalFunction, gardenDOI, ownsThisFunction }: { 
+  modalFunction: ModalFunctionWithOwner; 
+  gardenDOI?: string;
+  ownsThisFunction: boolean;
+}) => {
+  const { mutateAsync: patchModalFunction } = usePatchModalFunction();
+
   return (
     <div className="mb-3 flex items-center justify-between gap-2">
-      <h1 className="text-xl md:text-2xl font-medium">{modalFunction.title}</h1>
+      <EditableTitle 
+        entity={modalFunction}
+        ownsThisEntity={ownsThisFunction}
+        onUpdate={async (updateData) => {
+          await patchModalFunction({
+            id: modalFunction.id,
+            modalFunction: updateData
+          });
+        }}
+      />
       <div className="flex items-center gap-1">
         <CopyButton
           icon={<LinkIcon className="h-4 w-4" />}

--- a/garden/src/features/modal/components/ModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/ModalFunctionPage.tsx
@@ -49,7 +49,7 @@ const ModalFunctionPage = () => {
       ];
 
   return (
-    <div className="container max-w-7xl mx-auto px-4 md:px-6 pt-6 font-display">
+    <div className="container mb-6 max-w-7xl mx-auto px-4 md:px-6 pt-6 font-display">
       <div className="flex flex-col lg:flex-row gap-6">
         {/* Main Content */}
         <div className="lg:w-2/3">

--- a/garden/src/features/search/components/SearchResult.tsx
+++ b/garden/src/features/search/components/SearchResult.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
 
 import { Garden } from "@/types";
@@ -21,9 +22,15 @@ import { BookOpenIcon, CalendarIcon, TagIcon } from "lucide-react";
 import { PersonIcon } from "@radix-ui/react-icons";
 
 import SaveGardenButton from "../../gardens/components/SaveGardenButton";
+import { Button } from "@/components/shadcn/button";
 
 export const SearchResult = ({ garden, verbose }: { garden: Garden; verbose: boolean }) => {
   const functions = [...(garden.entrypoints ?? []), ...(garden.modal_functions ?? [])];
+  const [showMore, setShowMore] = useState(false);
+
+  const handleShowMore = () => {
+    setShowMore(!showMore);
+  }
   return (
     <Card className="transition-colors hover:bg-gray-50 hover:shadow-lg">
       <CardHeader>
@@ -54,10 +61,18 @@ export const SearchResult = ({ garden, verbose }: { garden: Garden; verbose: boo
         </CardDescription>
       </CardHeader>
       
-      <MarkdownCardContent 
-        className="line-clamp-3"
-        content={garden.description || "*No description available*"}
-      />
+      <div className="p-1">
+        <MarkdownCardContent 
+          className={`m-2 p-2 text-balanced ${(showMore) ? "" : "line-clamp-3"}`}
+          content={garden.description || "*No description available*"}
+        />
+        <Button 
+          onClick={handleShowMore}
+          className="text-black text-xs bg-inherit hover:text-blue-400 hover:bg-inherit hover:underline"
+        >
+          {(showMore) ? "Show Less" : "Show More"}
+        </Button>
+      </div>
       
       {verbose && functions?.length > 0 && (
         <CardContent>


### PR DESCRIPTION
Resolves: #285 

This PR contains another set of style tweaks and fixes.

- Made sure homepage example code works
- fixed text overflow issue on search result cards

**Before**:
<img width="562" alt="image" src="https://github.com/user-attachments/assets/2c7e3436-798e-4e23-a85d-c75b9cfd7502" />

**After (different garden, but same description)**:
<img width="566" alt="image" src="https://github.com/user-attachments/assets/c9c1db82-986a-4c85-94cc-ff9451e23e21" />

- Clean up styles on a Garden and Function pages to match each other

**Garden Page**
<img width="1240" alt="image" src="https://github.com/user-attachments/assets/66175b23-f256-418a-a5a9-619a1b8cf61a" />

**Function Page**
<img width="1240" alt="image" src="https://github.com/user-attachments/assets/b04dd5e6-62fe-4134-8017-457eeda39150" />

