### PR TITLE
Add function hardware spec to function cards and metadata sidebar

### DIFF
--- a/garden/src/features/gardens/components/ModalFunctionBox.tsx
+++ b/garden/src/features/gardens/components/ModalFunctionBox.tsx
@@ -1,7 +1,7 @@
 import { ModalFunction } from "@/types";
 import { useNavigate } from "react-router-dom";
 import { Card, CardHeader, CardTitle, CardFooter, MarkdownCardContent } from "@/components/shadcn/card";
-import { FunctionSquare } from "lucide-react";
+import { FunctionSquare, Cpu } from "lucide-react";
 
 interface ModalFunctionBoxProps {
   modalFunction: ModalFunction;
@@ -37,26 +37,36 @@ const ModalFunctionBox = ({ modalFunction, gardenDoi }: ModalFunctionBoxProps) =
         content={modalFunction.description || "No description available"}
       />
       
-      {modalFunction.tags && modalFunction.tags.length > 0 && (
-        <CardFooter className="px-5 py-3 border-t border-gray-100 bg-gray-50/80 flex items-center">
-          <div className="flex gap-2 text-gray-600 text-xs">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-              className="h-4 w-4"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z"
-              />
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 6h.008v.008H6V6z" />
-            </svg>
-            <span>{modalFunction.tags.join(", ")}</span>
-          </div>
+      {(modalFunction.tags && modalFunction.tags.length > 0 || modalFunction.hardware_spec?.gpus) && (
+        <CardFooter className="px-5 py-3 border-t border-gray-100 bg-gray-50/80 flex flex-row items-center">
+          {/* Tags Section */}
+          {modalFunction.tags && modalFunction.tags.length > 0 && (
+            <div className="flex gap-2 text-gray-600 text-xs items-center">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={1.5}
+                stroke="currentColor"
+                className="h-4 w-4"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M9.568 3H5.25A2.25 2.25 0 003 5.25v4.318c0 .597.237 1.17.659 1.591l9.581 9.581c.699.699 1.78.872 2.607.33a18.095 18.095 0 005.223-5.223c.542-.827.369-1.908-.33-2.607L11.16 3.66A2.25 2.25 0 009.568 3z"
+                />
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 6h.008v.008H6V6z" />
+              </svg>
+              <span>{modalFunction.tags.join(", ")}</span>
+            </div>
+          )}
+          {/* Hardware Spec Section */}
+          {modalFunction.hardware_spec?.gpus && (
+             <div className="flex gap-2 text-gray-600 text-xs items-center ml-auto">
+               <Cpu className="h-4 w-4 flex-shrink-0"/>
+               <span>GPU: {modalFunction.hardware_spec.gpus}</span>
+             </div>
+          )}
         </CardFooter>
       )}
     </Card>

--- a/garden/src/features/modal/components/FunctionMetadataSidebar.tsx
+++ b/garden/src/features/modal/components/FunctionMetadataSidebar.tsx
@@ -20,6 +20,26 @@ export const FunctionMetadataSidebar = ({
             modalFunction: updateData,
         });
     };
+
+    // Helper function to format hardware specifications
+    const formatHardwareSpec = (spec: { [key: string]: string } | undefined | null): string[] => {
+        if (!spec) {
+            return [];
+        }
+        return Object.entries(spec).map(([key, value]) => {
+            let displayKey = key;
+            if (key.toLowerCase() === 'gpus' || key.toLowerCase() === 'cpu') {
+                displayKey = key.toUpperCase();
+            } else if (key.toLowerCase() === 'memory') {
+                displayKey = key.charAt(0).toUpperCase() + key.slice(1).toLowerCase();
+            }
+            if(!value) {
+              value = "Not Specified";
+            }
+            return `${displayKey}: ${value}`;
+        });
+    };
+
     return (
         <Metadata name={"Function"} entity={modalFunction} ownsThisEntity={ownsThisFunction}>
           <div className="group border border-transparent bg-white rounded-md py-1.5 px-2.5 shadow-sm">
@@ -81,6 +101,19 @@ export const FunctionMetadataSidebar = ({
             isArray={true}
             onUpdate={updateFunction}
           />
+
+          {/* Add EditableMetadataField for Hardware Specifications (Read-Only) */}
+          <EditableMetadataField
+            label="Hardware Specifications"
+            helpText="Compute resources allocated for the function"
+            value={formatHardwareSpec(modalFunction.hardware_spec)}
+            fieldName="hardware_spec"
+            entity={modalFunction}
+            ownsThisEntity={false}
+            isArray={true}
+            onUpdate={updateFunction}
+          />
+
         </Metadata>
     );
 }

--- a/garden/src/types/backend-schema.ts
+++ b/garden/src/types/backend-schema.ts
@@ -280,23 +280,6 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/modal-invocations": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Invoke Modal Fn */
-        post: operations["invoke_modal_fn_modal_invocations_post"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
     "/modal-invocations/async": {
         parameters: {
             query?: never;
@@ -1418,8 +1401,6 @@ export interface components {
             title: string;
             /** Authors */
             authors?: string[];
-            /** Owner */
-            owner: string,
             /** Contributors */
             contributors?: string[];
             /** Doi */
@@ -1461,6 +1442,8 @@ export interface components {
              * @default false
              */
             is_archived: boolean;
+            /** Owner */
+            owner: string;
             /**
              * Owner Identity Id
              * Format: uuid
@@ -1865,8 +1848,6 @@ export interface components {
         };
         /** ModalFunctionMetadataResponse */
         ModalFunctionMetadataResponse: {
-            /** Owner */
-            owner: string;
             /**
              * Is Archived
              * @default false
@@ -1918,6 +1899,17 @@ export interface components {
             id: number;
             /** Modal App Id */
             modal_app_id: number;
+            /** Owner */
+            owner: string;
+            /**
+             * Owner Identity Id
+             * Format: uuid
+             */
+            owner_identity_id: string;
+            /** Hardware Spec */
+            hardware_spec: {
+                [key: string]: string;
+            };
         };
         /** ModalFunctionPatchRequest */
         ModalFunctionPatchRequest: {
@@ -1973,12 +1965,6 @@ export interface components {
             args_kwargs_serialized?: string | null;
             /** Args Blob Id */
             args_blob_id?: string | null;
-        };
-        /** ModalInvocationResponse */
-        ModalInvocationResponse: {
-            /** Data Format */
-            data_format: number;
-            result: components["schemas"]["_ModalGenericResult"];
         };
         /** NameIdentifier */
         NameIdentifier: {
@@ -3223,39 +3209,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": unknown;
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
-    invoke_modal_fn_modal_invocations_post: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ModalInvocationRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ModalInvocationResponse"];
                 };
             };
             /** @description Validation Error */


### PR DESCRIPTION
This PR adds a functions hardware spec to the metadata sidebar, as well as the GPU to the function cards.

Depends on: https://github.com/Garden-AI/garden-backend/pull/267

<img width="410" alt="image" src="https://github.com/user-attachments/assets/06634e1c-93b9-4c8a-9a26-45a6a19d7443" />


<img width="783" alt="image" src="https://github.com/user-attachments/assets/d2aa6a5e-86ff-41a9-8e77-4a790a4a7e75" />

## Tested
Manually