### PR TITLE
Fix to enable changing notebook link

### DIFF
--- a/garden/src/features/materials/components/ModalAssociatedMaterials.tsx
+++ b/garden/src/features/materials/components/ModalAssociatedMaterials.tsx
@@ -380,8 +380,7 @@ const AssociatedMaterials = ({ resource, ownsThisFunction }: AssociatedMaterials
                           parentFunction: resource,
                           parentDoi: resource.doi || undefined
                         }}
-                        onUpdate={async () => {
-                          const updatedNotebook = notebooks[index];
+                        onUpdate={async (updatedNotebook) => {
                           await handleUpdateMaterial('notebooks', index, updatedNotebook);
                         }}
                         onDelete={() => handleDeleteMaterial('notebooks', index)}


### PR DESCRIPTION
I was trying to change the link to an example notebook but I couldn't. I noticed that the PATCH request had the old notebook link in it. This fix passes

I admit that I don't yet understand the ModalAssociatedMaterials component too deeply, so this is a quick and dirty fix. (Could this break other things? Not sure, but wanted to get this link changed)