### PR TITLE
Clean up copy around garden publication

### DIFF
--- a/garden/src/components/Navbar.tsx
+++ b/garden/src/components/Navbar.tsx
@@ -77,7 +77,7 @@ const Navbar = () => {
                   <Plus size={24} className="hover:text-green" />
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p>Deploy & Create a Garden</p>
+                  <p>Make a Garden</p>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>

--- a/garden/src/components/TombstonePage.tsx
+++ b/garden/src/components/TombstonePage.tsx
@@ -1,5 +1,4 @@
 import { Garden } from "@/types";
-import GardenDropdownOptions from "@/features/gardens/components/GardenDropdownOptions";
 import { CircleAlert } from "lucide-react";
 
 const TombstonePage = ({ garden }: { garden: Garden }) => {
@@ -9,7 +8,6 @@ const TombstonePage = ({ garden }: { garden: Garden }) => {
         <div className="bg-gray-200 px-6 py-4">
           <div className="flex items-center justify-between">
             <h1 className="text-2xl font-bold text-gray-800">Garden Archived</h1>
-            <GardenDropdownOptions garden={garden} />
           </div>
         </div>
 

--- a/garden/src/features/gardens/components/GardenDropdownOptions.tsx
+++ b/garden/src/features/gardens/components/GardenDropdownOptions.tsx
@@ -33,10 +33,9 @@ import { usePatchGarden } from "../api/usePatchGarden";
 
 import { SUPER_USERS } from "@/utils/utils";
 
-const GardenDropdownMenu = ({ garden }: { garden: Garden }) => {
+const GardenDropdownMenu = ({ garden, setIsPublishGardenModalOpen }: { garden: Garden, setIsPublishGardenModalOpen: (open: boolean) => void }) => {
   const auth = useGlobusAuth();
 
-  const [isPublishGardenModalOpen, setIsPublishGardenModalOpen] = React.useState(false);
   const [isDeleteGardenModalOpen, setIsDeleteGardenModalOpen] = React.useState(false);
   const [isArchiveGardenModalOpen, setIsArchiveGardenModalOpen] = React.useState(false);
 
@@ -61,7 +60,7 @@ const GardenDropdownMenu = ({ garden }: { garden: Garden }) => {
             <>
               <DropdownMenuItem onSelect={() => setIsPublishGardenModalOpen(true)}>
                 <Globe className="mr-2 h-5 w-5" />
-                <span className="">Register Garden DOI</span>
+                <span className="">Publish Garden</span>
               </DropdownMenuItem>
 
               <DropdownMenuItem
@@ -88,12 +87,6 @@ const GardenDropdownMenu = ({ garden }: { garden: Garden }) => {
           )}
         </DropdownMenuContent>
       </DropdownMenu>
-
-      <PublishGardenModal
-        isOpen={isPublishGardenModalOpen}
-        setIsOpen={setIsPublishGardenModalOpen}
-        garden={garden}
-      />
 
       <DeleteGardenModal
         garden={garden}
@@ -158,9 +151,9 @@ export const PublishGardenModal = ({
     <AlertDialog open={isOpen} onOpenChange={setIsOpen}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Register Garden DOI</AlertDialogTitle>
+          <AlertDialogTitle>Publish Garden</AlertDialogTitle>
           <AlertDialogDescription className="pb-4">
-            Register your garden's DOI to make it citable.
+            Publish your garden to make it findable and citable.
           </AlertDialogDescription>
           <Alert className="my-4 rounded-lg border-yellow-200 bg-yellow-50 p-4 text-yellow-800 shadow-md">
             <div className="mb-2 flex items-center space-x-2">
@@ -169,21 +162,22 @@ export const PublishGardenModal = ({
             </div>
             <AlertDescription className="space-y-4">
               <ul className="list-disc space-y-1 pl-5">
-                <li>This will make your Garden's DOI findable on doi.org.</li>
-                <li>Gardens with registered DOIs can be archived (hidden) but not deleted.</li>
+                <li>Other users will be able to find your Garden in search results.</li>
+                <li>Your Garden's DOI will findable on doi.org.</li>
+                <li>Published Gardens can be archived (hidden) but not deleted.</li>
               </ul>
             </AlertDescription>
           </Alert>
 
           <p className="pt-3 text-sm">
             Please type
-            <span className="font-semibold"> register {doi} </span>to confirm:
+            <span className="font-semibold"> publish {doi} </span>to confirm:
           </p>
           <div className=" mb-4">
             <Input
               type="text"
               className="mt-2 w-full rounded border border-gray-300 p-2"
-              placeholder={`register ${doi}`}
+              placeholder={`publish ${doi}`}
               value={input}
               onChange={(e) => setInput(e.target.value)}
             />
@@ -193,10 +187,10 @@ export const PublishGardenModal = ({
           <AlertDialogCancel>Cancel</AlertDialogCancel>
           <AlertDialogAction
             onClick={handleRegisterGardenDOI}
-            disabled={isPending || input !== `register ${doi}`}
+            disabled={isPending || input !== `publish ${doi}`}
             className="bg-primary hover:bg-primary/60"
           >
-            I understand, register DOI for this Garden
+            I understand, publish this Garden
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/garden/src/features/gardens/components/GardenDropdownOptions.tsx
+++ b/garden/src/features/gardens/components/GardenDropdownOptions.tsx
@@ -71,11 +71,6 @@ const GardenDropdownMenu = ({ garden, setIsPublishGardenModalOpen }: { garden: G
                 <span className="">Delete Garden</span>
               </DropdownMenuItem>
             </>
-          ) : garden.is_archived ? (
-            <DropdownMenuItem onSelect={() => setIsPublishGardenModalOpen(true)}>
-              <Globe className="mr-2 h-5 w-5" />
-              <span className="">Make Garden Visible</span>
-            </DropdownMenuItem>
           ) : (
             <DropdownMenuItem
               onSelect={() => setIsArchiveGardenModalOpen(true)}

--- a/garden/src/features/gardens/components/GardenMetadataSidebar.tsx
+++ b/garden/src/features/gardens/components/GardenMetadataSidebar.tsx
@@ -69,16 +69,6 @@ export const GardenMetadataSidebar = ({garden, ownsThisGarden}: {garden: Garden,
             />
 
             <EditableMetadataField
-                label="Version"
-                helpText="Garden version"
-                value={garden.version}
-                fieldName="version"
-                entity={garden}
-                ownsThisEntity={ownsThisGarden}
-                onUpdate={updateGarden}
-            />
-
-            <EditableMetadataField
                 label="Tags"
                 helpText="Tags help users discover this Garden"
                 value={garden.tags}

--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -7,6 +7,7 @@ import { LoadingOverlay } from "@/components/LoadingOverlay";
 import NotFoundPage from "@/components/NotFoundPage";
 import TombstonePage from "@/components/TombstonePage";
 import SaveGardenButton from "./SaveGardenButton";
+import { PublishGardenModal } from "@/features/gardens/components/GardenDropdownOptions";
 
 import { useGetGarden } from "../api/useGetGarden";
 import { usePatchGarden } from "../api/usePatchGarden";
@@ -36,6 +37,8 @@ interface GardenContentProps {
 const GardenContent = ({ garden, ownsThisGarden, isNewlyCreated }: GardenContentProps) => {
   const { mutateAsync: patchGarden } = usePatchGarden();
   const isPublished = !garden.is_archived && !garden.doi_is_draft;
+  const [isPublishGardenModalOpen, setIsPublishGardenModalOpen] = React.useState(false);
+
   return (
     <div className="container max-w-7xl">
       <div className="mt-2 mb-4">
@@ -54,7 +57,13 @@ const GardenContent = ({ garden, ownsThisGarden, isNewlyCreated }: GardenContent
         ownsThisGarden={ownsThisGarden}
       />
 
-      {ownsThisGarden && !isPublished && <VisibilityWarning />}
+      {ownsThisGarden && !isPublished && (
+        <VisibilityWarning
+          garden={garden}
+          isPublishGardenModalOpen={isPublishGardenModalOpen}
+          setIsPublishGardenModalOpen={setIsPublishGardenModalOpen}
+        />
+      )}
 
       {/* Hero Metadata Section */}
       <div className="bg-gradient-to-b from-white to-gray-50 rounded-lg shadow-md border border-gray-100 p-6 mb-6">
@@ -74,7 +83,10 @@ const GardenContent = ({ garden, ownsThisGarden, isNewlyCreated }: GardenContent
               />
               <div className="flex">
                 <SaveGardenButton garden={garden} />
-                <GardenDropdownOptions garden={garden} />
+                <GardenDropdownOptions
+                  garden={garden}
+                  setIsPublishGardenModalOpen={setIsPublishGardenModalOpen}
+                />
               </div>
             </div>
 
@@ -96,6 +108,12 @@ const GardenContent = ({ garden, ownsThisGarden, isNewlyCreated }: GardenContent
           />
         </div>
       </div>
+
+      <PublishGardenModal
+        isOpen={isPublishGardenModalOpen}
+        setIsOpen={setIsPublishGardenModalOpen}
+        garden={garden}
+      />
     </div>
   );
 };

--- a/garden/src/features/gardens/components/garden-page/VisibilityWarning.tsx
+++ b/garden/src/features/gardens/components/garden-page/VisibilityWarning.tsx
@@ -1,18 +1,31 @@
 import React from "react";
+import { Button } from "@/components/shadcn/button";
 
-const VisibilityWarning = () => {
-
+const VisibilityWarning = ({ garden, isPublishGardenModalOpen, setIsPublishGardenModalOpen }: {
+  garden: any,
+  isPublishGardenModalOpen: boolean,
+  setIsPublishGardenModalOpen: (open: boolean) => void
+}) => {
   return (
     <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 mb-6">
       <div className="flex items-start items-center">
         <div className="flex-1">
-          <h3 className="font-medium text-amber-800">This is Garden is not public</h3>
+          <h3 className="font-medium text-amber-800">This is a draft Garden.</h3>
           <p className="text-amber-700 text-sm mt-1">
-            This Garden won&apos;t show up in search results. Register the DOI to make it public.
+            This Garden won&apos;t show up in search results. It will be auto-deleted after two weeks if it is not published.
           </p>
           <p className="text-amber-700 text-sm mt-1">
-            Other users can still access it directly if you share the DOI.
+            Publish this Garden to make it findable in search results.
           </p>
+        </div>
+        <div className="ml-4 flex-shrink-0">
+          <Button
+            variant="default"
+            onClick={() => setIsPublishGardenModalOpen(true)}
+            disabled={isPublishGardenModalOpen}
+          >
+            Publish Garden
+          </Button>
         </div>
       </div>
     </div>

--- a/garden/src/features/modal/components/FunctionMetadataSidebar.tsx
+++ b/garden/src/features/modal/components/FunctionMetadataSidebar.tsx
@@ -42,23 +42,6 @@ export const FunctionMetadataSidebar = ({
 
     return (
         <Metadata name={"Function"} entity={modalFunction} ownsThisEntity={ownsThisFunction}>
-          <div className="group border border-transparent bg-white rounded-md py-1.5 px-2.5 shadow-sm">
-            <div className="flex items-center justify-between">
-              <p className="text-sm text-gray-500 font-medium">DOI</p>
-              <CopyButton 
-                content={modalFunction.doi || ""} 
-                hint="Copy DOI" 
-                className="ml-2" 
-                icon={<LinkIcon className="h-4 w-4" />}
-              />
-            </div>
-            <div className="mt-0.5">
-              <p className="font-medium font-mono text-gray-800 overflow-hidden overflow-ellipsis">
-                {modalFunction.doi || "No DOI"}
-              </p>
-            </div>
-          </div>
-
           <EditableMetadataField
             label="Model Authors"
             helpText="Original authors of the models used by this function"


### PR DESCRIPTION
Part of https://github.com/Garden-AI/garden-backend/issues/301

This is a grab-bag of little tweaks around the new state management rules. The biggest change here is reframing publication away from registering a DOI and towards publishing a garden. Previous menu options and copy focused on registering a Garden's DOI.


<img width="1512" alt="Screenshot 2025-05-02 at 2 10 13 PM" src="https://github.com/user-attachments/assets/2c46ed37-1245-4386-b2e5-1b03ac73a28a" />

Now we warn about auto-deletion, and there is a new button in the draft state warning so that you don't need to dig through the meatball menu to publish.


<img width="540" alt="Screenshot 2025-05-02 at 2 10 22 PM" src="https://github.com/user-attachments/assets/70b3a2a2-cff7-430f-a9de-687d419240ef" />

<img width="267" alt="Screenshot 2025-05-02 at 2 10 17 PM" src="https://github.com/user-attachments/assets/0c7c58ad-d825-4706-86fe-a2004fedf01c" />

The top-level copy here used to be "Register DOI" which undersold what was going on.
