### PR TITLE
Create standalone model deployment creation flow

### DIFF
--- a/garden/src/app/router.tsx
+++ b/garden/src/app/router.tsx
@@ -15,8 +15,8 @@ import SearchPage from "@/features/search/components/SearchPage";
 import TeamsPage from "@/features/team/components/TeamsPage";
 import UserProfilePage from "@/features/users/components/UserProfilePage";
 import { useGlobusAuth } from "@globus/react-auth-context";
-import { ModelDeploymentDetails } from "@/features/users/components/model-deployments/ModelDeploymentDetails";
 import ModelDeploymentPage from "@/features/users/components/model-deployments/ModelDeploymentPage";
+import ModalAppUploadPage from "@/features/modal/components/ModalAppUploadPage";
 
 const Router: React.FC = () => {
   return (
@@ -45,6 +45,10 @@ const Router: React.FC = () => {
         {/* Modal Routes */}
         <Route path="modal-functions">
           <Route path=":id" element={<ModalFunctionPage />} />
+        </Route>
+
+        <Route element={<PrivateRoutes />}>
+          <Route path="modal-app/create" element={<ModalAppUploadPage />} />
         </Route>
 
         {/* Model Deployment Routes */}

--- a/garden/src/features/gardens/components/create/CreateGardenPage.tsx
+++ b/garden/src/features/gardens/components/create/CreateGardenPage.tsx
@@ -1,11 +1,11 @@
 import { CreateGardenForm } from "./CreateGardenForm";
-import { UploadModalAppForm } from "@/features/modal/components/UploadModalAppForm";
+import { ModalAppForm } from "@/features/modal/components/ModalAppForm";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { Button } from "@/components/shadcn/button";
 import { useGetGlobusGroups } from "@/features/gardens/api/useGetGlobusGroups";
 
 const CreateGardenPage = () => {
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const modalAppId = searchParams.get("modalAppId");
 
   const { data: groups } = useGetGlobusGroups();
@@ -20,7 +20,13 @@ const CreateGardenPage = () => {
       {modalAppId ? (
         <CreateGardenForm modalAppId={modalAppId} />
       ) : (
-        <UploadModalAppForm />
+        <ModalAppForm 
+          showOverallProgress={true}
+          currentPhase={1}
+          // Don't show success screen since we'll redirect immediately
+          showSuccessScreen={false}
+          // Default navigation behavior will set search params to include modalAppId
+        />
       )}
     </div>
   );

--- a/garden/src/features/modal/api/useModalAppForm.tsx
+++ b/garden/src/features/modal/api/useModalAppForm.tsx
@@ -9,6 +9,7 @@ import { useSearchParams, useNavigate } from "react-router-dom";
 import { ApiError } from "@/features/gardens/utils/garden.utils";
 import { ModalFileMetadataResponse } from "@/types";
 import { ValidationError, DeploymentError } from "./useModalAppUpload";
+import { useQueryClient } from "@tanstack/react-query";
 
 export const modalAppFormSchema = z.object({
   file_contents: z.string().min(1, "Modal file is required"),
@@ -43,6 +44,7 @@ export const useModalAppForm = ({
   const auth = useGlobusAuth();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
+  const queryClient = useQueryClient();
   const uuid = auth?.authorization?.user?.sub;
   const [file, setFile] = useState<File | null>(null);
   const [modalMetadata, setModalMetadata] = useState<ModalFileMetadataResponse | null>(null);
@@ -297,6 +299,9 @@ export const useModalAppForm = ({
       const appId = await deployModalApp(data.file_contents, updatedMetadata, uuid);
       setDeployedAppId(appId);
       toast.success("Modal app deployed successfully!");
+      
+      // Invalidate the modelDeployments query to ensure fresh data is fetched
+      queryClient.invalidateQueries({ queryKey: ["modelDeployments"] });
       
       if (showSuccessScreen) {
         // Show success screen in the form (don't navigate away immediately)

--- a/garden/src/features/modal/api/useModalAppForm.tsx
+++ b/garden/src/features/modal/api/useModalAppForm.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { useModalAppUpload } from "./useModalAppUpload";
 import { useGlobusAuth } from "@globus/react-auth-context";
 import { toast } from "sonner";
-import { useSearchParams } from "react-router-dom";
+import { useSearchParams, useNavigate } from "react-router-dom";
 import { ApiError } from "@/features/gardens/utils/garden.utils";
 import { ModalFileMetadataResponse } from "@/types";
 import { ValidationError, DeploymentError } from "./useModalAppUpload";
@@ -19,19 +19,38 @@ export const modalAppFormSchema = z.object({
 
 export type ModalAppFormValues = z.infer<typeof modalAppFormSchema>;
 
+export interface UseModalAppFormOptions {
+  /**
+   * Function called after successful deployment
+   * @param appId The ID of the deployed app
+   */
+  onDeploymentSuccess?: (appId: number) => void;
+  /**
+   * Whether to show a success screen after deployment
+   * @default false
+   */
+  showSuccessScreen?: boolean;
+}
+
 /**
  * Hook for managing the Modal app upload form state and submission
  * Handles file reading, form state, and integration with the Modal API
  */
-export const useModalAppForm = () => {
+export const useModalAppForm = ({
+  onDeploymentSuccess,
+  showSuccessScreen = false,
+}: UseModalAppFormOptions = {}) => {
   const auth = useGlobusAuth();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const uuid = auth?.authorization?.user?.sub;
-  const [, setSearchParams] = useSearchParams();
   const [file, setFile] = useState<File | null>(null);
   const [modalMetadata, setModalMetadata] = useState<ModalFileMetadataResponse | null>(null);
   const [isValidating, setIsValidating] = useState(false);
   const [isDeploying, setIsDeploying] = useState(false);
   const [isValidated, setIsValidated] = useState(false);
+  const [isDeploymentComplete, setIsDeploymentComplete] = useState(false);
+  const [deployedAppId, setDeployedAppId] = useState<number | null>(null);
   const [validationError, setValidationError] = useState<ValidationError | null>(null);
   const [deploymentError, setDeploymentError] = useState<DeploymentError | null>(null);
 
@@ -54,6 +73,18 @@ export const useModalAppForm = () => {
     },
   });
 
+  // Reset the form state
+  const resetForm = () => {
+    setFile(null);
+    setModalMetadata(null);
+    setIsValidated(false);
+    setIsDeploymentComplete(false);
+    setDeployedAppId(null);
+    setValidationError(null);
+    setDeploymentError(null);
+    form.reset();
+  };
+
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFile = e.target.files?.[0];
     if (!selectedFile) return;
@@ -73,6 +104,8 @@ export const useModalAppForm = () => {
     
     // Reset modalMetadata when a new file is selected
     setModalMetadata(null);
+    setIsDeploymentComplete(false);
+    setDeployedAppId(null);
     
     setFile(selectedFile);
     setIsValidating(true);
@@ -262,10 +295,20 @@ export const useModalAppForm = () => {
       };
       
       const appId = await deployModalApp(data.file_contents, updatedMetadata, uuid);
+      setDeployedAppId(appId);
       toast.success("Modal app deployed successfully!");
       
-      // Navigate to the garden creation form with just the modal app ID
-      setSearchParams({ modalAppId: appId.toString() });
+      if (showSuccessScreen) {
+        // Show success screen in the form (don't navigate away immediately)
+        setIsDeploymentComplete(true);
+      }
+      
+      if (onDeploymentSuccess) {
+        onDeploymentSuccess(appId);
+      } else {
+        // Default behavior - navigate to garden creation with the modal app ID
+        setSearchParams({ modalAppId: appId.toString() });
+      }
     } catch (error: any) {
       setDeploymentError(error as DeploymentError);
     } finally {
@@ -280,10 +323,13 @@ export const useModalAppForm = () => {
     handleFunctionMetadataChange,
     handleValidate,
     handleSubmit: form.handleSubmit(handleSubmit),
+    resetForm,
     modalMetadata,
     isValidating,
     isDeploying,
     isValidated,
+    isDeploymentComplete,
+    deployedAppId,
     validationError,
     deploymentError
   };

--- a/garden/src/features/modal/components/FormActions.tsx
+++ b/garden/src/features/modal/components/FormActions.tsx
@@ -32,7 +32,7 @@ export const FormActions = ({
         type="submit" 
         disabled={!isValidated || isDeploying}
       >
-        {isDeploying ? "Deploying..." : "Deploy Modal App & Continue"}
+        {isDeploying ? "Deploying..." : "Deploy Modal App"}
       </Button>
     </div>
   </div>

--- a/garden/src/features/modal/components/ModalAppForm.tsx
+++ b/garden/src/features/modal/components/ModalAppForm.tsx
@@ -1,0 +1,158 @@
+import { Form } from "@/components/shadcn/form";
+import { useModalAppForm, UseModalAppFormOptions } from "@/features/modal/api/useModalAppForm";
+import { FileUploadSection } from "@/features/modal/components/FileUploadSection";
+import { DetectedAppCard } from "@/features/modal/components/DetectedAppCard";
+import { FunctionMetadataEditor } from "@/features/modal/components/FunctionMetadataEditor";
+import { FormActions } from "@/features/modal/components/FormActions";
+import { DeploymentLoading } from "@/features/modal/components/DeploymentLoading";
+import { DeploymentNotice } from "@/features/modal/components/DeploymentNotice";
+import { ValidationErrorAlert } from "@/features/modal/components/alerts/ValidationErrorAlert";
+import { DeploymentErrorAlert } from "@/features/modal/components/alerts/DeploymentErrorAlert";
+import { OverallProgress } from "@/components/progress/OverallProgress";
+import { ProgressSteps } from "@/features/modal/components/progress/ProgressSteps";
+import { Alert, AlertDescription, AlertTitle } from "@/components/shadcn/alert";
+import { CheckCircle2 } from "lucide-react";
+import { Button } from "@/components/shadcn/button";
+import { Link } from "react-router-dom";
+
+export interface ModalAppFormProps extends UseModalAppFormOptions {
+  /**
+   * Whether to show the overall progress bar (used in multi-step flows like garden creation)
+   * @default false 
+   */
+  showOverallProgress?: boolean;
+  /**
+   * The current phase in a multi-step flow
+   * @default 1
+   */
+  currentPhase?: number;
+  /**
+   * URL for the "View My Deployments" button in success state
+   * @default "/user"
+   */
+  viewDeploymentsUrl?: string;
+}
+
+export const ModalAppForm = ({
+  showOverallProgress = false,
+  currentPhase = 1,
+  viewDeploymentsUrl = "/user",
+  ...hookOptions
+}: ModalAppFormProps) => {
+  const {
+    form,
+    file,
+    handleFileChange,
+    handleFunctionMetadataChange,
+    handleValidate,
+    handleSubmit,
+    resetForm,
+    modalMetadata,
+    isValidating,
+    isDeploying,
+    isValidated,
+    isDeploymentComplete,
+    deployedAppId,
+    validationError,
+    deploymentError
+  } = useModalAppForm(hookOptions);
+
+  // Determine the current step based on state
+  const getCurrentStep = () => {
+    if (isDeploymentComplete) return 5; // Deployment complete
+    if (isDeploying) return 4; // Deploying stage
+    if (isValidated && modalMetadata) return 3; // Edit details stage
+    if (isValidating) return 2; // Validation stage
+    if (file) return 2; // File uploaded, automatic validation will happen
+    return 1; // Initial upload stage
+  };
+
+  const currentStep = getCurrentStep();
+
+  return (
+    <>
+      {showOverallProgress && (
+        <OverallProgress 
+          currentPhase={currentPhase} 
+          isCompleted={isDeploymentComplete || isDeploying || isValidated} 
+        />
+      )}
+      
+      <div className="rounded-lg border bg-white p-6 shadow-sm">
+        <h2 className="mb-6 text-xl font-bold">Upload and Deploy Modal App</h2>
+        
+        {/* Detailed Progress Steps */}
+        <ProgressSteps currentStep={currentStep} />
+        
+        {isDeploymentComplete ? (
+          <div className="py-12">
+            <Alert className="mb-6 bg-green-50 border-green-200">
+              <CheckCircle2 className="h-5 w-5 text-green-600" />
+              <AlertTitle className="text-green-800 font-bold">Deployment Successful!</AlertTitle>
+              <AlertDescription className="text-green-700">
+                Your Modal App has been successfully deployed and is ready to use.
+              </AlertDescription>
+            </Alert>
+            <div className="flex justify-center space-x-4">
+              {deployedAppId && (
+                <Button asChild variant="default">
+                  <Link to={`/model-deployments/${deployedAppId}`}>View Deployment</Link>
+                </Button>
+              )}
+              <Button asChild variant="secondary">
+                <Link to={viewDeploymentsUrl}>View All Deployments</Link>
+              </Button>
+              <Button variant="outline" onClick={resetForm}>
+                Deploy Another App
+              </Button>
+            </div>
+          </div>
+        ) : isDeploying ? (
+          <>
+            {/* Centralized loading display during deployment */}
+            <DeploymentLoading isVisible={true} />
+            <DeploymentNotice isVisible={true} />
+          </>
+        ) : (
+          <Form {...form}>
+            <form onSubmit={handleSubmit} className="space-y-6">
+              {/* File Upload Section */}
+              <FileUploadSection 
+                handleFileChange={handleFileChange}
+                isValidating={isValidating}
+                isDeploying={isDeploying}
+                isValidated={isValidated}
+                file={file}
+              />
+              
+              {/* Error Displays */}
+              {validationError && <ValidationErrorAlert error={validationError} />}
+              {deploymentError && <DeploymentErrorAlert error={deploymentError} />}
+              
+              {/* Modal App Details */}
+              {modalMetadata && (
+                <div className="space-y-6">
+                  <DetectedAppCard metadata={modalMetadata} />
+                  <FunctionMetadataEditor 
+                    form={form} 
+                    metadata={modalMetadata} 
+                    handleFunctionMetadataChange={handleFunctionMetadataChange} 
+                  />
+                </div>
+              )}
+              
+              <FormActions 
+                file={file}
+                isValidated={isValidated}
+                isValidating={isValidating}
+                isDeploying={isDeploying}
+                handleValidate={handleValidate}
+                resetForm={resetForm}
+              />
+            </form>
+          </Form>
+        )}
+      </div>
+    </>
+  );
+}; 

--- a/garden/src/features/modal/components/ModalAppUploadPage.tsx
+++ b/garden/src/features/modal/components/ModalAppUploadPage.tsx
@@ -1,0 +1,21 @@
+import { ModalAppForm } from "./ModalAppForm";
+
+const ModalAppUploadPage = () => {
+
+  return (
+    <div className="mx-auto max-w-6xl px-8 py-16 font-display">
+      <div className="mb-12 flex items-center space-x-8">
+        <div className="space-y-4">
+          <h1 className="text-4xl font-light">Create a New Modal App Deployment</h1>
+        </div>
+      </div>
+      <ModalAppForm 
+        showOverallProgress={false}
+        showSuccessScreen={true}
+        viewDeploymentsUrl="/user?tab=model-deployments"
+      />
+    </div>
+  );
+};
+
+export default ModalAppUploadPage; 

--- a/garden/src/features/modal/components/progress/ProgressSteps.tsx
+++ b/garden/src/features/modal/components/progress/ProgressSteps.tsx
@@ -25,7 +25,7 @@ export const ProgressSteps = ({ currentStep }: ProgressStepsProps) => {
         {/* Progress Bar Fill - This shows completed steps with primary color */}
         <div 
           className="absolute left-0 top-4 h-0.5 bg-primary transition-all duration-300 ease-in-out"
-          style={{ width: `${(currentStep - 1) / (steps.length - 1) * 100}%` }}
+          style={{ width: `${(currentStep - 1) / (steps.length - 1) * 75}%` }}
         ></div>
         
         {/* Steps */}

--- a/garden/src/features/users/components/ModelDeployments.tsx
+++ b/garden/src/features/users/components/ModelDeployments.tsx
@@ -54,7 +54,7 @@ interface ModelDeploymentsProps {
 
 export const ModelDeployments = ({ modelDeployments }: ModelDeploymentsProps) => {
     const navigate = useNavigate();
-    
+
     const handleCreateDeployment = () => {
         navigate("/modal-app/create");
     };
@@ -62,18 +62,18 @@ export const ModelDeployments = ({ modelDeployments }: ModelDeploymentsProps) =>
     return (
         <div>
             <div className="flex justify-end">
-            <Button onClick={handleCreateDeployment}>
                 <TooltipProvider>
-               <Tooltip>
-                 <TooltipTrigger asChild>
-                    <Plus></Plus> 
-                 </TooltipTrigger>
-                 <TooltipContent>
-                   <p>Create a new Deployment</p>
-                 </TooltipContent>
-               </Tooltip>
+                    <Tooltip delayDuration={100}>
+                        <TooltipTrigger asChild>
+                            <Button onClick={handleCreateDeployment} size={"sm"} variant={"outline"} aria-description="Create a new model deployment">
+                                <Plus></Plus>
+                            </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            <p>Create a new Deployment</p>
+                        </TooltipContent>
+                    </Tooltip>
                 </TooltipProvider>
-            </Button>
             </div>
             <ModelDeploymentsTable columns={columns} data={modelDeployments} />
         </div>

--- a/garden/src/features/users/components/ModelDeployments.tsx
+++ b/garden/src/features/users/components/ModelDeployments.tsx
@@ -1,6 +1,10 @@
 import { ColumnDef } from "@tanstack/react-table";
 import { StatusHeader } from "./model-deployments/StatusHeader";
 import { ModelDeploymentsTable } from "./model-deployments/ModelDeploymentsTable";
+import { Button } from "@/components/shadcn/button";
+import { useNavigate } from "react-router-dom";
+import { Plus } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/tooltip";
 
 export interface ModelDeployment {
     name: string,
@@ -49,8 +53,28 @@ interface ModelDeploymentsProps {
 }
 
 export const ModelDeployments = ({ modelDeployments }: ModelDeploymentsProps) => {
+    const navigate = useNavigate();
+    
+    const handleCreateDeployment = () => {
+        navigate("/modal-app/create");
+    };
+
     return (
         <div>
+            <div className="flex justify-end">
+            <Button onClick={handleCreateDeployment}>
+                <TooltipProvider>
+               <Tooltip>
+                 <TooltipTrigger asChild>
+                    <Plus></Plus> 
+                 </TooltipTrigger>
+                 <TooltipContent>
+                   <p>Create a new Deployment</p>
+                 </TooltipContent>
+               </Tooltip>
+                </TooltipProvider>
+            </Button>
+            </div>
             <ModelDeploymentsTable columns={columns} data={modelDeployments} />
         </div>
     )

--- a/garden/src/features/users/components/UserProfilePage.tsx
+++ b/garden/src/features/users/components/UserProfilePage.tsx
@@ -2,8 +2,12 @@ import UserProfileTabs from "./UserProfileTabs";
 import UserProfileCard from "./UserProfileCard";
 import { useGetUserInfo } from "../api/useGetUserInfo";
 import { LoadingOverlay } from "@/components/LoadingOverlay";
+import { useSearchParams } from "react-router-dom";
 
 const UserProfilePage = () => {
+  const [searchParams] = useSearchParams();
+  const tab = searchParams.get("tab") as "profile" | "my-gardens" | "saved-gardens" | "model-deployments" | null;
+  
   const {
     data: currUserInfo,
     isLoading: fetchingUserInfoLoading,
@@ -22,7 +26,7 @@ const UserProfilePage = () => {
   return (
     <div className="mt-16 flex h-full min-h-[80vh] w-full flex-row justify-center gap-10 p-10">
       <UserProfileCard />
-      <UserProfileTabs />
+      <UserProfileTabs defaultTab={tab || undefined} />
     </div>
   );
 };

--- a/garden/src/features/users/components/UserProfileTabs.tsx
+++ b/garden/src/features/users/components/UserProfileTabs.tsx
@@ -5,10 +5,14 @@ import SavedGardens from "./SavedGardens";
 import { ModelDeployments } from "./ModelDeployments";
 import { useGetModelDeployments } from "../api/useGetModelDeployments";
 
-const UserProfileTabs = () => {
+interface UserProfileTabsProps {
+  defaultTab?: "profile" | "my-gardens" | "saved-gardens" | "model-deployments";
+}
+
+const UserProfileTabs = ({ defaultTab = "profile" }: UserProfileTabsProps) => {
   const modelDeployments = useGetModelDeployments().data || [];
   return (
-    <Tabs defaultValue="profile" className="w-full font-display">
+    <Tabs defaultValue={defaultTab} className="w-full font-display">
       <TabsList className="h-12 w-full bg-transparent">
         <TabsTrigger
           value="profile"
@@ -28,14 +32,12 @@ const UserProfileTabs = () => {
         >
           Saved Gardens
         </TabsTrigger>
-        {/* Hidden until the feature is more fleshed out 
         <TabsTrigger
           value="model-deployments"
           className="h-full w-full border-b-4 bg-gray-100 hover:border-green hover:bg-gradient-to-b hover:from-gray-100 hover:from-70% hover:to-green data-[state=active]:border-green data-[state=active]:bg-green data-[state=active]:bg-opacity-30"
         >
           Model Deployments
         </TabsTrigger>
-        */}
       </TabsList>
       <div className="min-h-[60vh] flex-grow overflow-auto pt-4 sm:pt-8">
         <TabsContent value="profile">
@@ -53,13 +55,11 @@ const UserProfileTabs = () => {
             <SavedGardens />
           </div>
         </TabsContent>
-        {/* Hidden until the feature is more fleshed out
         <TabsContent value="model-deployments">
           <div className="px-6">
             <ModelDeployments modelDeployments={modelDeployments}></ModelDeployments>
           </div>
         </TabsContent>
-        */}
       </div>
     </Tabs>
   );

--- a/garden/src/features/users/components/UserProfileTabs.tsx
+++ b/garden/src/features/users/components/UserProfileTabs.tsx
@@ -32,12 +32,14 @@ const UserProfileTabs = ({ defaultTab = "profile" }: UserProfileTabsProps) => {
         >
           Saved Gardens
         </TabsTrigger>
+        {/* hidden until feature is complete
         <TabsTrigger
           value="model-deployments"
           className="h-full w-full border-b-4 bg-gray-100 hover:border-green hover:bg-gradient-to-b hover:from-gray-100 hover:from-70% hover:to-green data-[state=active]:border-green data-[state=active]:bg-green data-[state=active]:bg-opacity-30"
         >
           Model Deployments
         </TabsTrigger>
+        */}
       </TabsList>
       <div className="min-h-[60vh] flex-grow overflow-auto pt-4 sm:pt-8">
         <TabsContent value="profile">
@@ -55,11 +57,13 @@ const UserProfileTabs = ({ defaultTab = "profile" }: UserProfileTabsProps) => {
             <SavedGardens />
           </div>
         </TabsContent>
+        {/* hidden until feature is complete 
         <TabsContent value="model-deployments">
           <div className="px-6">
             <ModelDeployments modelDeployments={modelDeployments}></ModelDeployments>
           </div>
         </TabsContent>
+        */}
       </div>
     </Tabs>
   );

--- a/garden/tests/app/features/modal/components/UploadModalAppForm.test.tsx
+++ b/garden/tests/app/features/modal/components/UploadModalAppForm.test.tsx
@@ -21,10 +21,13 @@ const createValidationResponse = (error: boolean, errorMessage: string) => ({
     handleFunctionMetadataChange: vi.fn(),
     handleValidate: vi.fn(),
     handleSubmit: vi.fn(),
+    resetForm: vi.fn(),
     modalMetadata: null,
     isValidating: false,
     isValidated: error,
     isDeploying: false,
+    isDeploymentComplete: false,
+    deployedAppId: null,
     validationError: error ? {
         message: errorMessage,
         isApiError: false
@@ -66,10 +69,13 @@ const createDeploymentErrorResponse = (errorMessage: string, isTimeout: boolean 
     handleFunctionMetadataChange: vi.fn(),
     handleValidate: vi.fn(),
     handleSubmit: vi.fn(),
+    resetForm: vi.fn(),
     modalMetadata: fakeModalMetadata, // Needs metadata to show deployment happened after validation
     isValidating: false,
     isValidated: true, // Must be true for deployment to have been attempted
     isDeploying: false, // Set to false to show deployment finished (with error)
+    isDeploymentComplete: false,
+    deployedAppId: null,
     validationError: null,
     deploymentError: {
         message: errorMessage,
@@ -91,10 +97,13 @@ const createDeployingResponse = () => ({
     handleFunctionMetadataChange: vi.fn(),
     handleValidate: vi.fn(),
     handleSubmit: vi.fn(),
+    resetForm: vi.fn(),
     modalMetadata: fakeModalMetadata,
     isValidating: false,
     isValidated: true,
     isDeploying: true, // This is what we're testing - the component in deploying state
+    isDeploymentComplete: false,
+    deployedAppId: null,
     validationError: null,
     deploymentError: null,
 });

--- a/garden/tests/app/features/modal/components/UploadModalAppForm.test.tsx
+++ b/garden/tests/app/features/modal/components/UploadModalAppForm.test.tsx
@@ -140,7 +140,7 @@ describe("UploadModalAppForm", () => {
             );
 
             // Core assertion: After successful validation, the deploy button should be enabled
-            const deployButton = screen.getByRole('button', { name: /Deploy Modal App & Continue/i });
+            const deployButton = screen.getByRole('button', { name: /Deploy Modal App/i });
             expect(deployButton).toBeEnabled();
         });
     });
@@ -212,7 +212,7 @@ describe("UploadModalAppForm", () => {
             );
             
             // Get the deploy button and verify it's enabled
-            const deployButton = screen.getByRole('button', { name: /Deploy Modal App & Continue/i });
+            const deployButton = screen.getByRole('button', { name: /Deploy Modal App/i });
             expect(deployButton).toBeEnabled();
         });
     });


### PR DESCRIPTION
Resolves: #322 

This PR makes it possible to create new model deployments outside of the Garden creation flow:

https://github.com/user-attachments/assets/8eadaa32-1e63-48ab-b297-afafbcbf29e0

On successful deployment the user has the option to view the deployment details, go back to the deployments view, or deploy another app.

This does not affect the 2-phase deployment flow that creates a garden after deploying a model.

## Testing
Manually