### PR TITLE
Make it clear wether metadata is for a Garden or a Function

### DIFF
--- a/garden/src/components/shared/metadata/Metadata.tsx
+++ b/garden/src/components/shared/metadata/Metadata.tsx
@@ -2,16 +2,17 @@ import { Garden, ModalFunction } from "@/types";
 import { ReactNode } from "react";
 
 interface MetadataProps {
+  name: string | undefined
   entity: Garden | ModalFunction;
   ownsThisEntity: boolean;
   children: ReactNode;
 }
 
-const Metadata = ({ entity, ownsThisEntity, children }: MetadataProps) => {
+const Metadata = ({  name, entity, ownsThisEntity, children }: MetadataProps) => {
   return (
     <div className="lg:w-1/3 bg-gray-50 rounded-lg p-4 border border-gray-200">
       <div className="space-y-2">
-        <h3 className="text-lg font-semibold mb-2">Metadata</h3>
+        <h3 className="text-lg font-semibold mb-2">{name + " " || ""}Metadata</h3>
         {children}
       </div>
     </div>

--- a/garden/src/features/gardens/components/GardenMetadataSidebar.tsx
+++ b/garden/src/features/gardens/components/GardenMetadataSidebar.tsx
@@ -15,7 +15,7 @@ export const GardenMetadataSidebar = ({garden, ownsThisGarden}: {garden: Garden,
     };
 
     return (
-        <Metadata entity={garden} ownsThisEntity={ownsThisGarden}>
+        <Metadata name={"Garden"} entity={garden} ownsThisEntity={ownsThisGarden}>
             {/* DOI Field */}
             <div className="group border border-transparent bg-white rounded-md py-1.5 px-2.5 shadow-sm">
                 <div className="flex items-center justify-between">

--- a/garden/src/features/modal/components/FunctionMetadataSidebar.tsx
+++ b/garden/src/features/modal/components/FunctionMetadataSidebar.tsx
@@ -21,7 +21,7 @@ export const FunctionMetadataSidebar = ({
         });
     };
     return (
-        <Metadata entity={modalFunction} ownsThisEntity={ownsThisFunction}>
+        <Metadata name={"Function"} entity={modalFunction} ownsThisEntity={ownsThisFunction}>
           <div className="group border border-transparent bg-white rounded-md py-1.5 px-2.5 shadow-sm">
             <div className="flex items-center justify-between">
               <p className="text-sm text-gray-500 font-medium">DOI</p>


### PR DESCRIPTION
This PR adds a name parameter to the metadata component. Since the function and garden pages are looking similar, I think this help keep users oriented as they click around the site.

**Before**:
<img width="416" alt="image" src="https://github.com/user-attachments/assets/da6ce8fa-a7ae-446d-94b6-14a2d0c8daa5" />

**After**
<img width="416" alt="image" src="https://github.com/user-attachments/assets/7bdb2186-d04a-46e0-b832-0e7bcb0729e6" />

<img width="423" alt="image" src="https://github.com/user-attachments/assets/42f886b2-a1c6-438d-96c8-148a37998060" />
