### PR TITLE
fix: invaldiate gardens cache after a successful garden create request

### DIFF
--- a/garden/src/features/gardens/api/useCreateGarden.ts
+++ b/garden/src/features/gardens/api/useCreateGarden.ts
@@ -24,6 +24,9 @@ export const useCreateGarden = () => {
   return useMutation<Garden, ApiError, GardenCreateRequest>({
     mutationFn: createGarden,
     onSuccess: (garden) => {
+      queryClient.invalidateQueries({ queryKey: ["garden"] });
+      queryClient.invalidateQueries({ queryKey: ["gardens"] });
+      // Set the specific garden data in cache
       queryClient.setQueryData(["garden", garden.doi], garden);
     },
   });


### PR DESCRIPTION
Fixes: #366 

This PR fixes the caching issue that caused the referenced bug.

We now correctly invalidate the cache of gardens for the logged in user after a successful garden create request.

*Before*

Notice the number of gardens doesn't change after creating a new one.


https://github.com/user-attachments/assets/be0bea7f-ef94-4d1b-8f78-39d3d66a891c



*After*

Correctly displaying new garden!

https://github.com/user-attachments/assets/30d5b2ac-8eac-4e00-bd9f-18f4d1fccaba



## Testing
Manually