### PR TITLE
Allow garden devs to edit any editable entity

### DIFF
--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -24,6 +24,8 @@ import { GardenTabbedSection } from "./GardenTabbedSection";
 import { GardenMetadataSidebar } from "./GardenMetadataSidebar";
 import { EditableTitle } from "@/components/shared/metadata";
 
+import { SUPER_USERS } from "@/utils/utils";
+
 interface GardenContentProps {
   garden: Garden;
   ownsThisGarden: boolean;
@@ -115,7 +117,10 @@ const GardenPage = () => {
     return <TombstonePage garden={garden} />;
   }
 
-  const ownsThisGarden = auth.isAuthenticated && garden.owner_identity_id === auth?.authorization?.user?.sub;
+  const isSuperUser = SUPER_USERS.includes(auth?.authorization?.user?.sub)
+  console.log(`User ID: ${auth?.authorization?.user?.sub}`)
+  console.log(`Is Super User: ${isSuperUser}`);
+  const ownsThisGarden = auth?.isAuthenticated && (garden.owner_identity_id === auth?.authorization?.user?.sub || isSuperUser);
 
   return (
     <MaterialsProvider garden={garden} refetchGarden={async () => { await refetch(); }}>

--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -118,8 +118,6 @@ const GardenPage = () => {
   }
 
   const isSuperUser = SUPER_USERS.includes(auth?.authorization?.user?.sub)
-  console.log(`User ID: ${auth?.authorization?.user?.sub}`)
-  console.log(`Is Super User: ${isSuperUser}`);
   const ownsThisGarden = auth?.isAuthenticated && (garden.owner_identity_id === auth?.authorization?.user?.sub || isSuperUser);
 
   return (

--- a/garden/src/features/modal/components/ModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/ModalFunctionPage.tsx
@@ -19,6 +19,7 @@ import ModalAssociatedMaterials from "@/features/materials/components/ModalAssoc
 import { FunctionMetadataSidebar } from "./FunctionMetadataSidebar";
 import { EditableCodeField } from "@/components/EditableCodeField";
 import { EditableMetadataField, EditableTitle } from "@/components/shared/metadata";
+import { SUPER_USERS } from "@/utils/utils";
 
 // Extend ModalFunction type to include owner_identity_id
 type ModalFunctionWithOwner = ModalFunction & {
@@ -30,7 +31,8 @@ const ModalFunctionPage = () => {
   const { data: modalFunction, isError, isLoading } = useGetModalFunction(id);
   const { data: garden, isLoading: isGardenLoading } = gardenDOI ? useGetGarden(gardenDOI) : { data: undefined, isLoading: false };
   const auth = useGlobusAuth();
-  const ownsThisFunction = auth.isAuthenticated && modalFunction?.owner_identity_id === auth?.authorization?.user?.sub;
+  const isSuperUser = SUPER_USERS.includes(auth.authorization?.user?.sub);
+  const ownsThisFunction = auth.isAuthenticated && (modalFunction?.owner_identity_id === auth?.authorization?.user?.sub || isSuperUser);
 
   if (isLoading || (gardenDOI && isGardenLoading)) return <LoadingOverlay />;
 

--- a/garden/src/utils/utils.ts
+++ b/garden/src/utils/utils.ts
@@ -1,0 +1,6 @@
+export const SUPER_USERS: string[] = [
+    "c8741264-d274-11e5-bee7-f30dff9f1ea8", // Ben
+    "6c9e223f-c215-4c26-9abb-262dbce0001c", // Will
+    "76024960-c68b-4fec-8cb8-b65b096f18da", // Owen
+    "e9a17e09-657b-4087-a719-241ab72b1d9b", // Hayden
+];


### PR DESCRIPTION
This PR is a first pass at allowing the garden dev team to have super-user abilities to edit any garden, function, or related material.

**A Garden I don't own (note the edit icons are visible)**:
<img width="1241" alt="image" src="https://github.com/user-attachments/assets/01ddd7d5-396b-46ca-b245-38b10003bd79" />


This is accomplished using a hard-coded list of UUIDs that are "SUPER_USERS". This is needed to render the editing functionality on the garden and function pages. This works great, but without a super user list on the backend, the patch requests get rejected. A backend PR that supports this is here: https://github.com/Garden-AI/garden-backend/pull/265)