### PR TITLE
fix: missing edit button on Garden description for super users

### DIFF
--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -76,7 +76,7 @@ const GardenContent = ({ garden, ownsThisGarden, isNewlyCreated }: GardenContent
               </div>
             </div>
 
-            <GardenDescription garden={garden} />
+            <GardenDescription garden={garden} ownsThisGarden={ownsThisGarden}/>
 
             {/* Tabbed Section */}
             <div className="mt-4">

--- a/garden/src/features/gardens/components/garden-page/GardenDescription.tsx
+++ b/garden/src/features/gardens/components/garden-page/GardenDescription.tsx
@@ -5,12 +5,11 @@ import { EditableMetadataField } from "@/components/shared/metadata";
 
 interface GardenDescriptionProps {
   garden: Garden;
+  ownsThisGarden: boolean,
 }
 
-const GardenDescription = ({ garden }: GardenDescriptionProps) => {
-  const { mutateAsync: updateGarden } = usePatchGarden();
-  const auth = useGlobusAuth();
-  const ownsThisGarden = auth.isAuthenticated && garden.owner_identity_id === auth?.authorization?.user?.sub;
+const GardenDescription = ({ garden, ownsThisGarden }: GardenDescriptionProps) => {
+  const { mutateAsync: updateGarden} = usePatchGarden();
 
   return (
     <div className="space-y-3 py-2">


### PR DESCRIPTION
This PR fixes a small bug where the edit icon on Garden descriptions wasn't being rendered for super users.

**Before**
<img width="838" alt="image" src="https://github.com/user-attachments/assets/a9acb082-ea56-4397-920c-f30a96ccf720" />


**After**
<img width="808" alt="image" src="https://github.com/user-attachments/assets/1bd2df3d-60ba-4db6-8e1c-c3d2a98fc984" />
