### PR TITLE
Deployment Message Update - Issue #358

### DIFF
--- a/garden/src/features/modal/components/DeploymentNotice.tsx
+++ b/garden/src/features/modal/components/DeploymentNotice.tsx
@@ -12,7 +12,6 @@ export const DeploymentNotice = ({ isVisible }: DeploymentNoticeProps) => {
       <h4 className="font-medium">Deployment in Progress</h4>
       <p className="mt-2 text-sm">
         Your Modal app is being deployed. This may take a few minutes if your app has large dependencies.
-        Please do not close this page while deployment is in progress.
       </p>
       <div className="mt-3 flex items-center gap-2 rounded-md bg-blue-100 p-2 text-xs">
         <InfoIcon className="h-4 w-4" />


### PR DESCRIPTION
## Incorrect Deployment Message
### Resolves #358 
---
- Edited `DeploymentNotice.tsx` to display correct deployment message.
---

#### Originally, the deployment message stated a warning about closing the window, which is no longer accurate due to moving to an asynchronous deployment flow:
![image](https://github.com/user-attachments/assets/c2e13d19-0ec3-4a75-84f0-0a1413d10d4a)

#### Removed the incorrect text within the message, deployment message is now valid:
![image](https://github.com/user-attachments/assets/d2cf8933-6efc-47ae-96b8-4dd1fef8314e)
