### PR TITLE
Create flow for updating model deployments

### DIFF
--- a/garden/src/features/gardens/components/create/CreateGardenForm.tsx
+++ b/garden/src/features/gardens/components/create/CreateGardenForm.tsx
@@ -12,7 +12,7 @@ import { useCreateGardenAndDOI } from "../../api/useCreateGardenAndDOI";
 import { GardenCreateRequest } from "@/types";
 import { ApiError } from "../../utils/garden.utils";
 import { AxiosError } from "axios";
-import { useModalAppMetadata } from "../../api/useModalAppMetadata";
+import { useModalAppMetadata } from "../../../modal/api/useModalAppMetadata";
 import { OverallProgress } from "@/components/progress/OverallProgress";
 import { cn } from "@/utils/form.utils";
 import { CheckCircle2 } from "lucide-react";

--- a/garden/src/features/modal/api/useCreateModalApp.tsx
+++ b/garden/src/features/modal/api/useCreateModalApp.tsx
@@ -1,12 +1,12 @@
 import axios from "@/lib/axios";
 import { useMutation } from "@tanstack/react-query";
 import { AxiosResponse, AxiosError } from "axios";
-import { ModalAppCreateRequest, ModalAppMetadataResponse } from "@/types";
-import { ApiError } from "../utils/garden.utils";
+import { ModalAppCreateRequest, ModalAppMetadataResponse, ModalAppPatchRequest } from "@/types";
+import { ApiError } from "../../gardens/utils/garden.utils";
 
 export const useCreateModalApp = () => {
-  return useMutation<AxiosResponse<ModalAppMetadataResponse>, Error, ModalAppCreateRequest>({
-    mutationFn: createModalApp,
+  return useMutation<AxiosResponse<ModalAppMetadataResponse>, Error, ModalAppCreateRequest | ModalAppPatchRequest>({
+    mutationFn: createOrUpdateModalApp,
   });
 };
 
@@ -21,13 +21,16 @@ export class DeployTimeoutError extends Error {
   }
 }
 
-const createModalApp = async (
-  req: ModalAppCreateRequest,
+export const createOrUpdateModalApp = async (
+  req: ModalAppCreateRequest | ModalAppPatchRequest,
+  update: number = 0,
 ): Promise<AxiosResponse<ModalAppMetadataResponse>> => {
   try {
     // Make the initial request
-    const response = await axios.post(`/modal-apps/async`, req);
-    
+    const response = update ?
+      await axios.patch(`/modal-apps/async/${update}`, req) :
+      await axios.post(`/modal-apps/async`, req);
+
     // Extract the job id from the response
     const appId = response.data.id
 

--- a/garden/src/features/modal/api/useModalAppForm.tsx
+++ b/garden/src/features/modal/api/useModalAppForm.tsx
@@ -31,6 +31,12 @@ export interface UseModalAppFormOptions {
    * @default false
    */
   showSuccessScreen?: boolean;
+
+  /**
+   * Update an existing modal app, otherwise create a new one
+   * @default undefined
+   */
+  toUpdate?: number;
 }
 
 /**
@@ -40,6 +46,7 @@ export interface UseModalAppFormOptions {
 export const useModalAppForm = ({
   onDeploymentSuccess,
   showSuccessScreen = false,
+  toUpdate,
 }: UseModalAppFormOptions = {}) => {
   const auth = useGlobusAuth();
   const navigate = useNavigate();
@@ -59,6 +66,7 @@ export const useModalAppForm = ({
   const {
     validateModalFile,
     deployModalApp,
+    updateModalApp,
     isValidating: useModalAppUploadIsValidating,
     validationError: useModalAppUploadValidationError,
     deploymentError: useModalAppUploadDeploymentError,
@@ -289,16 +297,26 @@ export const useModalAppForm = ({
     try {
       clearErrors();
       window.scrollTo(0, 0);
-      
+
       // Update the metadata with any edited function details
       const updatedMetadata = {
         ...modalMetadata,
         modal_functions: data.modal?.modal_functions || modalMetadata.modal_functions,
       };
       
-      const appId = await deployModalApp(data.file_contents, updatedMetadata, uuid);
+      let appId: number | undefined;
+      if (toUpdate) {
+        appId = await updateModalApp(data.file_contents, toUpdate);
+      } else {
+        appId = await deployModalApp(data.file_contents, updatedMetadata, uuid);
+      }
+      
+      if (appId === undefined) {
+        throw new Error("Failed to deploy Modal app. App ID not returned.");
+      }
+      
       setDeployedAppId(appId);
-      toast.success("Modal app deployed successfully!");
+      toast.success(`Modal app ${toUpdate ? "updated" : "deployed"} successfully!`);
       
       // Invalidate the modelDeployments query to ensure fresh data is fetched
       queryClient.invalidateQueries({ queryKey: ["modelDeployments"] });
@@ -308,14 +326,39 @@ export const useModalAppForm = ({
         setIsDeploymentComplete(true);
       }
       
-      if (onDeploymentSuccess) {
+      if (onDeploymentSuccess && appId !== undefined) {
         onDeploymentSuccess(appId);
+      } else if (toUpdate) {
+        console.log("UPDATED!!");
       } else {
         // Default behavior - navigate to garden creation with the modal app ID
         setSearchParams({ modalAppId: appId.toString() });
       }
     } catch (error: any) {
-      setDeploymentError(error as DeploymentError);
+      // Get the properly formatted error from useModalAppUpload
+      if (useModalAppUploadDeploymentError) {
+        setDeploymentError(useModalAppUploadDeploymentError);
+      } else if (error instanceof ApiError) {
+        setDeploymentError({
+          message: error.message,
+          suggestedFix: error.suggestedFix,
+          isTimeout: false,
+          isApiError: true
+        });
+      } else if (error instanceof Error) {
+        setDeploymentError({
+          message: error.message,
+          isTimeout: false,
+          isApiError: false
+        });
+      } else {
+        // Fallback for unknown error types
+        setDeploymentError({
+          message: "Failed to deploy Modal app. Please try again.",
+          isTimeout: false,
+          isApiError: false
+        });
+      }
     } finally {
       setIsDeploying(false);
     }

--- a/garden/src/features/modal/api/useModalAppMetadata.tsx
+++ b/garden/src/features/modal/api/useModalAppMetadata.tsx
@@ -2,7 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import axios from "@/lib/axios";
 import { useEffect } from "react";
 import { UseFormReturn } from "react-hook-form";
-import { GardenCreateFormData } from "../types/garden.types";
+import { GardenCreateFormData } from "../../gardens/types/garden.types";
 import { useGlobusAuth } from "@globus/react-auth-context";
 import { useGetUserInfo } from "@/features/users/api/useGetUserInfo";
 

--- a/garden/src/features/modal/api/useModalAppUpload.tsx
+++ b/garden/src/features/modal/api/useModalAppUpload.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
 import { useValidateModalFile } from "../../gardens/api/useValidateModalFile";
-import { useCreateModalApp, DeployTimeoutError } from "../../gardens/api/useCreateModalApp";
-import { ModalFileMetadataResponse } from "@/types";
+import { useCreateModalApp, DeployTimeoutError, createOrUpdateModalApp } from "../../modal/api/useCreateModalApp";
+import { ModalAppPatchRequest, ModalFileMetadataResponse } from "@/types";
 import { ApiError } from "../../gardens/utils/garden.utils";
 import { AxiosError } from "axios";
+import instance from "@/lib/axios";
 
 export interface ValidationError {
   message: string;
@@ -25,7 +26,8 @@ interface ExtendedModalFileMetadata extends ModalFileMetadataResponse {
 
 export interface UseModalAppUploadReturn {
   validateModalFile: (fileContents: string) => Promise<ModalFileMetadataResponse | null>;
-  deployModalApp: (fileContents: string, modalMetadata: ModalFileMetadataResponse, ownerIdentityId?: string) => Promise<number>;
+  deployModalApp: (fileContents: string, modalMetadata: ModalFileMetadataResponse, ownerIdentityId?: string) => Promise<number | undefined>;
+  updateModalApp: (fileContents: string, appId: number) => Promise<number | undefined>;
   modalMetadata: ExtendedModalFileMetadata | null;
   isValidating: boolean;
   isDeploying: boolean;
@@ -42,18 +44,49 @@ export const useModalAppUpload = (): UseModalAppUploadReturn => {
   const [modalMetadata, setModalMetadata] = useState<ExtendedModalFileMetadata | null>(null);
   const [validationError, setValidationError] = useState<ValidationError | null>(null);
   const [deploymentError, setDeploymentError] = useState<DeploymentError | null>(null);
-  
+
   const { mutateAsync: validateFile, isPending: isValidating } = useValidateModalFile();
-  const { mutateAsync: createApp, isPending: isDeploying } = useCreateModalApp();
+  const { mutateAsync: createOrUpdateApp, isPending: isDeploying } = useCreateModalApp();
 
   const clearErrors = () => {
     setValidationError(null);
     setDeploymentError(null);
   };
 
+  const handleDeploymentError = async (error: any): Promise<never> => {
+    const isTimeout = error instanceof DeployTimeoutError;
+    let errorMessage = "Failed to deploy Modal app";
+    let suggestedFix: string | undefined = undefined;
+    let isApiError = false;
+
+    if (error instanceof ApiError) {
+      errorMessage = error.message;
+      suggestedFix = error.suggestedFix;
+      isApiError = true;
+    } else if (error instanceof AxiosError) {
+      const apiError = ApiError.fromAxiosError(error);
+      errorMessage = apiError.message;
+      suggestedFix = apiError.suggestedFix;
+      isApiError = true;
+    } else if (error instanceof Error) {
+      errorMessage = error.message;
+    } else if (error && typeof error === 'object' && 'message' in error) {
+      errorMessage = String(error.message);
+    }
+
+    setDeploymentError({
+      message: errorMessage,
+      suggestedFix,
+      isTimeout,
+      isApiError
+    });
+
+    throw error;
+  };
+
   const validateModalFile = async (fileContents: string): Promise<ModalFileMetadataResponse | null> => {
     setValidationError(null);
-    
+
     try {
       const metadata = await validateFile({ file_contents: fileContents });
       setModalMetadata(metadata);
@@ -62,7 +95,7 @@ export const useModalAppUpload = (): UseModalAppUploadReturn => {
       let errorMessage = "Unknown validation error";
       let suggestedFix: string | undefined = undefined;
       let isApiError = false;
-      
+
       if (error instanceof ApiError) {
         errorMessage = error.message;
         suggestedFix = error.suggestedFix;
@@ -70,20 +103,20 @@ export const useModalAppUpload = (): UseModalAppUploadReturn => {
       } else if (error instanceof Error) {
         errorMessage = error.message;
       }
-      
+
       setValidationError({
         message: errorMessage,
         suggestedFix,
         isApiError
       });
-      
+
       return null;
     }
   };
 
-  const deployModalApp = async (fileContents: string, metadata: ModalFileMetadataResponse, ownerIdentityId?: string): Promise<number> => {
+  const deployModalApp = async (fileContents: string, metadata: ModalFileMetadataResponse, ownerIdentityId?: string): Promise<number | undefined> => {
     setDeploymentError(null);
-    
+
     try {
       // Ensure modal_functions are included with any user edits
       const appRequest = {
@@ -95,9 +128,9 @@ export const useModalAppUpload = (): UseModalAppUploadReturn => {
         base_image_name: metadata.base_image_name,
         owner_identity_id: ownerIdentityId,
       };
-      
-      const response = await createApp(appRequest);
-      
+
+      const response = await createOrUpdateApp(appRequest);
+
       // Update the stored metadata with the latest version
       if (modalMetadata) {
         setModalMetadata({
@@ -106,41 +139,34 @@ export const useModalAppUpload = (): UseModalAppUploadReturn => {
           id: response.data.id,
         });
       }
-      
+
       return response.data.id;
     } catch (error) {
-      const isTimeout = error instanceof DeployTimeoutError;
-      let errorMessage = "Failed to deploy Modal app";
-      let suggestedFix: string | undefined = undefined;
-      let isApiError = false;
-      
-      if (error instanceof ApiError) {
-        errorMessage = error.message;
-        suggestedFix = error.suggestedFix;
-        isApiError = true;
-      } else if (error instanceof AxiosError) {
-        const apiError = ApiError.fromAxiosError(error);
-        errorMessage = apiError.message;
-        suggestedFix = apiError.suggestedFix;
-        isApiError = true;
-      } else if (error instanceof Error) {
-        errorMessage = error.message;
-      }
-      
-      setDeploymentError({
-        message: errorMessage,
-        suggestedFix,
-        isTimeout,
-        isApiError
-      });
-      
-      throw error;
+      await handleDeploymentError(error);
+      return undefined;
+    }
+  };
+
+  const updateModalApp = async (fileContents: string, appId: number): Promise<number | undefined> => {
+    setDeploymentError(null);
+
+    try {
+      const updateRequest: ModalAppPatchRequest = {
+        file_contents: fileContents,
+      };
+
+      const response = await createOrUpdateModalApp(updateRequest, appId);
+      return response.data.id;
+    } catch (error) {
+      await handleDeploymentError(error);
+      return undefined;
     }
   };
 
   return {
     validateModalFile,
     deployModalApp,
+    updateModalApp,
     modalMetadata,
     isValidating,
     isDeploying,

--- a/garden/src/features/modal/api/useUpdateModalApp.ts
+++ b/garden/src/features/modal/api/useUpdateModalApp.ts
@@ -1,0 +1,11 @@
+import { ModalAppCreateRequest, ModalAppMetadataResponse } from "@/types";
+import { useMutation } from "@tanstack/react-query";
+import { AxiosResponse } from "axios";
+
+import { createOrUpdateModalApp } from "./useCreateModalApp";
+
+export const useUpdateModalApp = () => {
+  return useMutation<AxiosResponse<ModalAppMetadataResponse>, Error, ModalAppCreateRequest>({
+    mutationFn: createOrUpdateModalApp,
+  });
+}

--- a/garden/src/features/modal/components/FormActions.tsx
+++ b/garden/src/features/modal/components/FormActions.tsx
@@ -5,6 +5,7 @@ interface FormActionsProps {
   isValidated: boolean;
   isValidating: boolean;
   isDeploying: boolean;
+  toUpdate?: number;
   handleValidate: () => void;
   resetForm: () => void;
 }
@@ -14,8 +15,9 @@ export const FormActions = ({
   isValidated, 
   isValidating, 
   isDeploying,
+  toUpdate = 0,
   handleValidate,
-  resetForm
+  resetForm,
 }: FormActionsProps) => (
   <div className="flex justify-between">
     <Button
@@ -32,7 +34,7 @@ export const FormActions = ({
         type="submit" 
         disabled={!isValidated || isDeploying}
       >
-        {isDeploying ? "Deploying..." : "Deploy Modal App"}
+        {isDeploying ? "Deploying..." :  toUpdate ? "Update Modal App" : "Deploy Modal App"}
       </Button>
     </div>
   </div>

--- a/garden/src/features/modal/components/ModalAppForm.tsx
+++ b/garden/src/features/modal/components/ModalAppForm.tsx
@@ -146,6 +146,7 @@ export const ModalAppForm = ({
                 isValidated={isValidated}
                 isValidating={isValidating}
                 isDeploying={isDeploying}
+                toUpdate={hookOptions.toUpdate || 0}
                 handleValidate={handleValidate}
                 resetForm={resetForm}
               />

--- a/garden/src/features/users/components/UserProfileTabs.tsx
+++ b/garden/src/features/users/components/UserProfileTabs.tsx
@@ -32,14 +32,14 @@ const UserProfileTabs = ({ defaultTab = "profile" }: UserProfileTabsProps) => {
         >
           Saved Gardens
         </TabsTrigger>
-        {/* TODO: hidden until feature is ready
+        {/* TODO: hidden until feature is ready */}
         <TabsTrigger
           value="model-deployments"
           className="h-full w-full border-b-4 bg-gray-100 hover:border-green hover:bg-gradient-to-b hover:from-gray-100 hover:from-70% hover:to-green data-[state=active]:border-green data-[state=active]:bg-green data-[state=active]:bg-opacity-30"
         >
           Model Deployments
         </TabsTrigger>
-        */}
+        {/* */}
       </TabsList>
       <div className="min-h-[60vh] flex-grow overflow-auto pt-4 sm:pt-8">
         <TabsContent value="profile">
@@ -57,13 +57,13 @@ const UserProfileTabs = ({ defaultTab = "profile" }: UserProfileTabsProps) => {
             <SavedGardens />
           </div>
         </TabsContent>
-        {/* TODO: hidden until feature is ready
+        {/* TODO: hidden until feature is ready */}
         <TabsContent value="model-deployments">
           <div className="px-6">
             <ModelDeployments modelDeployments={modelDeployments}></ModelDeployments>
           </div>
         </TabsContent>
-        */ }
+        {/* */ }
       </div>
     </Tabs>
   );

--- a/garden/src/features/users/components/UserProfileTabs.tsx
+++ b/garden/src/features/users/components/UserProfileTabs.tsx
@@ -32,14 +32,14 @@ const UserProfileTabs = ({ defaultTab = "profile" }: UserProfileTabsProps) => {
         >
           Saved Gardens
         </TabsTrigger>
-        {/* TODO: hidden until feature is ready */}
+        {/* TODO: hidden until feature is ready
         <TabsTrigger
           value="model-deployments"
           className="h-full w-full border-b-4 bg-gray-100 hover:border-green hover:bg-gradient-to-b hover:from-gray-100 hover:from-70% hover:to-green data-[state=active]:border-green data-[state=active]:bg-green data-[state=active]:bg-opacity-30"
         >
           Model Deployments
         </TabsTrigger>
-        {/* */}
+       */}
       </TabsList>
       <div className="min-h-[60vh] flex-grow overflow-auto pt-4 sm:pt-8">
         <TabsContent value="profile">
@@ -57,13 +57,13 @@ const UserProfileTabs = ({ defaultTab = "profile" }: UserProfileTabsProps) => {
             <SavedGardens />
           </div>
         </TabsContent>
-        {/* TODO: hidden until feature is ready */}
+        {/* TODO: hidden until feature is ready
         <TabsContent value="model-deployments">
           <div className="px-6">
             <ModelDeployments modelDeployments={modelDeployments}></ModelDeployments>
           </div>
         </TabsContent>
-        {/* */ }
+       */ }
       </div>
     </Tabs>
   );

--- a/garden/src/features/users/components/model-deployments/ModelDeploymentDetails.tsx
+++ b/garden/src/features/users/components/model-deployments/ModelDeploymentDetails.tsx
@@ -19,7 +19,7 @@ import {
     LeafIcon,
     InfoIcon,
     Trash,
-    RefreshCcw
+    RotateCw
 } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import CopyButton from "@/components/CopyButton";
@@ -116,17 +116,19 @@ export const ModelDeploymentDetails = ({ entity }: ModelDeploymentDetailsProps) 
             <div className="flex flex-col space-y-4">
                 <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
                     <h1 className="text-2xl font-bold text-gray-900">{displayName}</h1>
-                    <div className="flex justify-between">
+                    <div className="flex items-center space-x-3">
                         <TooltipProvider delayDuration={100}>
                             <Tooltip>
                                 <TooltipTrigger asChild>
                                     <Button
                                         variant={"outline"}
                                         size={"sm"}
+                                        className="flex items-center gap-2"
                                         aria-description="Update this model deployment"
                                         onClick={handleUpdate}
                                     >
-                                        <RefreshCcw />
+                                        <RotateCw className="h-4 w-4" />
+                                        <span>Update</span>
                                     </Button>
                                 </TooltipTrigger>
                                 <TooltipContent>
@@ -140,10 +142,12 @@ export const ModelDeploymentDetails = ({ entity }: ModelDeploymentDetailsProps) 
                                     <Button
                                         variant={"destructive"}
                                         size={"sm"}
+                                        className="flex items-center gap-2"
                                         aria-description="Delete this model deployment"
                                         onClick={handleDelete}
                                     >
-                                        <Trash />
+                                        <Trash className="h-4 w-4" />
+                                        <span>Delete</span>
                                     </Button>
                                 </TooltipTrigger>
                                 <TooltipContent>
@@ -312,7 +316,7 @@ export const ModelDeploymentDetails = ({ entity }: ModelDeploymentDetailsProps) 
 
             {/* Update deployment dialog */}
             <Dialog open={showUpdateDialog} onOpenChange={setShowUpdateDialog}>
-                <DialogContent>
+                <DialogContent className="w-[95%] md:w-4/5 lg:w-3/4 max-w-4xl">
                     <DialogHeader>
                         <DialogTitle>Update Model Deployment</DialogTitle>
                         <DialogDescription>Upload an updated Modal App file to update this model deployment.</DialogDescription>

--- a/garden/src/features/users/components/model-deployments/ModelDeploymentDetails.tsx
+++ b/garden/src/features/users/components/model-deployments/ModelDeploymentDetails.tsx
@@ -317,7 +317,7 @@ export const ModelDeploymentDetails = ({ entity }: ModelDeploymentDetailsProps) 
                         <DialogTitle>Update Model Deployment</DialogTitle>
                         <DialogDescription>Upload an updated Modal App file to update this model deployment.</DialogDescription>
                     </DialogHeader>
-                    <ModalAppForm></ModalAppForm>
+                    <ModalAppForm toUpdate={entity.id} onDeploymentSuccess={(_) => setShowUpdateDialog(false)}></ModalAppForm>
                 </DialogContent>
             </Dialog>
 

--- a/garden/src/features/users/components/model-deployments/ModelDeploymentDetails.tsx
+++ b/garden/src/features/users/components/model-deployments/ModelDeploymentDetails.tsx
@@ -18,7 +18,8 @@ import {
     ClockIcon,
     LeafIcon,
     InfoIcon,
-    Trash
+    Trash,
+    RefreshCcw
 } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import CopyButton from "@/components/CopyButton";
@@ -31,6 +32,8 @@ import  instance  from "@/lib/axios";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/shadcn/dialog";
+import { ModalAppForm } from "@/features/modal/components/ModalAppForm";
 
 interface ModelDeploymentDetailsProps {
     entity: ModalAppMetadataResponse | AsyncModalAppMetadataResponse,
@@ -42,6 +45,7 @@ export const ModelDeploymentDetails = ({ entity }: ModelDeploymentDetailsProps) 
     const navigate = useNavigate();
     const queryClient = useQueryClient();
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+    const [showUpdateDialog, setShowUpdateDialog] = useState(false);
 
     // Get display name (prefer original_app_name if available)
     const displayName = entity.original_app_name || entity.app_name;
@@ -102,13 +106,34 @@ export const ModelDeploymentDetails = ({ entity }: ModelDeploymentDetailsProps) 
         setShowDeleteDialog(true);
     };
 
+    const handleUpdate = () => {
+        setShowUpdateDialog(true);
+    };
+
     return (
         <div className="p-6 space-y-6 max-w-6xl mx-auto">
             {/* Header with Status Section */}
             <div className="flex flex-col space-y-4">
                 <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
                     <h1 className="text-2xl font-bold text-gray-900">{displayName}</h1>
-                    <div className="flex justify-end">
+                    <div className="flex justify-between">
+                        <TooltipProvider delayDuration={100}>
+                            <Tooltip>
+                                <TooltipTrigger asChild>
+                                    <Button
+                                        variant={"outline"}
+                                        size={"sm"}
+                                        aria-description="Update this model deployment"
+                                        onClick={handleUpdate}
+                                    >
+                                        <RefreshCcw />
+                                    </Button>
+                                </TooltipTrigger>
+                                <TooltipContent>
+                                    <p>Update this Deployment</p>
+                                </TooltipContent>
+                            </Tooltip>
+                        </TooltipProvider>
                         <TooltipProvider delayDuration={100}>
                             <Tooltip>
                                 <TooltipTrigger asChild>
@@ -284,6 +309,17 @@ export const ModelDeploymentDetails = ({ entity }: ModelDeploymentDetailsProps) 
                     </AccordionContent>
                 </AccordionItem>
             </Accordion>
+
+            {/* Update deployment dialog */}
+            <Dialog open={showUpdateDialog} onOpenChange={setShowUpdateDialog}>
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>Update Model Deployment</DialogTitle>
+                        <DialogDescription>Upload an updated Modal App file to update this model deployment.</DialogDescription>
+                    </DialogHeader>
+                    <ModalAppForm></ModalAppForm>
+                </DialogContent>
+            </Dialog>
 
             {/* Delete Confirmation Dialog */}
             <AlertDialog open={showDeleteDialog} onOpenChange={setShowDeleteDialog}>

--- a/garden/src/types/backend-schema.ts
+++ b/garden/src/types/backend-schema.ts
@@ -181,8 +181,7 @@ export interface paths {
         };
         /** Get Garden By Doi */
         get: operations["get_garden_by_doi_gardens__doi__get"];
-        /** Create Or Replace Garden */
-        put: operations["create_or_replace_garden_gardens__doi__put"];
+        put?: never;
         post?: never;
         /** Delete Garden */
         delete: operations["delete_garden_gardens__doi__delete"];
@@ -369,6 +368,28 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/modal-apps/async/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Patch Modal App
+         * @description Update a modal app's metadata in-place.
+         *
+         *     Triggers a redeployment if file_contents has changed.
+         */
+        patch: operations["patch_modal_app_modal_apps_async__id__patch"];
         trace?: never;
     };
     "/modal-apps/": {
@@ -1813,6 +1834,17 @@ export interface components {
             /** Modal Function Ids */
             readonly modal_function_ids: number[];
         };
+        /** ModalAppPatchRequest */
+        ModalAppPatchRequest: {
+            /** Base Image Name */
+            base_image_name?: string | null;
+            /** Requirements */
+            requirements?: string[] | null;
+            /** Conda Requirements */
+            conda_requirements?: string[] | null;
+            /** File Contents */
+            file_contents?: string | null;
+        };
         /** ModalBlobUploadURLRequest */
         ModalBlobUploadURLRequest: {
             /** Content Length */
@@ -2986,41 +3018,6 @@ export interface operations {
             };
         };
     };
-    create_or_replace_garden_gardens__doi__put: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                doi: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["GardenCreateRequest"];
-            };
-        };
-        responses: {
-            /** @description Successful Response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GardenMetadataResponse"];
-                };
-            };
-            /** @description Validation Error */
-            422: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["HTTPValidationError"];
-                };
-            };
-        };
-    };
     delete_garden_gardens__doi__delete: {
         parameters: {
             query?: never;
@@ -3408,6 +3405,41 @@ export interface operations {
             cookie?: never;
         };
         requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AsyncModalAppMetadataResponse"];
+                };
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    patch_modal_app_modal_apps_async__id__patch: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ModalAppPatchRequest"];
+            };
+        };
         responses: {
             /** @description Successful Response */
             200: {

--- a/garden/src/types/index.ts
+++ b/garden/src/types/index.ts
@@ -10,6 +10,7 @@ type EntrypointCreateRequest = components["schemas"]["EntrypointCreateRequest"];
 type EntrypointPatchRequest = components["schemas"]["EntrypointPatchRequest"];
 
 type ModalAppCreateRequest = components["schemas"]["ModalAppCreateRequest"];
+type ModalAppPatchRequest = components["schemas"]["ModalAppPatchRequest"]
 type ModalAppMetadataResponse = components["schemas"]["ModalAppMetadataResponse"];
 type BaseModalFunction = components["schemas"]["ModalFunctionMetadataResponse"];
 
@@ -69,6 +70,7 @@ export type {
   AsyncModalJobStatus,
   ModalFileMetadataRequest,
   ModalFileMetadataResponse,
+  ModalAppPatchRequest,
   Model,
   Notebook
 };


### PR DESCRIPTION
Resolves: #323 

This PR adds a flow to update existing model deployments from the deployment details page.

### Existing deployment with 1 function, updated with 2 new functions

https://github.com/user-attachments/assets/5da86e4e-ba9d-49cf-956b-cf445927ff6b

### Removing functions that are in-use results in an error

https://github.com/user-attachments/assets/b235c36b-2971-49b9-bb07-d44825309ad2


## Discussion

This is pretty straight forward logically speaking, but touched a decent number of files. I adapted the existing modal app creation logic to handle updates via the new backend route. This allows us to reuse the modal app upload form in both create and update contexts.

I also moved a couple of hooks from the garden feature directory to the modal feature directory since they are not related to gardens.

## Testing
Manually