### PR TITLE
Add Gardeners to filter options on search page

### DIFF
--- a/garden/src/features/search/api/useSearchGardens.ts
+++ b/garden/src/features/search/api/useSearchGardens.ts
@@ -31,13 +31,16 @@ export const transformSearchResultToGardens = (searchResult?: GardenSearchRespon
 };
 
 export const transformSearchParamsToSearchRequest = (searchParams: URLSearchParams): any => {
-  const filterKeys = ["year", "authors", "tags"];
+  const filterKeys = ["year", "model_authors", "gardeners", "tags"];
   const userFilters: GardenSearchFilter[] =
     filterKeys
       .filter((key) => searchParams.has(key))
       .map((key) => {
+        let field_name = key;
+        if (key === "model_authors") field_name = "authors";
+        if (key === "gardeners") field_name = "owner";
         return {
-          field_name: key,
+          field_name: field_name,
           values: searchParams.get(key)!.split(",").map(decodeURIComponent),
         };
       }) || [];

--- a/garden/src/features/search/components/Filters.tsx
+++ b/garden/src/features/search/components/Filters.tsx
@@ -46,7 +46,7 @@ const SearchFilters = ({
               return (
                 <AccordionItem key={facet.name} value={facet.name}>
                   <AccordionTrigger>
-                    <Label className="capitalize">{facet.name}</Label>
+                    <Label className="capitalize">{facet.name.split("_").join(" ")}</Label>
                   </AccordionTrigger>
                   <AccordionContent className="pl-2">
                     {facet?.values?.slice(0, 7).map((bucket, index) => (

--- a/garden/src/features/search/hooks/useSearchResults.ts
+++ b/garden/src/features/search/hooks/useSearchResults.ts
@@ -8,7 +8,7 @@ import {
 import { Garden, GardenSearchRequest } from "@/types";
 
 type SortOrder = "asc" | "desc" | "relevance" | null;
-const filterKeys = ["tags", "authors", "year"];
+const filterKeys = ["tags", "model_authors", "gardeners", "year"];
 
 interface GardenSearchResult {
   total: number;


### PR DESCRIPTION
Resolves: #312 

This PR adds the ability to filter search results by Gardener.

Depends on: https://github.com/Garden-AI/garden-backend/pull/271

<img width="279" alt="image" src="https://github.com/user-attachments/assets/31df2eaf-2604-4506-b4c2-026b149c2f84" />
