### PR TITLE
Better visibility into modal deployment errors

### DIFF
--- a/garden/src/features/gardens/components/create/CreateGardenPage.tsx
+++ b/garden/src/features/gardens/components/create/CreateGardenPage.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { CreateGardenForm } from "./CreateGardenForm";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useGetGlobusGroups } from "@/features/gardens/api/useGetGlobusGroups";
@@ -33,11 +34,11 @@ const CreateGardenPage = () => {
     return (
       <div className="mx-auto max-w-6xl px-8 py-16 font-display">
         <OverallProgress currentPhase={1} />
-        <ModalAppUploadPage 
+        <ModalAppUploadPage
           isMultiStep={true}
           onSuccess={(id: number) => {
             navigate(`/garden/create?modalAppId=${id}`);
-          }} 
+          }}
         />
       </div>
     );
@@ -47,7 +48,7 @@ const CreateGardenPage = () => {
   return (
     <div className="mx-auto max-w-6xl px-8 py-16 font-display">
       {modalAppId && <OverallProgress currentPhase={2} isSubmitting={isSubmitting} />}
-      <CreateGardenForm 
+      <CreateGardenForm
         modalAppId={modalAppId}
         hasModalApp={!!modalAppId}
         onFormStateChange={onFormStateChange}

--- a/garden/src/features/gardens/utils/garden.utils.ts
+++ b/garden/src/features/gardens/utils/garden.utils.ts
@@ -69,58 +69,64 @@ export const tagOptions: Option[] = [
 export class ApiError extends Error {
   readonly statusCode?: number;
   readonly suggestedFix?: string;
-
+  readonly deploymentOutput?: string;
   constructor(
     message: string,
     suggestedFix?: string,
+    deploymentOutput?: string,
   ) {
     super(message);
     Object.setPrototypeOf(this, ApiError.prototype);
     this.name = 'ApiError';
     this.suggestedFix = suggestedFix;
+    this.deploymentOutput = deploymentOutput;
   }
 
   static fromAxiosError(error: AxiosError): ApiError {
     interface ApiErrorInfo {
       detail: string,
       suggestedFix: string,
+      deploymentOutput: string,
     }
-    const { detail, suggestedFix } = error.response?.data as ApiErrorInfo ?? {};
+    const { detail, suggestedFix, deploymentOutput } = error.response?.data as ApiErrorInfo ?? {};
+
     return new ApiError(
       detail || 'Unknown API Error',
       suggestedFix,
+      deploymentOutput,
     );
   }
 
   toString(): string {
-    let str = `Error: ${this.message}`;
-    let suggestedFix = this.suggestedFix ? `, suggested_fix: ${this.suggestedFix}` : '';
-    return str + suggestedFix;
+    const str = `Error: ${this.message}`;
+    const suggestedFix = this.suggestedFix ? `, suggested_fix: ${this.suggestedFix}` : '';
+    const deploymentOutput = this.deploymentOutput ? `, deployment_output: ${this.deploymentOutput}` : '';
+    return str + suggestedFix + deploymentOutput;
   }
 }
 
 export type MaterialType = 'datasets' | 'papers' | 'repositories' | 'notebooks';
 
 export const getUniqueItemCount = (modalFunctions: ModalFunction[] | undefined, materialType: MaterialType): number => {
-    if (!modalFunctions) return 0;
-    
-    const getIdentifier = (item: any) => {
-        switch (materialType) {
-            case 'datasets':
-            case 'papers':
-                return item.doi || item.url || item.title;
-            case 'repositories':
-            case 'notebooks':
-                return item.url;
-        }
-    };
+  if (!modalFunctions) return 0;
 
-    return modalFunctions.reduce((uniqueItems, mf) => {
-        const items = mf[materialType];
-        if (!items) return uniqueItems;
-        
-        const ids = new Set(items.map(getIdentifier));
-        ids.forEach(id => uniqueItems.add(id));
-        return uniqueItems;
-    }, new Set()).size;
+  const getIdentifier = (item: any) => {
+    switch (materialType) {
+      case 'datasets':
+      case 'papers':
+        return item.doi || item.url || item.title;
+      case 'repositories':
+      case 'notebooks':
+        return item.url;
+    }
+  };
+
+  return modalFunctions.reduce((uniqueItems, mf) => {
+    const items = mf[materialType];
+    if (!items) return uniqueItems;
+
+    const ids = new Set(items.map(getIdentifier));
+    ids.forEach(id => uniqueItems.add(id));
+    return uniqueItems;
+  }, new Set()).size;
 };

--- a/garden/src/features/globus/components/GlobusGroupError.tsx
+++ b/garden/src/features/globus/components/GlobusGroupError.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Button } from "@/components/shadcn/button";
 import { useNavigate } from "react-router-dom";
 
@@ -12,7 +13,7 @@ export const GlobusGroupError = () => {
         <div className="space-y-12">
           <h1 className="text-4xl font-bold text-center">Become a Gardener</h1>
           <p className="text-gray-700">
-            If you are a researcher, student, or enthusiast who wants to create model gardens, please submit{" "} 
+            If you are a researcher, student, or enthusiast who wants to create model gardens, please submit{" "}
             <a href="https://forms.gle/uWByDVgzaiazxVJr9" className="font-bold text-primary">
               this interest form.
             </a>{" "}
@@ -27,8 +28,8 @@ export const GlobusGroupError = () => {
           </p>
 
           <div className="flex items-center justify-center space-x-4">
-            <a 
-              href="https://forms.gle/uWByDVgzaiazxVJr9" 
+            <a
+              href="https://forms.gle/uWByDVgzaiazxVJr9"
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center justify-center rounded-md text-sm font-bold ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2"

--- a/garden/src/features/modal/api/useCreateModalApp.tsx
+++ b/garden/src/features/modal/api/useCreateModalApp.tsx
@@ -48,7 +48,11 @@ export const createOrUpdateModalApp = async (
 
       const pollResponse = await axios.get(`/modal-apps/${appId}`);
       if (pollResponse.data.deploy_status === "error") {
-        throw new ApiError(pollResponse.data.deploy_error, pollResponse.data.suggested_fix);
+        throw new ApiError(
+          pollResponse.data.deploy_error,
+          pollResponse.data.suggested_fix,
+          pollResponse.data.deployment_output
+        );
       }
       if (pollResponse.data.deploy_status === "done") {
         return pollResponse;

--- a/garden/src/features/modal/api/useCreateModalApp.tsx
+++ b/garden/src/features/modal/api/useCreateModalApp.tsx
@@ -48,7 +48,7 @@ export const createOrUpdateModalApp = async (
 
       const pollResponse = await axios.get(`/modal-apps/${appId}`);
       if (pollResponse.data.deploy_status === "error") {
-        throw new ApiError(pollResponse.data.deploy_error);
+        throw new ApiError(pollResponse.data.deploy_error, pollResponse.data.suggested_fix);
       }
       if (pollResponse.data.deploy_status === "done") {
         return pollResponse;

--- a/garden/src/features/modal/api/useModalAppForm.tsx
+++ b/garden/src/features/modal/api/useModalAppForm.tsx
@@ -108,44 +108,44 @@ export const useModalAppForm = ({
   const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFile = e.target.files?.[0];
     if (!selectedFile) return;
-    
+
     // Reset validation state when a new file is selected
     setIsValidated(false);
     clearErrors();
-    
+
     // Reset any form-level validation errors
     form.clearErrors();
-    
+
     // If we had previously validated a file, inform the user
     // that the new file will be validated automatically
     if (modalMetadata) {
       toast.info("New file selected. Validating...");
     }
-    
+
     // Reset modalMetadata when a new file is selected
     setModalMetadata(null);
     setIsDeploymentComplete(false);
     setDeployedAppId(null);
-    
+
     setFile(selectedFile);
     setIsValidating(true);
     setValidationError(null);
     setDeploymentError(null);
-    
+
     try {
       const fileContents = await selectedFile.text();
       form.setValue("file_contents", fileContents);
-      
+
       // Automatically validate the file after loading
       const metadata = await validateModalFile(fileContents);
-      
+
       if (metadata) {
         setIsValidated(true);
-        
+
         // Initialize the modal_functions field with the validated metadata
         const functions = metadata.modal_functions || [];
         form.setValue("modal.modal_functions", functions as any);
-        
+
         setModalMetadata(metadata);
         toast.success("Modal file validated successfully");
       } else {
@@ -190,30 +190,30 @@ export const useModalAppForm = ({
 
   // New handler for updating function metadata
   const handleFunctionMetadataChange = (
-    functionIndex: number, 
-    field: string, 
+    functionIndex: number,
+    field: string,
     value: string,
     event?: React.KeyboardEvent<HTMLTextAreaElement>
   ) => {
     // Handle tab key in text areas to insert spaces
     if (event?.key === 'Tab') {
       event.preventDefault();
-      
+
       // Default 2-space indentation
       const indentSize = 2;
       const indent = ' '.repeat(indentSize);
       const { selectionStart, selectionEnd } = event.currentTarget;
-      
+
       // Insert indentation at cursor
       const newValue = value.substring(0, selectionStart) + indent + value.substring(selectionEnd);
-      
+
       // Update value with indentation
       const path = `modal.modal_functions.${functionIndex}.${field}` as const;
-      form.setValue(path, newValue, { 
-        shouldValidate: true, 
-        shouldDirty: true 
+      form.setValue(path, newValue, {
+        shouldValidate: true,
+        shouldDirty: true
       });
-      
+
       // Set cursor position after inserted indent
       setTimeout(() => {
         const input = event.currentTarget;
@@ -221,13 +221,13 @@ export const useModalAppForm = ({
         input.focus();
         input.setSelectionRange(newCursorPos, newCursorPos);
       }, 0);
-      
+
       return;
     }
-    
+
     // Regular field update without special handling
     const path = `modal.modal_functions.${functionIndex}.${field}` as const;
-    form.setValue(path, value, { 
+    form.setValue(path, value, {
       shouldValidate: true,
       shouldDirty: true,
     });
@@ -242,17 +242,17 @@ export const useModalAppForm = ({
     try {
       const fileContents = await file.text();
       form.setValue("file_contents", fileContents);
-      
+
       // Automatically validate the file after loading
       const metadata = await validateModalFile(fileContents);
-      
+
       if (metadata) {
         setIsValidated(true);
-        
+
         // Initialize the modal_functions field with the validated metadata
         const functions = metadata.modal_functions || [];
         form.setValue("modal.modal_functions", functions as any);
-        
+
         setModalMetadata(metadata);
         toast.success("Modal file validated successfully");
       } else {
@@ -310,29 +310,29 @@ export const useModalAppForm = ({
         ...modalMetadata,
         modal_functions: data.modal?.modal_functions || modalMetadata.modal_functions,
       };
-      
+
       let appId: number | undefined;
       if (toUpdate) {
         appId = await updateModalApp(data.file_contents, toUpdate);
       } else {
         appId = await deployModalApp(data.file_contents, updatedMetadata, uuid);
       }
-      
+
       if (appId === undefined) {
         throw new Error("Failed to deploy Modal app. App ID not returned.");
       }
-      
+
       setDeployedAppId(appId);
       toast.success(`Modal app ${toUpdate ? "updated" : "deployed"} successfully!`);
-      
+
       // Invalidate the modelDeployments query to ensure fresh data is fetched
       queryClient.invalidateQueries({ queryKey: ["modelDeployments"] });
-      
+
       if (showSuccessScreen) {
         // Show success screen in the form (don't navigate away immediately)
         setIsDeploymentComplete(true);
       }
-      
+
       if (onDeploymentSuccess && appId !== undefined) {
         onDeploymentSuccess(appId);
       } else if (toUpdate) {
@@ -342,16 +342,16 @@ export const useModalAppForm = ({
         if (redirectUrl) {
           // Replace :id placeholder with actual app ID
           const finalUrl = redirectUrl.replace(':id', appId.toString());
-          
+
           // Check if we're using search params or path params
           if (finalUrl.includes('?')) {
             // Parse the URL to extract search params
             const [path, searchParamsString] = finalUrl.split('?');
             const urlSearchParams = new URLSearchParams(searchParamsString);
-            
+
             // Set search params and navigate to the path
             setSearchParams(urlSearchParams);
-            
+
             // If we're changing the URL path (not just search params), navigate
             if (path !== window.location.pathname) {
               navigate(path);
@@ -373,6 +373,7 @@ export const useModalAppForm = ({
         setDeploymentError({
           message: error.message,
           suggestedFix: error.suggestedFix,
+          deploymentOutput: error.deploymentOutput,
           isTimeout: false,
           isApiError: true
         });

--- a/garden/src/features/modal/api/useModalAppUpload.tsx
+++ b/garden/src/features/modal/api/useModalAppUpload.tsx
@@ -4,7 +4,6 @@ import { useCreateModalApp, DeployTimeoutError, createOrUpdateModalApp } from ".
 import { ModalAppPatchRequest, ModalFileMetadataResponse } from "@/types";
 import { ApiError } from "../../gardens/utils/garden.utils";
 import { AxiosError } from "axios";
-import instance from "@/lib/axios";
 
 export interface ValidationError {
   message: string;
@@ -15,6 +14,7 @@ export interface ValidationError {
 export interface DeploymentError {
   message: string;
   suggestedFix?: string;
+  deploymentOutput?: string;
   isTimeout: boolean;
   isApiError: boolean;
 }
@@ -57,16 +57,19 @@ export const useModalAppUpload = (): UseModalAppUploadReturn => {
     const isTimeout = error instanceof DeployTimeoutError;
     let errorMessage = "Failed to deploy Modal app";
     let suggestedFix: string | undefined = undefined;
+    let deploymentOutput: string | undefined = undefined;
     let isApiError = false;
 
     if (error instanceof ApiError) {
       errorMessage = error.message;
       suggestedFix = error.suggestedFix;
+      deploymentOutput = error.deploymentOutput;
       isApiError = true;
     } else if (error instanceof AxiosError) {
       const apiError = ApiError.fromAxiosError(error);
       errorMessage = apiError.message;
       suggestedFix = apiError.suggestedFix;
+      deploymentOutput = apiError.deploymentOutput;
       isApiError = true;
     } else if (error instanceof Error) {
       errorMessage = error.message;
@@ -77,6 +80,7 @@ export const useModalAppUpload = (): UseModalAppUploadReturn => {
     setDeploymentError({
       message: errorMessage,
       suggestedFix,
+      deploymentOutput,
       isTimeout,
       isApiError
     });

--- a/garden/src/features/modal/components/UploadModalAppForm.tsx
+++ b/garden/src/features/modal/components/UploadModalAppForm.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Form } from "@/components/shadcn/form";
 import { useSearchParams } from "react-router-dom";
 import { useModalAppForm } from "@/features/modal/api/useModalAppForm";
@@ -14,7 +15,7 @@ import { ProgressSteps } from "@/features/modal/components/progress/ProgressStep
 
 export const UploadModalAppForm = () => {
   const [, setSearchParams] = useSearchParams();
-  
+
   const {
     form,
     file,
@@ -49,17 +50,17 @@ export const UploadModalAppForm = () => {
   return (
     <>
       {/* Overall Progress - Moved outside the card to connect with page heading */}
-      <OverallProgress 
-        currentPhase={currentPhase} 
-        isCompleted={isDeploying || isValidated} 
+      <OverallProgress
+        currentPhase={currentPhase}
+        isCompleted={isDeploying || isValidated}
       />
-      
+
       <div className="rounded-lg border bg-white p-6 shadow-sm">
         <h2 className="mb-6 text-xl font-bold">Upload and Deploy Modal App</h2>
-        
+
         {/* Detailed Progress Steps for current phase */}
         <ProgressSteps currentStep={currentStep} />
-        
+
         {isDeploying ? (
           <>
             {/* Centralized loading display during deployment */}
@@ -70,31 +71,31 @@ export const UploadModalAppForm = () => {
           <Form {...form}>
             <form onSubmit={handleSubmit} className="space-y-6">
               {/* File Upload Section */}
-              <FileUploadSection 
+              <FileUploadSection
                 handleFileChange={handleFileChange}
                 isValidating={isValidating}
                 isDeploying={isDeploying}
                 isValidated={isValidated}
                 file={file}
               />
-              
+
               {/* Error Displays */}
               {validationError && <ValidationErrorAlert error={validationError} />}
               {deploymentError && <DeploymentErrorAlert error={deploymentError} />}
-              
+
               {/* Modal App Details */}
               {modalMetadata && (
                 <div className="space-y-6">
                   <DetectedAppCard metadata={modalMetadata} />
-                  <FunctionMetadataEditor 
-                    form={form} 
-                    metadata={modalMetadata} 
-                    handleFunctionMetadataChange={handleFunctionMetadataChange} 
+                  <FunctionMetadataEditor
+                    form={form}
+                    metadata={modalMetadata}
+                    handleFunctionMetadataChange={handleFunctionMetadataChange}
                   />
                 </div>
               )}
-              
-              <FormActions 
+
+              <FormActions
                 file={file}
                 isValidated={isValidated}
                 isValidating={isValidating}

--- a/garden/src/features/modal/components/alerts/DeploymentErrorAlert.tsx
+++ b/garden/src/features/modal/components/alerts/DeploymentErrorAlert.tsx
@@ -1,45 +1,73 @@
+import React, { useState } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/shadcn/alert";
-import { AlertTriangle, HelpCircleIcon, InfoIcon } from "lucide-react";
+import { AlertTriangle, ChevronDown, ChevronRight, HelpCircleIcon } from "lucide-react";
 import { DeploymentError } from "@/features/modal/api/useModalAppUpload";
+import { Button } from "@/components/shadcn/button";
 
 interface DeploymentErrorAlertProps {
   error: DeploymentError;
 }
 
-export const DeploymentErrorAlert = ({ error }: DeploymentErrorAlertProps) => (
-  <Alert variant="destructive">
-    <AlertTriangle className="h-4 w-4" />
-    <AlertTitle>
-      {error.isTimeout 
-        ? "Deployment Timeout" 
-        : error.isApiError 
-          ? "Deployment Failed" 
-          : "Deployment Error"}
-    </AlertTitle>
-    <AlertDescription className="space-y-2">
-      <p>{error.message}</p>
-      {error.suggestedFix && (
-        <div className="mt-2 rounded-md bg-red-50 p-3">
-          <div className="flex">
-            <div className="flex-shrink-0">
-              <HelpCircleIcon className="h-5 w-5 text-red-400" aria-hidden="true" />
-            </div>
-            <div className="ml-3">
-              <h3 className="text-sm font-medium text-red-800">Suggested Fix</h3>
-              <div className="mt-2 text-sm text-red-700">
-                <p>{error.suggestedFix}</p>
+export const DeploymentErrorAlert = ({ error }: DeploymentErrorAlertProps) => {
+  const [showOutput, setShowOutput] = useState(false);
+
+  return (
+    <Alert variant="destructive">
+      <AlertTriangle className="h-4 w-4" />
+      <AlertTitle>
+        {error.isTimeout
+          ? "Deployment Timeout"
+          : error.isApiError
+            ? "Deployment Failed"
+            : "Deployment Error"}
+      </AlertTitle>
+      <AlertDescription className="space-y-2">
+        <p>{error.message}</p>
+        {error.suggestedFix && (
+          <div className="mt-2 rounded-md bg-red-50 p-3">
+            <div className="flex">
+              <div className="flex-shrink-0">
+                <HelpCircleIcon className="h-5 w-5 text-red-400" aria-hidden="true" />
+              </div>
+              <div className="ml-3">
+                <h3 className="text-sm font-medium text-red-800">Suggested Fix</h3>
+                <div className="mt-2 text-sm text-red-700">
+                  <p>{error.suggestedFix}</p>
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      )}
-      {error.isTimeout && (
-        <p className="mt-2 text-sm font-medium">
-          This Garden is taking a long time to deploy. If your Modal App downloads large files or 
-          installs large libraries, this may be expected. The installation is still happening 
-          in the background.
-        </p>
-      )}
-    </AlertDescription>
-  </Alert>
-); 
+        )}
+        {error.deploymentOutput && (
+          <div className="mt-2 rounded-md bg-gray-50 p-3">
+            <Button
+              type="button"
+              variant="ghost"
+              className="flex w-full items-center justify-between p-0 text-sm font-medium text-gray-700"
+              onClick={() => setShowOutput(!showOutput)}
+            >
+              <span className="flex items-center">
+                {showOutput ? <ChevronDown className="h-4 w-4 mr-1" /> : <ChevronRight className="h-4 w-4 mr-1" />}
+                Deployment Output
+              </span>
+            </Button>
+            {showOutput && (
+              <div className="mt-2">
+                <pre className="whitespace-pre-wrap text-xs overflow-auto max-h-60 p-2 bg-gray-100 rounded">
+                  {error.deploymentOutput}
+                </pre>
+              </div>
+            )}
+          </div>
+        )}
+        {error.isTimeout && (
+          <p className="mt-2 text-sm font-medium">
+            This Garden is taking a long time to deploy. If your Modal App downloads large files or
+            installs large libraries, this may be expected. The installation is still happening
+            in the background.
+          </p>
+        )}
+      </AlertDescription>
+    </Alert>
+  )
+}; 

--- a/garden/src/features/model-deployments/ModelDeploymentDetails.tsx
+++ b/garden/src/features/model-deployments/ModelDeploymentDetails.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { ModalAppMetadataResponse, AsyncModalAppMetadataResponse } from "@/types";
 import {
     Card,
@@ -20,7 +20,9 @@ import {
     LeafIcon,
     InfoIcon,
     Trash,
-    RotateCw
+    RotateCw,
+    ChevronDown,
+    ChevronRight
 } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 import CopyButton from "@/components/CopyButton";
@@ -32,7 +34,6 @@ import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, 
 import instance from "@/lib/axios";
 import { toast } from "sonner";
 import { useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/shadcn/dialog";
 import { ModalAppForm } from "@/features/modal/components/ModalAppForm";
 
@@ -47,6 +48,7 @@ export const ModelDeploymentDetails = ({ entity }: ModelDeploymentDetailsProps) 
     const queryClient = useQueryClient();
     const [showDeleteDialog, setShowDeleteDialog] = useState(false);
     const [showUpdateDialog, setShowUpdateDialog] = useState(false);
+    const [showOutput, setShowOutput] = useState(false);
 
     // Get display name (prefer original_app_name if available)
     const displayName = entity.original_app_name || entity.app_name;
@@ -55,6 +57,7 @@ export const ModelDeploymentDetails = ({ entity }: ModelDeploymentDetailsProps) 
     const isAsyncEntity = 'deploy_status' in entity;
     const deployStatus = isAsyncEntity ? (entity as AsyncModalAppMetadataResponse).deploy_status : 'done';
     const deployError = isAsyncEntity ? (entity as AsyncModalAppMetadataResponse).deploy_error : null;
+    const deploymentOutput = isAsyncEntity ? (entity as AsyncModalAppMetadataResponse).deployment_output : null;
 
     // Status display helpers
     const getStatusDisplay = () => {
@@ -179,6 +182,30 @@ export const ModelDeploymentDetails = ({ entity }: ModelDeploymentDetailsProps) 
                                                 {deployError}
                                             </pre>
                                         </div>
+
+                                        {/* Deployment Output (collapsible) */}
+                                        {deploymentOutput && (
+                                            <div className="mt-4 bg-white/60 p-3 rounded border border-red-200">
+                                                <Button
+                                                    type="button"
+                                                    variant="ghost"
+                                                    className="flex w-full items-center justify-between p-0 text-sm font-medium text-red-700"
+                                                    onClick={() => setShowOutput(!showOutput)}
+                                                >
+                                                    <span className="flex items-center">
+                                                        {showOutput ? <ChevronDown className="h-4 w-4 mr-1" /> : <ChevronRight className="h-4 w-4 mr-1" />}
+                                                        Deployment Output
+                                                    </span>
+                                                </Button>
+                                                {showOutput && (
+                                                    <div className="mt-2">
+                                                        <pre className="text-xs text-red-800 whitespace-pre-wrap font-mono overflow-auto max-h-60 p-2 bg-white/80 rounded">
+                                                            {deploymentOutput}
+                                                        </pre>
+                                                    </div>
+                                                )}
+                                            </div>
+                                        )}
                                     </div>
                                 )}
 
@@ -322,7 +349,7 @@ export const ModelDeploymentDetails = ({ entity }: ModelDeploymentDetailsProps) 
                         <DialogTitle>Update Model Deployment</DialogTitle>
                         <DialogDescription>Upload an updated Modal App file to update this model deployment.</DialogDescription>
                     </DialogHeader>
-                    <ModalAppForm toUpdate={entity.id} onDeploymentSuccess={(_) => setShowUpdateDialog(false)}></ModalAppForm>
+                    <ModalAppForm toUpdate={entity.id} onDeploymentSuccess={() => setShowUpdateDialog(false)}></ModalAppForm>
                 </DialogContent>
             </Dialog>
 

--- a/garden/src/types/backend-schema.ts
+++ b/garden/src/types/backend-schema.ts
@@ -610,6 +610,10 @@ export interface components {
             deploy_status?: components["schemas"]["AsyncModalJobStatus"] | null;
             /** Deploy Error */
             deploy_error?: string | null;
+            /** Suggested Fix */
+            suggested_fix?: string | null;
+            /** Deployment Output */
+            deployment_output?: string | null;
             /** Modal Function Names */
             readonly modal_function_names: string[];
             /** Modal Function Ids */


### PR DESCRIPTION
Depends on: https://github.com/Garden-AI/garden-backend/pull/299

This PR adds displays of suggested fixes and deployment output from modal when a model deployment is in an error state.

### The Upload & Deploy form

https://github.com/user-attachments/assets/96863b78-cf07-4573-b662-5940b619a001


### The deployment details page

https://github.com/user-attachments/assets/3fd0f2cf-d687-4a91-a10c-4155a8406975


## Discussion

The only major changes here are adding the structure to display the delplyoment output. Some of the hooks and error handling needed updates to track the new fields as errors move through the system.

Some extra files got touched that aren't related to this feature, but got hit by the new formatter setup. No logic changed, but whitespace got cleaned up.

## Testing
Manually