### PR TITLE
fix: draft gardens in search

### DIFF
--- a/garden/src/features/search/api/useSearchGardens.ts
+++ b/garden/src/features/search/api/useSearchGardens.ts
@@ -47,6 +47,10 @@ export const transformSearchParamsToSearchRequest = (searchParams: URLSearchPara
 
   const defaultFilters: GardenSearchFilter[] = [
     {
+      field_name: "doi_is_draft",
+      values: ["false"],
+    },
+    {
       field_name: "is_archived",
       values: ["false"],
     },


### PR DESCRIPTION
Resolves: #349 

This PR stops 'draft' gardens from showing up in search results.

Easy fix! We just needed to add a filter to the search request hitting POST `/gardens/search`:
```ts
{
    field_name: "doi_is_draft",
    values: ["false"],
}
```