### PR TITLE
Remove test garden concept

### DIFF
--- a/garden/src/components/HomePage.tsx
+++ b/garden/src/components/HomePage.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useEffect } from "react";
 import { Link } from "react-router-dom";
 import {
@@ -57,7 +58,6 @@ const HomePage = () => {
       owner_identity_id: "100",
       id: 100,
       modal_function_ids: [],
-      is_test: false,
     },
     {
       title: "Materials Property Prediction with MAST-ML",
@@ -73,7 +73,6 @@ const HomePage = () => {
       owner_identity_id: "100",
       id: 100,
       modal_function_ids: [],
-      is_test: false,
     },
     {
       title: "Conservative to Primitive Conversion in Relativistic Hydrodynamics",
@@ -89,7 +88,6 @@ const HomePage = () => {
       owner_identity_id: "100",
       id: 100,
       modal_function_ids: [],
-      is_test: false,
     },
     {
       title: "Generative Materials Models",
@@ -105,7 +103,6 @@ const HomePage = () => {
       owner_identity_id: "100",
       id: 100,
       modal_function_ids: [],
-      is_test: false,
     },
   ];
 
@@ -142,7 +139,7 @@ const HomePage = () => {
               target="_blank"
               className="mr-5 hover:text-gray-200 dark:hover:text-gray-200"
             >
-              <UChicagoLogo/>
+              <UChicagoLogo />
             </a>
 
             <a
@@ -150,7 +147,7 @@ const HomePage = () => {
               target="_blank"
               className="mr-5 hover:text-gray-200 dark:hover:text-gray-400"
             >
-              <NSFLogo/>
+              <NSFLogo />
             </a>
 
             <a
@@ -158,7 +155,7 @@ const HomePage = () => {
               target="_blank"
               className="mr-5 hover:text-gray-200 dark:hover:text-gray-400"
             >
-              <WisconsinLogo/>
+              <WisconsinLogo />
             </a>
 
             <a
@@ -166,14 +163,14 @@ const HomePage = () => {
               target="_blank"
               className="mr-5 pb-4 hover:text-gray-200 dark:hover:text-gray-400"
             >
-              <ArgonneLogo/>
+              <ArgonneLogo />
             </a>
             <a
               href="https://www.energy.gov/"
               target="_blank"
               className="mr-5 hover:text-gray-200 dark:hover:text-gray-400"
             >
-              <DOELogo/>
+              <DOELogo />
             </a>
 
             <a
@@ -181,7 +178,7 @@ const HomePage = () => {
               target="_blank"
               className="mr-5 w-24 pb-4 pt-3 hover:text-gray-200 dark:hover:text-gray-400"
             >
-              <MITLogo/>
+              <MITLogo />
             </a>
           </div>
         </div>
@@ -195,7 +192,7 @@ const HomePage = () => {
           <h2 className="mt-2 text-lg">
             There are many great platforms for hosting chatbots.
             But you work in science, and you want the best model for predicting
-            <Link to="/garden/10.26311/ep98-br79" className="text-green hover:text-darkgreen hover:underline"> material tensile strength</Link> or the 
+            <Link to="/garden/10.26311/ep98-br79" className="text-green hover:text-darkgreen hover:underline"> material tensile strength</Link> or the
             <Link to="/garden/10.26311/hhwc-0v60" className="text-green hover:text-darkgreen hover:underline"> behavior of neutron stars</Link>.
             Garden is the best place to find, share, and run specialized AI models for science. (Scientific chatbots are welcome too.)
           </h2>
@@ -231,7 +228,7 @@ const HomePage = () => {
           <div className="mt-12 px-4 md:mt-4 md:w-5/12">
             <h1 className="text-3xl font-semibold">Reproducible Science Needs On-Demand Models</h1>
             <h2 className="mt-4 text-lg">
-              It can take days to get another lab's model running. 
+              It can take days to get another lab's model running.
               Models hosted on Garden are runnable in seconds, so you can build on others' work.
               (And you can get real users and citations for models you've developed.)
             </h2>
@@ -268,12 +265,12 @@ const HomePage = () => {
                   <>
                     <div className="rounded-md border bg-white p-6">
                       <p className="text-base text-gray-800 ">
-                        Models are paired with the GPU they need to run effectively. Garden provides researchers free monthly GPU quotas to try out models. 
+                        Models are paired with the GPU they need to run effectively. Garden provides researchers free monthly GPU quotas to try out models.
                       </p>
                       <p className="text-base text-gray-800 pt-2">
                         For large production runs, you can "bring your own compute" by applying HPC allocations or cloud credits.{" "}
                       </p>
-                      
+
                     </div>
                   </>
                 </AccordionContent>
@@ -315,11 +312,11 @@ const HomePage = () => {
                   <>
                     <div className="rounded-md border bg-white p-6">
                       <p className="text-base text-gray-800 ">
-                        If you already publish your model weights on Hugging Face, that's great! 
+                        If you already publish your model weights on Hugging Face, that's great!
                         Garden's job is on-demand inference, not file storage.
                       </p>
                       <p className="text-base text-gray-800 pt-2">
-                        We recommend users publish their model weights and code on open repositories 
+                        We recommend users publish their model weights and code on open repositories
                         like Hugging Face and use Garden to make them runnable on-demand.{" "}
                       </p>
                     </div>
@@ -331,7 +328,7 @@ const HomePage = () => {
         </div>
 
       </div>
-      
+
 
       <div className="mx-auto mt-12 max-w-5xl px-4 mb-12">
         <h2 className="text-3xl font-semibold">Get Started in Seconds</h2>
@@ -353,45 +350,45 @@ result = g.predict_piezoelectric_displacement(materials)`}
             <div className="w-full md:w-1/2">
               <h3 className="mb-4 text-2xl font-semibold">Easy To Run, Easy To Publish</h3>
               <p className="mb-6 text-lg">
-                  Garden uses{" "}
-                  <a
-                    href="https://modal.com/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-green hover:text-darkgreen hover:underline"
-                  >
-                    Modal
-                  </a>{" "}
-                  to run models in the cloud and{" "}
-                  <a
-                    href="https://www.globus.org/compute"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-green hover:text-darkgreen hover:underline"
-                  >
-                    Globus Compute
-                  </a>{" "}
-                  to run models on Research computing clusters.
-                  
-                  {" "}
-                  <a
-                    href="https://garden-ai.readthedocs.io/en/latest/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-green hover:text-darkgreen hover:underline"
-                  >
-                    Read our documentation
-                  </a>{" "}
-                  to learn how to publish your models with Garden.
+                Garden uses{" "}
+                <a
+                  href="https://modal.com/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-green hover:text-darkgreen hover:underline"
+                >
+                  Modal
+                </a>{" "}
+                to run models in the cloud and{" "}
+                <a
+                  href="https://www.globus.org/compute"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-green hover:text-darkgreen hover:underline"
+                >
+                  Globus Compute
+                </a>{" "}
+                to run models on Research computing clusters.
+
+                {" "}
+                <a
+                  href="https://garden-ai.readthedocs.io/en/latest/"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-green hover:text-darkgreen hover:underline"
+                >
+                  Read our documentation
+                </a>{" "}
+                to learn how to publish your models with Garden.
               </p>
             </div>
           </div>
         </div>
       </div>
 
-      
 
-      
+
+
     </div>
   );
 };

--- a/garden/src/features/gardens/api/usePatchGarden.ts
+++ b/garden/src/features/gardens/api/usePatchGarden.ts
@@ -2,7 +2,6 @@ import { Garden, GardenPatchRequest } from "@/types";
 import axios from "@/lib/axios";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { useNavigate } from "react-router-dom";
 
 interface PatchGardenProps {
   doi: string;
@@ -15,12 +14,11 @@ const patchGarden = async ({ doi, garden }: PatchGardenProps): Promise<Garden> =
     const response = await axios.patch(`/gardens/${doi}`, garden);
     return response.data;
   } catch (error) {
-    throw new Error("Error patching garden");
+    throw new Error(`Error patching garden: ${error}`);
   }
 };
 
 export const usePatchGarden = () => {
-  const navigate = useNavigate();
   const queryClient = useQueryClient();
   return useMutation<Garden, Error, PatchGardenProps, { previousGarden: Garden | undefined }>({
     mutationFn: patchGarden,
@@ -47,7 +45,6 @@ export const usePatchGarden = () => {
           description: garden.description ?? previousGarden.description,
           year: garden.year ?? previousGarden.year,
           version: garden.version ?? previousGarden.version,
-          is_test: garden.is_test ?? previousGarden.is_test,
           is_archived: garden.is_archived ?? previousGarden.is_archived,
           doi_is_draft: garden.doi_is_draft ?? previousGarden.doi_is_draft,
           tags: garden.tags ?? previousGarden.tags ?? [],
@@ -68,12 +65,12 @@ export const usePatchGarden = () => {
     onSuccess: (data, input) => {
       // Update the cache with the new data
       queryClient.setQueryData(["garden", data.doi], data);
-      
+
       // Invalidate related queries
       queryClient.invalidateQueries({ queryKey: ["garden", data.doi] });
       queryClient.invalidateQueries({ queryKey: ["gardens"] });
       queryClient.invalidateQueries({ queryKey: ["search"] });
-      
+
       // Use custom success message if provided, otherwise use default
       toast.success(input.successMessage || "Garden updated successfully!");
     },

--- a/garden/src/features/gardens/components/GardenDropdownOptions.tsx
+++ b/garden/src/features/gardens/components/GardenDropdownOptions.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { useNavigate } from "react-router-dom";
 import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { Archive, Edit, EllipsisVertical, Globe, Trash, TriangleAlert, FlaskConical } from "lucide-react";
+import { Archive, EllipsisVertical, Globe, Trash, TriangleAlert } from "lucide-react";
 
 import { useUpdateDOI } from "@/api/doi/useUpdateDOI";
 import { Alert, AlertDescription, AlertTitle } from "@/components/shadcn/alert";
@@ -39,12 +39,10 @@ import { SUPER_USERS } from "@/utils/utils";
 
 const GardenDropdownMenu = ({ garden }: { garden: Garden }) => {
   const auth = useGlobusAuth();
-  const navigate = useNavigate();
 
   const [isPublishGardenModalOpen, setIsPublishGardenModalOpen] = React.useState(false);
   const [isDeleteGardenModalOpen, setIsDeleteGardenModalOpen] = React.useState(false);
   const [isArchiveGardenModalOpen, setIsArchiveGardenModalOpen] = React.useState(false);
-  const [isMakeTestModalOpen, setIsMakeTestModalOpen] = React.useState(false);
 
   const isSuperUser = SUPER_USERS.includes(auth.authorization?.user?.sub);
   if ((!auth.isAuthenticated || garden.owner_identity_id !== auth.authorization?.user?.sub) && !isSuperUser) {
@@ -69,13 +67,6 @@ const GardenDropdownMenu = ({ garden }: { garden: Garden }) => {
                 <Globe className="mr-2 h-5 w-5" />
                 <span className="">Register Garden DOI</span>
               </DropdownMenuItem>
-
-              {!garden.is_test && (
-                <DropdownMenuItem onSelect={() => setIsMakeTestModalOpen(true)}>
-                  <FlaskConical className="mr-2 h-5 w-5" />
-                  <span className="">Make Test Garden</span>
-                </DropdownMenuItem>
-              )}
 
               <DropdownMenuItem
                 onSelect={() => setIsDeleteGardenModalOpen(true)}
@@ -119,12 +110,6 @@ const GardenDropdownMenu = ({ garden }: { garden: Garden }) => {
         isOpen={isArchiveGardenModalOpen}
         setIsOpen={setIsArchiveGardenModalOpen}
       />
-
-      <MakeTestGardenModal
-        garden={garden}
-        isOpen={isMakeTestModalOpen}
-        setIsOpen={setIsMakeTestModalOpen}
-      />
     </>
   );
 };
@@ -137,7 +122,7 @@ const LoadingOverlay = () => {
   );
 };
 
-const PublishGardenModal = ({
+export const PublishGardenModal = ({
   garden,
   isOpen,
   setIsOpen,
@@ -170,7 +155,7 @@ const PublishGardenModal = ({
           toast.success("Garden DOI registered successfully!");
           updateGarden({
             doi,
-            garden: { doi_is_draft: false, is_archived: false, is_test: false },
+            garden: { doi_is_draft: false, is_archived: false },
           });
 
           for (const entrypoint of garden.entrypoints || []) {
@@ -257,78 +242,6 @@ const PublishGardenModal = ({
         </AlertDialogFooter>
       </AlertDialogContent>
 
-      {isPending && <LoadingOverlay />}
-    </AlertDialog>
-  );
-};
-
-const MakeTestGardenModal = ({
-  garden,
-  isOpen,
-  setIsOpen,
-}: {
-  garden: Garden;
-  isOpen: boolean;
-  setIsOpen: (open: boolean) => void;
-}) => {
-  const queryClient = useQueryClient();
-  const { mutate: updateGarden, isPending } = usePatchGarden();
-  const doi = garden.doi;
-
-  const handleMakeTestGarden = () => {
-    updateGarden(
-      {
-        doi,
-        garden: {
-          is_test: true
-        },
-      },
-      {
-        onSuccess: () => {
-          setIsOpen(false);
-          queryClient.invalidateQueries({ queryKey: ["garden", doi] });
-          toast.success("Garden converted to test mode successfully!");
-        },
-        onError: () => {
-          toast.error("Error converting garden to test mode");
-        },
-      }
-    );
-  };
-
-  return (
-    <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Convert to Test Garden</AlertDialogTitle>
-          <AlertDialogDescription className="pb-3">
-            Are you sure you want to convert this to a test garden?
-          </AlertDialogDescription>
-          <Alert className="rounded-lg border-yellow-200 bg-yellow-50 p-4 text-yellow-800 shadow-md">
-            <div className="mb-2 flex items-center space-x-2">
-              <FlaskConical className="mb-1 h-5 w-5 text-yellow-600" />
-              <AlertTitle className="text-lg font-semibold">What This Means</AlertTitle>
-            </div>
-            <AlertDescription className="space-y-4">
-              <ul className="list-disc space-y-1 pl-5">
-                <li>The garden will no longer appear in search results</li>
-                <li>Users can still access it directly via the URL</li>
-                <li>You can make it public again at any time</li>
-              </ul>
-            </AlertDescription>
-          </Alert>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction
-            onClick={handleMakeTestGarden}
-            disabled={isPending}
-            className="bg-primary hover:bg-primary/60"
-          >
-            Make Test Garden
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
       {isPending && <LoadingOverlay />}
     </AlertDialog>
   );

--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -54,7 +54,7 @@ const GardenContent = ({ garden, ownsThisGarden, isNewlyCreated }: GardenContent
         ownsThisGarden={ownsThisGarden}
       />
 
-      {ownsThisGarden && !isPublished && <VisibilityWarning garden={garden} />}
+      {ownsThisGarden && !isPublished && <VisibilityWarning />}
 
       {/* Hero Metadata Section */}
       <div className="bg-gradient-to-b from-white to-gray-50 rounded-lg shadow-md border border-gray-100 p-6 mb-6">

--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -35,6 +35,7 @@ interface GardenContentProps {
 
 const GardenContent = ({ garden, ownsThisGarden, isNewlyCreated }: GardenContentProps) => {
   const { mutateAsync: patchGarden } = usePatchGarden();
+  const isPublished = !garden.is_archived && !garden.doi_is_draft;
   return (
     <div className="container max-w-7xl">
       <div className="mt-2 mb-4">
@@ -53,7 +54,7 @@ const GardenContent = ({ garden, ownsThisGarden, isNewlyCreated }: GardenContent
         ownsThisGarden={ownsThisGarden}
       />
 
-      {garden.is_test && ownsThisGarden && <VisibilityWarning garden={garden} updateGarden={patchGarden} />}
+      {ownsThisGarden && !isPublished && <VisibilityWarning garden={garden} />}
 
       {/* Hero Metadata Section */}
       <div className="bg-gradient-to-b from-white to-gray-50 rounded-lg shadow-md border border-gray-100 p-6 mb-6">

--- a/garden/src/features/gardens/components/create/CreateGardenForm.tsx
+++ b/garden/src/features/gardens/components/create/CreateGardenForm.tsx
@@ -33,9 +33,9 @@ interface CreateGardenFormProps {
   onFormStateChange?: (isSubmitting: boolean) => void;
 }
 
-export const CreateGardenForm = ({ 
-  modalAppId, 
-  onFormStateChange 
+export const CreateGardenForm = ({
+  modalAppId,
+  onFormStateChange
 }: CreateGardenFormProps) => {
   const navigate = useNavigate();
   const auth = useGlobusAuth();
@@ -54,7 +54,6 @@ export const CreateGardenForm = ({
       entrypoint_ids: [],
       doi: "", // Will be generated
       doi_is_draft: true,
-      is_test: true,
       year: "2025",
       language: "en",
       tags: [],
@@ -103,7 +102,7 @@ export const CreateGardenForm = ({
           ...(modalApp.modal_function_ids || []),
           ...(values.modal_function_ids || [])
         ];
-        
+
         // Remove duplicates if any
         gardenCreateRequest.modal_function_ids = [...new Set(gardenCreateRequest.modal_function_ids)];
       }
@@ -117,7 +116,7 @@ export const CreateGardenForm = ({
         const apiError = ApiError.fromAxiosError(error);
         const errorMessage = apiError.message;
         const suggestedFix = apiError.suggestedFix;
-        
+
         if (suggestedFix) {
           toast.error(<div>
             <p>{errorMessage}</p>
@@ -129,7 +128,7 @@ export const CreateGardenForm = ({
       } else if (error instanceof ApiError) {
         const errorMessage = error.message;
         const suggestedFix = error.suggestedFix;
-        
+
         if (suggestedFix) {
           toast.error(<div>
             <p>{errorMessage}</p>
@@ -143,7 +142,7 @@ export const CreateGardenForm = ({
       } else {
         toast.error("An unknown error occurred. Please check the form and try again.");
       }
-      
+
       console.error(error);
     }
   };
@@ -152,9 +151,9 @@ export const CreateGardenForm = ({
     <>
       <div className="rounded-lg border bg-white p-6 shadow-sm">
         <h2 className="mb-6 text-xl font-bold">Create Garden</h2>
-        
+
         <Form {...form}>
-          <form 
+          <form
             onSubmit={form.handleSubmit(onSubmit)}
             onKeyDown={(e) => {
               // Prevent form submission when Enter is pressed in any input field

--- a/garden/src/features/gardens/components/garden-page/VisibilityWarning.tsx
+++ b/garden/src/features/gardens/components/garden-page/VisibilityWarning.tsx
@@ -1,63 +1,19 @@
-import React, { useState } from "react";
-import { Garden } from "@/types";
-import { useQueryClient } from "@tanstack/react-query";
-import { toast } from "sonner";
-import LoadingSpinner from "@/components/LoadingSpinner";
+import React from "react";
 
-interface VisibilityWarningProps {
-  garden: Garden;
-  updateGarden: Function;
-}
-
-const VisibilityWarning = ({ garden, updateGarden }: VisibilityWarningProps) => {
-  const [isLoading, setIsLoading] = useState(false);
-  const queryClient = useQueryClient();
-  
-  const handleMakePublic = () => {
-    setIsLoading(true);
-    
-    updateGarden(
-      {
-        doi: garden.doi,
-        garden: { is_test: false }
-      },
-      {
-        onSuccess: () => {
-          queryClient.invalidateQueries({ queryKey: ["gardens"] });
-          queryClient.invalidateQueries({ queryKey: ["search"] });
-          toast.success("Garden is now public");
-          setIsLoading(false);
-        },
-        onError: (error: any) => {
-          toast.error(`Error making garden public: ${error.message}`);
-          setIsLoading(false);
-        },
-      }
-    );
-  };
+const VisibilityWarning = () => {
 
   return (
     <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-6">
-      <div className="flex items-start">
+      <div className="flex items-start items-center">
         <div className="flex-1">
-          <h3 className="font-medium text-amber-800">This is a Test Garden</h3>
+          <h3 className="font-medium text-amber-800">This is Garden is not public</h3>
           <p className="text-amber-700 text-sm mt-1">
-            This garden won't show up in search results. Other users can still access it directly if you share the link.
+            This Garden won&apos;t show up in search results. Register the DOI to make it public.
+          </p>
+          <p className="text-amber-700 text-sm mt-1">
+            Other users can still access it directly if you share the DOI.
           </p>
         </div>
-        <button
-          onClick={handleMakePublic}
-          disabled={isLoading}
-          className="px-3 py-1.5 bg-amber-600 text-white rounded-md hover:bg-amber-700 disabled:opacity-50 disabled:cursor-not-allowed"
-        >
-          {isLoading ? (
-            <span className="flex items-center">
-              <LoadingSpinner /> Making public...
-            </span>
-          ) : (
-            "Make Garden Public"
-          )}
-        </button>
       </div>
     </div>
   );

--- a/garden/src/features/gardens/types/garden.types.ts
+++ b/garden/src/features/gardens/types/garden.types.ts
@@ -9,14 +9,13 @@ export const gardenFormSchema = z.object({
   description: z
     .string()
     .max(1000, { message: "Description must not exceed 1000 characters" }),
-  
+
   authors: z.array(z.string()),
   contributors: z.array(z.string()),
   tags: z.array(z.string()),
   doi: z.string(), // Will be generated
   doi_is_draft: z.boolean(),
   is_archived: z.boolean(),
-  is_test: z.boolean(),
   year: z.string().optional(),
   language: z.string().optional(),
   version: z.string().regex(/^\d+\.\d+(\.\d+)?$/, {

--- a/garden/src/features/search/api/useSearchGardens.ts
+++ b/garden/src/features/search/api/useSearchGardens.ts
@@ -47,10 +47,6 @@ export const transformSearchParamsToSearchRequest = (searchParams: URLSearchPara
 
   const defaultFilters: GardenSearchFilter[] = [
     {
-      field_name: "is_test",
-      values: ["false"],
-    },
-    {
       field_name: "is_archived",
       values: ["false"],
     },

--- a/garden/src/types/backend-schema.ts
+++ b/garden/src/types/backend-schema.ts
@@ -1421,11 +1421,6 @@ export interface components {
             doi: string;
             /** Doi Is Draft */
             doi_is_draft?: boolean | null;
-            /**
-             * Is Test
-             * @default false
-             */
-            is_test: boolean;
             /** Description */
             description: string | null;
             /**
@@ -1475,11 +1470,6 @@ export interface components {
             doi: string;
             /** Doi Is Draft */
             doi_is_draft?: boolean | null;
-            /**
-             * Is Test
-             * @default false
-             */
-            is_test: boolean;
             /** Description */
             description: string | null;
             /**
@@ -1556,8 +1546,6 @@ export interface components {
             } | null;
             /** Is Archived */
             is_archived?: boolean | null;
-            /** Is Test */
-            is_test?: boolean | null;
             /** Entrypoint Ids */
             entrypoint_ids?: string[] | null;
             /** Modal Function Ids */

--- a/garden/tests/app/features/gardens/GardenPage.test.tsx
+++ b/garden/tests/app/features/gardens/GardenPage.test.tsx
@@ -16,7 +16,6 @@ const fakeGarden = {
     is_archived: false,
     entrypoints: [],
     modal_functions: [],
-    is_test: false
 };
 
 vi.mock("react-router-dom", async () => {
@@ -46,17 +45,17 @@ function setupTest({
     if (isNewlyCreated) {
         testParams.set("newlyCreated", "true");
     }
-    
+
     // Mock useSearchParams directly for this test
     vi.spyOn(require("react-router-dom"), "useSearchParams").mockReturnValue([
         testParams,
         vi.fn()
     ]);
-    
-    const authUser = { 
-        sub: isOwner ? "user-123" : "different-user-456" 
+
+    const authUser = {
+        sub: isOwner ? "user-123" : "different-user-456"
     };
-    
+
     // Mock the auth hook
     vi.spyOn(authHook, "useGlobusAuth").mockReturnValue(createMockAuthState({
         isAuthenticated: true,
@@ -65,7 +64,7 @@ function setupTest({
             authenticated: true
         } as any
     }));
-    
+
     // Mock the garden API
     vi.spyOn(getGardenHook, "useGetGarden").mockReturnValue({
         data: fakeGarden,
@@ -86,7 +85,7 @@ describe("GardenPage", () => {
                         authenticated: true
                     } as any
                 }));
-                
+
                 // Mock the garden API
                 vi.spyOn(getGardenHook, "useGetGarden").mockReturnValue({
                     data: fakeGarden,
@@ -117,40 +116,40 @@ describe("GardenPage", () => {
                     authenticated: true
                 } as any
             }));
-            
+
             // Mock the garden API
             vi.spyOn(getGardenHook, "useGetGarden").mockReturnValue({
                 data: fakeGarden,
                 isLoading: false,
                 isError: false
             } as any);
-            
+
             // Render the GardenPage component
             renderWithProviders(
                 <MemoryRouter>
                     <GardenPage />
                 </MemoryRouter>
             );
-            
+
             // Verify that edit buttons are visible and interactive for the owner
-            
+
             // Check that the edit title button is present and interactive
             const editTitleButton = screen.getByLabelText("Edit title");
             expect(editTitleButton).toBeInTheDocument();
             expect(editTitleButton).not.toHaveAttribute("aria-hidden", "true");
             expect(editTitleButton).not.toBeDisabled();
-            
+
             // Check for editable metadata fields that should be interactive for owners
             const editAuthorButton = screen.getByLabelText("Edit model authors");
             expect(editAuthorButton).toBeInTheDocument();
             expect(editAuthorButton).not.toHaveAttribute("aria-hidden", "true");
             expect(editAuthorButton).not.toBeDisabled();
-            
+
             const editYearButton = screen.getByLabelText("Edit year");
             expect(editYearButton).toBeInTheDocument();
             expect(editYearButton).not.toHaveAttribute("aria-hidden", "true");
             expect(editYearButton).not.toBeDisabled();
-            
+
             // Check that description can be edited (owner-only function)
             const editDescriptionButton = screen.getByLabelText("Edit description");
             expect(editDescriptionButton).toBeInTheDocument();
@@ -169,61 +168,61 @@ describe("GardenPage", () => {
                     authenticated: true
                 } as any
             }));
-            
+
             // Mock the garden API
             vi.spyOn(getGardenHook, "useGetGarden").mockReturnValue({
                 data: fakeGarden,
                 isLoading: false,
                 isError: false
             } as any);
-            
+
             // Render the GardenPage component
             const { container } = renderWithProviders(
                 <MemoryRouter>
                     <GardenPage />
                 </MemoryRouter>
             );
-            
+
             // Check that edit controls are properly secured for non-owners
-            
+
             // The page might implement security in different ways:
             // 1. Not rendering edit buttons at all for non-owners
             // 2. Rendering disabled buttons
             // 3. Removing click handlers from buttons
-            
+
             // Check if title edit functionality exists
             const editTitleButton = screen.queryByLabelText("Edit title");
-            
+
             // If the button doesn't exist at all, that's one secure approach
             if (!editTitleButton) {
                 expect(editTitleButton).toBeNull();
             } else {
                 // If it exists, it must be properly disabled
                 expect(
-                    editTitleButton.hasAttribute("disabled") || 
+                    editTitleButton.hasAttribute("disabled") ||
                     !editTitleButton.onclick // No click handler
                 ).toBeTruthy();
             }
-            
+
             // More comprehensive check: make sure no enabled edit buttons exist in the entire document
             const allButtons = container.querySelectorAll('button');
             const enabledEditButtons = Array.from(allButtons).filter(button => {
-                const isEditButton = button.textContent?.toLowerCase().includes('edit') || 
-                                    button.getAttribute('aria-label')?.toLowerCase().includes('edit');
+                const isEditButton = button.textContent?.toLowerCase().includes('edit') ||
+                    button.getAttribute('aria-label')?.toLowerCase().includes('edit');
                 const isEnabled = !button.hasAttribute('disabled');
                 return isEditButton && isEnabled;
             });
-            
+
             // There should be no enabled edit buttons for non-owners
             expect(enabledEditButtons.length).toBe(0);
-            
+
             // Check specific metadata fields - they should either not be editable or not have edit buttons
             const metadataEditControls = [
                 screen.queryByLabelText("Edit Authors"),
                 screen.queryByLabelText("Edit Year"),
                 screen.queryByLabelText("Edit description")
             ];
-            
+
             metadataEditControls.forEach(control => {
                 if (control) {
                     // If control exists, ensure it's properly disabled

--- a/garden/tests/app/features/modal/components/UploadModalAppForm.test.tsx
+++ b/garden/tests/app/features/modal/components/UploadModalAppForm.test.tsx
@@ -148,7 +148,7 @@ describe("UploadModalAppForm", () => {
     describe("when deployment fails", () => {
         it("should render the deployment error message", () => {
             const errorMessage = "DEPLOYMENT_ERROR FOR TESTING";
-            
+
             vi.spyOn(useModalAppFormModule, "useModalAppForm")
                 .mockReturnValue(createDeploymentErrorResponse(errorMessage));
 
@@ -160,7 +160,7 @@ describe("UploadModalAppForm", () => {
 
             // Check for error message content
             expect(screen.getByText(errorMessage)).toBeInTheDocument();
-            
+
             // Check for deployment error alert title
             expect(screen.getByText("Deployment Error")).toBeInTheDocument();
         });
@@ -176,7 +176,7 @@ describe("UploadModalAppForm", () => {
                     <UploadModalAppForm />
                 </MemoryRouter>
             );
-            
+
             // When deployment is in progress, we should see the loading component
             expect(screen.getByText("Deploying your Modal app...")).toBeInTheDocument();
             expect(screen.getByText("Deployment in Progress")).toBeInTheDocument();
@@ -189,10 +189,10 @@ describe("UploadModalAppForm", () => {
                 e.preventDefault();
                 return Promise.resolve();
             });
-            
+
             // We need to mock the form object's handleSubmit too
             const formHandleSubmitSpy = vi.fn(() => handleSubmitSpy);
-            
+
             vi.spyOn(useModalAppFormModule, "useModalAppForm")
                 .mockReturnValue({
                     ...createValidationResponse(false, ""),
@@ -210,7 +210,7 @@ describe("UploadModalAppForm", () => {
                     <UploadModalAppForm />
                 </MemoryRouter>
             );
-            
+
             // Get the deploy button and verify it's enabled
             const deployButton = screen.getByRole('button', { name: /Deploy Modal App/i });
             expect(deployButton).toBeEnabled();


### PR DESCRIPTION
Resolves: #340 

This PR removes all traces (at least all I could find) of gardens being in a 'Test' state.

The only UI changes are:

**Rewording the visibility warning**
<img width="856" alt="image" src="https://github.com/user-attachments/assets/a4307a85-54e9-4ac3-8ae0-0b4e8416a9ed" />

**Removing the 'test' related options from the dropdown**
<img width="329" alt="image" src="https://github.com/user-attachments/assets/c49b0ee0-0701-4538-90b9-9ff9904adab1" />

A few other files got hit by the auto-formatter.
