### PR TITLE
improve handling of validation errors during modal app uploads

### DIFF
--- a/garden/src/features/gardens/api/useValidateModalFile.tsx
+++ b/garden/src/features/gardens/api/useValidateModalFile.tsx
@@ -1,6 +1,6 @@
 import axios from "@/lib/axios";
 import { useMutation } from "@tanstack/react-query";
-import {ModalFileMetadataRequest, ModalFileMetadataResponse} from "@/types";
+import { ModalFileMetadataRequest, ModalFileMetadataResponse } from "@/types";
 import { AxiosError } from "axios";
 import { ApiError } from "../utils/garden.utils";
 
@@ -11,7 +11,6 @@ const validateModalFile = async (
     const response = await axios.post(`/modal-file-metadata`, req);
     return response.data;
   } catch (error: unknown) {
-    console.log(error);
     if (error instanceof AxiosError) {
       throw ApiError.fromAxiosError(error);
     }

--- a/garden/src/features/gardens/components/create/CreateGardenPage.tsx
+++ b/garden/src/features/gardens/components/create/CreateGardenPage.tsx
@@ -35,7 +35,6 @@ const CreateGardenPage = () => {
       <div className="mx-auto max-w-6xl px-8 py-16 font-display">
         <OverallProgress currentPhase={1} />
         <ModalAppUploadPage
-          isMultiStep={true}
           onSuccess={(id: number) => {
             navigate(`/garden/create?modalAppId=${id}`);
           }}

--- a/garden/src/features/gardens/utils/garden.utils.ts
+++ b/garden/src/features/gardens/utils/garden.utils.ts
@@ -89,12 +89,17 @@ export class ApiError extends Error {
       deploymentOutput?: string,
     }
 
-    const responseData = error.response?.data as ApiErrorInfo;
+    const raw_data: unknown = error.response?.data;
+    const responseData = {
+      detail: raw_data.detail,
+      suggestedFix: raw_data.suggested_fix,
+      deploymentOutput: raw_data.deployment_output,
+    } as ApiErrorInfo;
+    let message = 'Unknown API Error';
     if (!responseData) {
-      return new ApiError(error.message || 'Unknown API Error');
+      return new ApiError(error.message || message);
     }
 
-    let message = 'Unknown API Error';
     let suggestedFix = responseData.suggestedFix;
     const deploymentOutput = responseData.deploymentOutput;
 
@@ -113,6 +118,7 @@ export class ApiError extends Error {
         }
       } else if (typeof responseData.detail === 'string') {
         message = responseData.detail;
+        suggestedFix = responseData.suggestedFix || ""
       }
     }
 
@@ -120,9 +126,9 @@ export class ApiError extends Error {
   }
 
   toString(): string {
-    const str = `Error: ${this.message}`;
-    const suggestedFix = this.suggestedFix ? `, suggested_fix: ${this.suggestedFix}` : '';
-    const deploymentOutput = this.deploymentOutput ? `, deployment_output: ${this.deploymentOutput}` : '';
+    const str = `Error: ${this.message} `;
+    const suggestedFix = this.suggestedFix ? `, suggested_fix: ${this.suggestedFix} ` : '';
+    const deploymentOutput = this.deploymentOutput ? `, deployment_output: ${this.deploymentOutput} ` : '';
     return str + suggestedFix + deploymentOutput;
   }
 }

--- a/garden/src/features/gardens/utils/garden.utils.ts
+++ b/garden/src/features/gardens/utils/garden.utils.ts
@@ -130,9 +130,9 @@ export class ApiError extends Error {
 export type MaterialType = 'datasets' | 'papers' | 'repositories' | 'notebooks';
 
 interface MaterialItem {
-  doi?: string;
-  url?: string;
-  title?: string;
+  doi?: string | null;
+  url?: string | null;
+  title?: string | null;
   [key: string]: unknown;
 }
 
@@ -143,10 +143,10 @@ export const getUniqueItemCount = (modalFunctions: ModalFunction[] | undefined, 
     switch (materialType) {
       case 'datasets':
       case 'papers':
-        return item.doi || item.url || item.title;
+        return item.doi || item.url || item.title || '';
       case 'repositories':
       case 'notebooks':
-        return item.url;
+        return item.url || '';
     }
   };
 

--- a/garden/src/features/gardens/utils/garden.utils.ts
+++ b/garden/src/features/gardens/utils/garden.utils.ts
@@ -84,17 +84,39 @@ export class ApiError extends Error {
 
   static fromAxiosError(error: AxiosError): ApiError {
     interface ApiErrorInfo {
-      detail: string,
-      suggestedFix: string,
-      deploymentOutput: string,
+      detail: string | Array<{ loc: Array<string | number>, msg: string, type: string }>,
+      suggestedFix?: string,
+      deploymentOutput?: string,
     }
-    const { detail, suggestedFix, deploymentOutput } = error.response?.data as ApiErrorInfo ?? {};
 
-    return new ApiError(
-      detail || 'Unknown API Error',
-      suggestedFix,
-      deploymentOutput,
-    );
+    const responseData = error.response?.data as ApiErrorInfo;
+    if (!responseData) {
+      return new ApiError(error.message || 'Unknown API Error');
+    }
+
+    let message = 'Unknown API Error';
+    let suggestedFix = responseData.suggestedFix;
+    const deploymentOutput = responseData.deploymentOutput;
+
+    // Handle different error formats from the backend
+    if (responseData.detail) {
+      if (Array.isArray(responseData.detail)) {
+        // Get the first validation error message from FastAPI
+        const firstError = responseData.detail[0];
+        if (firstError && firstError.msg) {
+          message = firstError.msg;
+
+          // Add helpful message for module import errors
+          if (message.includes('module level import') || message.includes('module-level import')) {
+            suggestedFix = suggestedFix || "Modal doesn't support module-level imports. Move your imports inside functions.";
+          }
+        }
+      } else if (typeof responseData.detail === 'string') {
+        message = responseData.detail;
+      }
+    }
+
+    return new ApiError(message, suggestedFix, deploymentOutput);
   }
 
   toString(): string {
@@ -107,10 +129,17 @@ export class ApiError extends Error {
 
 export type MaterialType = 'datasets' | 'papers' | 'repositories' | 'notebooks';
 
+interface MaterialItem {
+  doi?: string;
+  url?: string;
+  title?: string;
+  [key: string]: unknown;
+}
+
 export const getUniqueItemCount = (modalFunctions: ModalFunction[] | undefined, materialType: MaterialType): number => {
   if (!modalFunctions) return 0;
 
-  const getIdentifier = (item: any) => {
+  const getIdentifier = (item: MaterialItem) => {
     switch (materialType) {
       case 'datasets':
       case 'papers':

--- a/garden/src/features/gardens/utils/garden.utils.ts
+++ b/garden/src/features/gardens/utils/garden.utils.ts
@@ -89,7 +89,13 @@ export class ApiError extends Error {
       deploymentOutput?: string,
     }
 
-    const raw_data: unknown = error.response?.data;
+    interface ModalException {
+      detail: string | Array<{ loc: Array<string | number>, msg: string, type: string }>,
+      suggested_fix?: string,
+      deployment_output?: string,
+    }
+
+    const raw_data: ModalException = error.response?.data as ModalException;
     const responseData = {
       detail: raw_data.detail,
       suggestedFix: raw_data.suggested_fix,

--- a/garden/src/features/modal/api/useCreateModalApp.tsx
+++ b/garden/src/features/modal/api/useCreateModalApp.tsx
@@ -1,4 +1,4 @@
-import axios from "@/lib/axios";
+import instance from "@/lib/axios";
 import { useMutation } from "@tanstack/react-query";
 import { AxiosResponse, AxiosError } from "axios";
 import { ModalAppCreateRequest, ModalAppMetadataResponse, ModalAppPatchRequest } from "@/types";
@@ -28,8 +28,8 @@ export const createOrUpdateModalApp = async (
   try {
     // Make the initial request
     const response = update ?
-      await axios.patch(`/modal-apps/async/${update}`, req) :
-      await axios.post(`/modal-apps/async`, req);
+      await instance.patch(`/modal-apps/async/${update}`, req) :
+      await instance.post(`/modal-apps/async`, req);
 
     // Extract the job id from the response
     const appId = response.data.id
@@ -46,7 +46,7 @@ export const createOrUpdateModalApp = async (
         throw new DeployTimeoutError();
       }
 
-      const pollResponse = await axios.get(`/modal-apps/${appId}`);
+      const pollResponse = await instance.get(`/modal-apps/${appId}`);
       if (pollResponse.data.deploy_status === "error") {
         throw new ApiError(
           pollResponse.data.deploy_error,
@@ -63,7 +63,9 @@ export const createOrUpdateModalApp = async (
   } catch (error: unknown) {
     if (error instanceof AxiosError) {
       throw ApiError.fromAxiosError(error);
+    } else {
+      console.error(`Error not from Axios: ${error}`)
+      throw error;
     }
-    throw error;
   }
 };

--- a/garden/src/features/modal/api/useModalAppForm.tsx
+++ b/garden/src/features/modal/api/useModalAppForm.tsx
@@ -144,7 +144,7 @@ export const useModalAppForm = ({
 
         // Initialize the modal_functions field with the validated metadata
         const functions = metadata.modal_functions || [];
-        form.setValue("modal.modal_functions", functions as any);
+        form.setValue("modal.modal_functions", functions);
 
         setModalMetadata(metadata);
         toast.success("Modal file validated successfully");
@@ -154,6 +154,13 @@ export const useModalAppForm = ({
         if (useModalAppUploadValidationError) {
           // Use the actual backend error with its specific message and suggested fix
           setValidationError(useModalAppUploadValidationError);
+          toast.error("Validation failed");
+        } else {
+          // If for some reason we don't have a validation error, create a generic one
+          setValidationError({
+            message: "File validation failed. Please check your file and try again.",
+            isApiError: false
+          });
           toast.error("Validation failed");
         }
       }
@@ -251,7 +258,7 @@ export const useModalAppForm = ({
 
         // Initialize the modal_functions field with the validated metadata
         const functions = metadata.modal_functions || [];
-        form.setValue("modal.modal_functions", functions as any);
+        form.setValue("modal.modal_functions", functions);
 
         setModalMetadata(metadata);
         toast.success("Modal file validated successfully");
@@ -261,6 +268,13 @@ export const useModalAppForm = ({
         if (useModalAppUploadValidationError) {
           // Use the actual backend error with its specific message and suggested fix
           setValidationError(useModalAppUploadValidationError);
+          toast.error("Validation failed");
+        } else {
+          // If for some reason we don't have a validation error, create a generic one
+          setValidationError({
+            message: "File validation failed. Please check your file and try again.",
+            isApiError: false
+          });
           toast.error("Validation failed");
         }
       }
@@ -365,7 +379,7 @@ export const useModalAppForm = ({
           setSearchParams({ modalAppId: appId.toString() });
         }
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       // Get the properly formatted error from useModalAppUpload
       if (useModalAppUploadDeploymentError) {
         setDeploymentError(useModalAppUploadDeploymentError);

--- a/garden/src/features/modal/api/useModalAppForm.tsx
+++ b/garden/src/features/modal/api/useModalAppForm.tsx
@@ -105,86 +105,52 @@ export const useModalAppForm = ({
     form.reset();
   };
 
-  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const selectedFile = e.target.files?.[0];
-    if (!selectedFile) return;
-
-    // Reset validation state when a new file is selected
-    setIsValidated(false);
-    clearErrors();
-
-    // Reset any form-level validation errors
-    form.clearErrors();
-
-    // If we had previously validated a file, inform the user
-    // that the new file will be validated automatically
-    if (modalMetadata) {
-      toast.info("New file selected. Validating...");
-    }
-
-    // Reset modalMetadata when a new file is selected
-    setModalMetadata(null);
-    setIsDeploymentComplete(false);
-    setDeployedAppId(null);
-
-    setFile(selectedFile);
+  // Helper to validate file contents and update state
+  const validateAndSetMetadata = async (fileContents: string) => {
     setIsValidating(true);
     setValidationError(null);
     setDeploymentError(null);
 
     try {
-      const fileContents = await selectedFile.text();
       form.setValue("file_contents", fileContents);
-
       // Automatically validate the file after loading
       const metadata = await validateModalFile(fileContents);
 
       if (metadata) {
         setIsValidated(true);
-
         // Initialize the modal_functions field with the validated metadata
         const functions = metadata.modal_functions || [];
         form.setValue("modal.modal_functions", functions);
-
         setModalMetadata(metadata);
         toast.success("Modal file validated successfully");
       } else {
         // If validateModalFile returns null but didn't throw an error,
         // check if useModalAppUpload has a validation error
         if (useModalAppUploadValidationError) {
-          // Use the actual backend error with its specific message and suggested fix
           setValidationError(useModalAppUploadValidationError);
-          toast.error("File validation failed");
         } else {
-          // If for some reason we don't have a validation error, create a generic one
           setValidationError({
-            message: "File validation failed",
-            suggestedFix: "Please check your file and try again.",
+            message: "File validation failed. Please check your file and try again.",
             isApiError: false
           });
-          toast.error("File validation failed");
         }
+        toast.error("File validation failed");
       }
     } catch (error) {
       if (useModalAppUploadValidationError) {
         setValidationError(useModalAppUploadValidationError);
-        toast.error("File validation failed.");
-      }
-      if (error instanceof ApiError) {
-        // If it's an ApiError, it will have the specific error information from the backend
+      } else if (error instanceof ApiError) {
         setValidationError({
           message: error.message,
           suggestedFix: error.suggestedFix,
           isApiError: true
         });
       } else if (error instanceof Error) {
-        // For generic errors
         setValidationError({
           message: error.message,
           isApiError: false
         });
       } else {
-        // Last resort fallback
         setValidationError({
           message: "Unknown error occurred during validation",
           isApiError: false
@@ -194,6 +160,27 @@ export const useModalAppForm = ({
     } finally {
       setIsValidating(false);
     }
+  };
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFile = e.target.files?.[0];
+    if (!selectedFile) return;
+
+    // Reset validation state when a new file is selected
+    setIsValidated(false);
+    clearErrors();
+    form.clearErrors();
+    if (modalMetadata) {
+      toast.info("New file selected. Validating...");
+    }
+    setModalMetadata(null);
+    setIsDeploymentComplete(false);
+    setDeployedAppId(null);
+    setFile(selectedFile);
+
+    // Validate the new file
+    const fileContents = await selectedFile.text();
+    await validateAndSetMetadata(fileContents);
   };
 
   // New handler for updating function metadata
@@ -243,68 +230,8 @@ export const useModalAppForm = ({
 
   const handleValidate = async () => {
     if (!file) return;
-
-    setIsValidating(true);
-    setValidationError(null);
-
-    try {
-      const fileContents = await file.text();
-      form.setValue("file_contents", fileContents);
-
-      // Automatically validate the file after loading
-      const metadata = await validateModalFile(fileContents);
-
-      if (metadata) {
-        setIsValidated(true);
-
-        // Initialize the modal_functions field with the validated metadata
-        const functions = metadata.modal_functions || [];
-        form.setValue("modal.modal_functions", functions);
-
-        setModalMetadata(metadata);
-        toast.success("Modal file validated successfully");
-      } else {
-        // If validateModalFile returns null but didn't throw an error,
-        // check if useModalAppUpload has a validation error
-        if (useModalAppUploadValidationError) {
-          // Use the actual backend error with its specific message and suggested fix
-          setValidationError(useModalAppUploadValidationError);
-          toast.error("Validation failed");
-        } else {
-          // If for some reason we don't have a validation error, create a generic one
-          setValidationError({
-            message: "File validation failed. Please check your file and try again.",
-            isApiError: false
-          });
-          toast.error("Validation failed");
-        }
-      }
-    } catch (error) {
-      // Don't create a new error object - use what's already in useModalAppUploadValidationError
-      if (useModalAppUploadValidationError) {
-        setValidationError(useModalAppUploadValidationError);
-      } else if (error instanceof ApiError) {
-        setValidationError({
-          message: error.message,
-          suggestedFix: error.suggestedFix,
-          isApiError: true
-        });
-      } else if (error instanceof Error) {
-        setValidationError({
-          message: error.message,
-          isApiError: false
-        });
-      } else {
-        // Fallback for unknown error types
-        setValidationError({
-          message: "Unknown error occurred during validation",
-          isApiError: false
-        });
-      }
-      toast.error("Validation failed");
-    } finally {
-      setIsValidating(false);
-    }
+    const fileContents = await file.text();
+    await validateAndSetMetadata(fileContents);
   };
 
   const handleSubmit = async (data: ModalAppFormValues) => {

--- a/garden/src/features/modal/api/useModalAppForm.tsx
+++ b/garden/src/features/modal/api/useModalAppForm.tsx
@@ -154,22 +154,23 @@ export const useModalAppForm = ({
         if (useModalAppUploadValidationError) {
           // Use the actual backend error with its specific message and suggested fix
           setValidationError(useModalAppUploadValidationError);
-          toast.error("Validation failed");
+          toast.error("File validation failed");
         } else {
           // If for some reason we don't have a validation error, create a generic one
           setValidationError({
-            message: "File validation failed. Please check your file and try again.",
+            message: "File validation failed",
+            suggestedFix: "Please check your file and try again.",
             isApiError: false
           });
-          toast.error("Validation failed");
+          toast.error("File validation failed");
         }
       }
     } catch (error) {
-      // Don't create a new error object - use what's already in useModalAppUploadValidationError
-      // which should have the proper error information from the backend
       if (useModalAppUploadValidationError) {
         setValidationError(useModalAppUploadValidationError);
-      } else if (error instanceof ApiError) {
+        toast.error("File validation failed.");
+      }
+      if (error instanceof ApiError) {
         // If it's an ApiError, it will have the specific error information from the backend
         setValidationError({
           message: error.message,
@@ -189,7 +190,7 @@ export const useModalAppForm = ({
           isApiError: false
         });
       }
-      toast.error("Validation failed");
+      toast.error("File validation failed");
     } finally {
       setIsValidating(false);
     }

--- a/garden/src/features/modal/api/useModalAppUpload.tsx
+++ b/garden/src/features/modal/api/useModalAppUpload.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useValidateModalFile } from "../../gardens/api/useValidateModalFile";
 import { useCreateModalApp, DeployTimeoutError, createOrUpdateModalApp } from "../../modal/api/useCreateModalApp";
 import { ModalAppPatchRequest, ModalFileMetadataResponse } from "@/types";
@@ -16,6 +16,14 @@ export interface DeploymentError {
   suggestedFix?: string;
   deploymentOutput?: string;
   isTimeout: boolean;
+  isApiError: boolean;
+}
+
+// Helper interface for the processed error
+interface ProcessedError {
+  message: string;
+  suggestedFix?: string;
+  deploymentOutput?: string;
   isApiError: boolean;
 }
 
@@ -45,36 +53,35 @@ export const useModalAppUpload = (): UseModalAppUploadReturn => {
   const [validationError, setValidationError] = useState<ValidationError | null>(null);
   const [deploymentError, setDeploymentError] = useState<DeploymentError | null>(null);
 
-  const { mutateAsync: validateFile, isPending: isValidating, error: validationQueryError } = useValidateModalFile();
+  const { mutateAsync: validateFile, isPending: isValidating } = useValidateModalFile();
   const { mutateAsync: createOrUpdateApp, isPending: isDeploying } = useCreateModalApp();
 
-  // Sync validation errors from the query with our local state
-  useEffect(() => {
-    if (validationQueryError) {
-      let errorMessage = "Unknown validation error";
-      let suggestedFix: string | undefined = undefined;
-      let isApiError = false;
+  // Helper function to process errors
+  const processError = (error: unknown): ProcessedError => {
+    let message = "Unknown error";
+    let suggestedFix: string | undefined = undefined;
+    let deploymentOutput: string | undefined = undefined;
+    let isApiError = false;
 
-      if (validationQueryError instanceof ApiError) {
-        errorMessage = validationQueryError.message;
-        suggestedFix = validationQueryError.suggestedFix;
-        isApiError = true;
-      } else if (validationQueryError instanceof AxiosError) {
-        const apiError = ApiError.fromAxiosError(validationQueryError);
-        errorMessage = apiError.message;
-        suggestedFix = apiError.suggestedFix;
-        isApiError = true;
-      } else if (validationQueryError instanceof Error) {
-        errorMessage = validationQueryError.message;
-      }
-
-      setValidationError({
-        message: errorMessage,
-        suggestedFix,
-        isApiError
-      });
+    if (error instanceof ApiError) {
+      message = error.message;
+      suggestedFix = error.suggestedFix;
+      deploymentOutput = error.deploymentOutput;
+      isApiError = true;
+    } else if (error instanceof AxiosError) {
+      const apiError = ApiError.fromAxiosError(error);
+      message = apiError.message;
+      suggestedFix = apiError.suggestedFix;
+      deploymentOutput = apiError.deploymentOutput;
+      isApiError = true;
+    } else if (error instanceof Error) {
+      message = error.message;
+    } else if (error && typeof error === 'object' && 'message' in error) {
+      message = String((error as { message: unknown }).message);
     }
-  }, [validationQueryError]);
+
+    return { message, suggestedFix, deploymentOutput, isApiError };
+  };
 
   const clearErrors = () => {
     setValidationError(null);
@@ -83,34 +90,9 @@ export const useModalAppUpload = (): UseModalAppUploadReturn => {
 
   const handleDeploymentError = async (error: unknown): Promise<never> => {
     const isTimeout = error instanceof DeployTimeoutError;
-    let errorMessage = "Failed to deploy Modal app";
-    let suggestedFix: string | undefined = undefined;
-    let deploymentOutput: string | undefined = undefined;
-    let isApiError = false;
-
-    if (error instanceof ApiError) {
-      errorMessage = error.message;
-      suggestedFix = error.suggestedFix;
-      deploymentOutput = error.deploymentOutput;
-      isApiError = true;
-    } else if (error instanceof AxiosError) {
-      const apiError = ApiError.fromAxiosError(error);
-      errorMessage = apiError.message;
-      suggestedFix = apiError.suggestedFix;
-      deploymentOutput = apiError.deploymentOutput;
-      isApiError = true;
-    } else if (error instanceof Error) {
-      errorMessage = error.message;
-    } else if (error && typeof error === 'object' && 'message' in error) {
-      errorMessage = String((error as { message: unknown }).message);
-    }
-
     setDeploymentError({
-      message: errorMessage,
-      suggestedFix,
-      deploymentOutput,
+      ...processError(error),
       isTimeout,
-      isApiError
     });
 
     throw error;
@@ -124,30 +106,9 @@ export const useModalAppUpload = (): UseModalAppUploadReturn => {
       setModalMetadata(metadata);
       return metadata;
     } catch (error) {
-      let errorMessage = "Unknown validation error";
-      let suggestedFix: string | undefined = undefined;
-      let isApiError = false;
-
-      if (error instanceof ApiError) {
-        errorMessage = error.message;
-        suggestedFix = error.suggestedFix;
-        isApiError = true;
-      } else if (error instanceof AxiosError) {
-        // Handle AxiosError directly if it wasn't converted to ApiError
-        const apiError = ApiError.fromAxiosError(error);
-        errorMessage = apiError.message;
-        suggestedFix = apiError.suggestedFix;
-        isApiError = true;
-      } else if (error instanceof Error) {
-        errorMessage = error.message;
-      }
-
       setValidationError({
-        message: errorMessage,
-        suggestedFix,
-        isApiError
+        ...processError(error),
       });
-
       return null;
     }
   };

--- a/garden/src/features/modal/api/useModalAppUpload.tsx
+++ b/garden/src/features/modal/api/useModalAppUpload.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useValidateModalFile } from "../../gardens/api/useValidateModalFile";
 import { useCreateModalApp, DeployTimeoutError, createOrUpdateModalApp } from "../../modal/api/useCreateModalApp";
 import { ModalAppPatchRequest, ModalFileMetadataResponse } from "@/types";
@@ -45,15 +45,43 @@ export const useModalAppUpload = (): UseModalAppUploadReturn => {
   const [validationError, setValidationError] = useState<ValidationError | null>(null);
   const [deploymentError, setDeploymentError] = useState<DeploymentError | null>(null);
 
-  const { mutateAsync: validateFile, isPending: isValidating } = useValidateModalFile();
+  const { mutateAsync: validateFile, isPending: isValidating, error: validationQueryError } = useValidateModalFile();
   const { mutateAsync: createOrUpdateApp, isPending: isDeploying } = useCreateModalApp();
+
+  // Sync validation errors from the query with our local state
+  useEffect(() => {
+    if (validationQueryError) {
+      let errorMessage = "Unknown validation error";
+      let suggestedFix: string | undefined = undefined;
+      let isApiError = false;
+
+      if (validationQueryError instanceof ApiError) {
+        errorMessage = validationQueryError.message;
+        suggestedFix = validationQueryError.suggestedFix;
+        isApiError = true;
+      } else if (validationQueryError instanceof AxiosError) {
+        const apiError = ApiError.fromAxiosError(validationQueryError);
+        errorMessage = apiError.message;
+        suggestedFix = apiError.suggestedFix;
+        isApiError = true;
+      } else if (validationQueryError instanceof Error) {
+        errorMessage = validationQueryError.message;
+      }
+
+      setValidationError({
+        message: errorMessage,
+        suggestedFix,
+        isApiError
+      });
+    }
+  }, [validationQueryError]);
 
   const clearErrors = () => {
     setValidationError(null);
     setDeploymentError(null);
   };
 
-  const handleDeploymentError = async (error: any): Promise<never> => {
+  const handleDeploymentError = async (error: unknown): Promise<never> => {
     const isTimeout = error instanceof DeployTimeoutError;
     let errorMessage = "Failed to deploy Modal app";
     let suggestedFix: string | undefined = undefined;
@@ -74,7 +102,7 @@ export const useModalAppUpload = (): UseModalAppUploadReturn => {
     } else if (error instanceof Error) {
       errorMessage = error.message;
     } else if (error && typeof error === 'object' && 'message' in error) {
-      errorMessage = String(error.message);
+      errorMessage = String((error as { message: unknown }).message);
     }
 
     setDeploymentError({
@@ -103,6 +131,12 @@ export const useModalAppUpload = (): UseModalAppUploadReturn => {
       if (error instanceof ApiError) {
         errorMessage = error.message;
         suggestedFix = error.suggestedFix;
+        isApiError = true;
+      } else if (error instanceof AxiosError) {
+        // Handle AxiosError directly if it wasn't converted to ApiError
+        const apiError = ApiError.fromAxiosError(error);
+        errorMessage = apiError.message;
+        suggestedFix = apiError.suggestedFix;
         isApiError = true;
       } else if (error instanceof Error) {
         errorMessage = error.message;

--- a/garden/src/features/modal/components/FileUploadSection.tsx
+++ b/garden/src/features/modal/components/FileUploadSection.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { FileCode, CheckCircle2 } from "lucide-react";
 import { Badge } from "@/components/shadcn/badge";
 import { cn } from "@/utils/form.utils";
@@ -10,10 +11,10 @@ interface FileUploadSectionProps {
   file: File | null;
 }
 
-export const FileUploadSection = ({ 
-  handleFileChange, 
-  isValidating, 
-  isDeploying, 
+export const FileUploadSection = ({
+  handleFileChange,
+  isValidating,
+  isDeploying,
   isValidated,
   file
 }: FileUploadSectionProps) => (
@@ -39,26 +40,26 @@ export const FileUploadSection = ({
                 </div>
               )}
             </div>
-            
+
             {/* Change file button */}
             <div className="flex items-center justify-between border-t bg-white px-3 py-2">
               <span className="text-sm text-gray-500">
-                {isValidating ? "Validating file..." : 
+                {isValidating ? "Validating file..." :
                   isDeploying ? "Deploying..." : "File uploaded"}
               </span>
-              <label 
+              <label
                 className={cn(
                   "cursor-pointer rounded-md border px-3 py-1 text-sm font-medium transition-colors",
-                  isValidating || isDeploying 
-                    ? "cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400" 
+                  isValidating || isDeploying
+                    ? "cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400"
                     : "border-primary bg-white text-primary hover:bg-primary/5"
                 )}
               >
                 Change File
-                <input 
-                  type="file" 
-                  accept=".py" 
-                  onChange={handleFileChange} 
+                <input
+                  type="file"
+                  accept=".py"
+                  onChange={handleFileChange}
                   disabled={isValidating || isDeploying}
                   className="hidden"
                 />
@@ -74,19 +75,19 @@ export const FileUploadSection = ({
             <p className="mb-4 text-xs text-gray-500">
               Upload a Python file containing your Modal app
             </p>
-            <label 
+            <label
               className={cn(
                 "cursor-pointer rounded-md px-4 py-2 text-sm font-medium transition-colors",
-                isValidating || isDeploying 
-                  ? "cursor-not-allowed bg-gray-100 text-gray-400" 
+                isValidating || isDeploying
+                  ? "cursor-not-allowed bg-gray-100 text-gray-400"
                   : "bg-primary text-primary-foreground hover:bg-primary/90"
               )}
             >
               Browse Files
-              <input 
-                type="file" 
-                accept=".py" 
-                onChange={handleFileChange} 
+              <input
+                type="file"
+                accept=".py"
+                onChange={handleFileChange}
                 disabled={isValidating || isDeploying}
                 className="hidden"
               />

--- a/garden/src/features/modal/components/FunctionMetadataEditor.tsx
+++ b/garden/src/features/modal/components/FunctionMetadataEditor.tsx
@@ -22,7 +22,7 @@ return result
 
 const getExampleUsagePreview = (functionName: string = "function_name", userValue?: string) => {
   const defaultExample = getExampleUsagePlaceholder(functionName);
-  
+
   return `
 from garden_ai import GardenClient
 client = GardenClient()
@@ -36,17 +36,17 @@ interface FunctionMetadataEditorProps {
   form: UseFormReturn<ModalAppFormValues>;
   metadata: ModalFileMetadataResponse;
   handleFunctionMetadataChange: (
-    functionIndex: number, 
-    field: string, 
+    functionIndex: number,
+    field: string,
     value: string,
     event?: React.KeyboardEvent<HTMLTextAreaElement>
   ) => void;
 }
 
-export const FunctionMetadataEditor = ({ 
-  form, 
-  metadata, 
-  handleFunctionMetadataChange 
+export const FunctionMetadataEditor = ({
+  form,
+  metadata,
+  handleFunctionMetadataChange
 }: FunctionMetadataEditorProps) => (
   <div className="rounded-lg border">
     <div className="border-b bg-gray-50 p-4">
@@ -83,7 +83,7 @@ export const FunctionMetadataEditor = ({
                   </FormItem>
                 )}
               />
-              
+
               <FormField
                 control={form.control}
                 name={`modal.modal_functions.${i}.description`}
@@ -91,9 +91,9 @@ export const FunctionMetadataEditor = ({
                   <FormItem>
                     <FormLabel>Description</FormLabel>
                     <FormControl>
-                      <Textarea 
-                        {...field} 
-                        placeholder="Describe what this function does..." 
+                      <Textarea
+                        {...field}
+                        placeholder="Describe what this function does..."
                         className="min-h-[100px]"
                       />
                     </FormControl>
@@ -104,7 +104,7 @@ export const FunctionMetadataEditor = ({
                   </FormItem>
                 )}
               />
-              
+
               <FormField
                 control={form.control}
                 name={`modal.modal_functions.${i}.example_usage`}
@@ -112,8 +112,8 @@ export const FunctionMetadataEditor = ({
                   <FormItem>
                     <FormLabel>Example Usage</FormLabel>
                     <FormControl>
-                      <Textarea 
-                        {...field} 
+                      <Textarea
+                        {...field}
                         placeholder={getExampleUsagePlaceholder(func.function_name)}
                         className="min-h-[150px] font-mono"
                         onChange={(e) => {
@@ -148,7 +148,7 @@ export const FunctionMetadataEditor = ({
                   </FormItem>
                 )}
               />
-              
+
               <FormField
                 control={form.control}
                 name={`modal.modal_functions.${i}.function_text`}

--- a/garden/src/features/modal/components/ModalAppForm.tsx
+++ b/garden/src/features/modal/components/ModalAppForm.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Form } from "@/components/shadcn/form";
 import { useModalAppForm, UseModalAppFormOptions } from "@/features/modal/api/useModalAppForm";
 import { FileUploadSection } from "@/features/modal/components/FileUploadSection";
@@ -91,18 +92,18 @@ export const ModalAppForm = ({
   return (
     <>
       {showOverallProgress && (
-        <OverallProgress 
-          currentPhase={currentPhase} 
-          isCompleted={isDeploymentComplete || isDeploying || isValidated} 
+        <OverallProgress
+          currentPhase={currentPhase}
+          isCompleted={isDeploymentComplete || isDeploying || isValidated}
         />
       )}
-      
+
       <div className="rounded-lg border bg-white p-6 shadow-sm">
         <h2 className="mb-6 text-xl font-bold">Upload and Deploy Modal App</h2>
-        
+
         {/* Detailed Progress Steps */}
         <ProgressSteps currentStep={currentStep} />
-        
+
         {isDeploymentComplete ? (
           <div className="py-12">
             <Alert className="mb-6 bg-green-50 border-green-200">
@@ -136,31 +137,31 @@ export const ModalAppForm = ({
           <Form {...form}>
             <form onSubmit={handleSubmit} className="space-y-6">
               {/* File Upload Section */}
-              <FileUploadSection 
+              <FileUploadSection
                 handleFileChange={handleFileChange}
                 isValidating={isValidating}
                 isDeploying={isDeploying}
                 isValidated={isValidated}
                 file={file}
               />
-              
+
               {/* Error Displays */}
               {validationError && <ValidationErrorAlert error={validationError} />}
               {deploymentError && <DeploymentErrorAlert error={deploymentError} />}
-              
+
               {/* Modal App Details */}
               {modalMetadata && (
                 <div className="space-y-6">
                   <DetectedAppCard metadata={modalMetadata} />
-                  <FunctionMetadataEditor 
-                    form={form} 
-                    metadata={modalMetadata} 
-                    handleFunctionMetadataChange={handleFunctionMetadataChange} 
+                  <FunctionMetadataEditor
+                    form={form}
+                    metadata={modalMetadata}
+                    handleFunctionMetadataChange={handleFunctionMetadataChange}
                   />
                 </div>
               )}
-              
-              <FormActions 
+
+              <FormActions
                 file={file}
                 isValidated={isValidated}
                 isValidating={isValidating}

--- a/garden/src/features/modal/components/ModalAppUploadPage.tsx
+++ b/garden/src/features/modal/components/ModalAppUploadPage.tsx
@@ -1,19 +1,14 @@
+import React from "react";
 import { ModalAppForm } from "./ModalAppForm";
 
 interface ModalAppUploadPageProps {
   onSuccess?: (id: number) => void;
-  /** Optional prop to indicate if this is part of a multi-step process */
-  isMultiStep?: boolean;
 }
 
-const ModalAppUploadPage = ({ onSuccess, isMultiStep = false }: ModalAppUploadPageProps) => {
+const ModalAppUploadPage = ({ onSuccess }: ModalAppUploadPageProps) => {
   return (
     <>
-      <div className="mb-12 flex items-center space-x-8">
-        <div className="space-y-4">
-        </div>
-      </div>
-      <ModalAppForm 
+      <ModalAppForm
         showOverallProgress={false}
         showSuccessScreen={true}
         viewDeploymentsUrl="/user?tab=model-deployments"

--- a/garden/src/features/modal/components/alerts/ValidationErrorAlert.tsx
+++ b/garden/src/features/modal/components/alerts/ValidationErrorAlert.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/shadcn/alert";
 import { AlertTriangle, HelpCircleIcon } from "lucide-react";
 import { ValidationError } from "@/features/modal/api/useModalAppUpload";


### PR DESCRIPTION
This PR is related to https://github.com/Garden-AI/garden-backend/pull/318

This makes sure the frontend correctly renders the error messages and suggested fixes we get from the backend instead of unhelpful 'Unknown API Error'.

Now when uploading a modal app with module level imports we should see this:

<img width="787" alt="image" src="https://github.com/user-attachments/assets/60017936-cf3f-4631-b451-681cac50d715" />
