### PR TITLE
fix: modal app upload dialog closes on success

### DIFF
--- a/garden/src/features/model-deployments/ModelDeploymentDetails.tsx
+++ b/garden/src/features/model-deployments/ModelDeploymentDetails.tsx
@@ -349,7 +349,7 @@ export const ModelDeploymentDetails = ({ entity }: ModelDeploymentDetailsProps) 
                         <DialogTitle>Update Model Deployment</DialogTitle>
                         <DialogDescription>Upload an updated Modal App file to update this model deployment.</DialogDescription>
                     </DialogHeader>
-                    <ModalAppForm toUpdate={entity.id} onDeploymentSuccess={() => setShowUpdateDialog(false)}></ModalAppForm>
+                    <ModalAppForm toUpdate={entity.id} onSuccess={() => setShowUpdateDialog(false)} />
                 </DialogContent>
             </Dialog>
 


### PR DESCRIPTION
Resolves: #351 

This PR fixes the bug when updating a modal app in-place, the form resets to step 3 and stays open, even though the deployment completed successfully.

*Before*

https://github.com/user-attachments/assets/ca3f8184-aebd-4b0c-93bd-29ef02bbd664

*After*

https://github.com/user-attachments/assets/a2751266-2cc2-46fa-8994-237564fca6c6

## Details

Easy fix! It was just a misnamed callback prop causing the issue.
The deployment details page was creating the upload form passing in `onDeplymentSuccess` when the form wants an `onSuccess` callback.

## Testing
Manually