### PR TITLE
Garden Indicator Update - Issues #248, #344, #347

### DIFF
--- a/garden/src/features/search/components/SearchResult.tsx
+++ b/garden/src/features/search/components/SearchResult.tsx
@@ -34,19 +34,25 @@ export const SearchResult = ({ garden, verbose }: { garden: Garden; verbose: boo
   return (
     <Card className={`relative transition-colors hover:shadow-lg ${garden.is_archived ? "bg-gray-100" : "hover:bg-gray-50"}`}>
       <CardHeader>
-        {garden.is_archived && (
-          <div style={{backgroundColor: "#DBE9FF", color: "#28487B"}}
+         {(
+          <div style={{backgroundColor: "#C2E6CA", color: "#11451F"}}
+            className="absolute top-0 left-0 w-full rounded-t-md px-4 py-1 text-center text-sm font-semibold shadow-sm">
+              Published Garden
+            </div>
+         )}
+        <div className="flex items-start justify-between space-x-3">
+          {garden.is_archived && (
+          <div style={{backgroundColor: "#D2D1F7", color: "#3C2F67"}}
             className="absolute top-0 left-0 w-full rounded-t-md px-4 py-1 text-center text-sm font-semibold shadow-sm">
               Archived Garden
           </div>
          )}
          {garden.doi_is_draft && (
-          <div style={{backgroundColor: "#C2E6CA", color: "#11451F"}}
+          <div style={{backgroundColor: "#DBE9FF", color: "#28487B"}}
             className="absolute top-0 left-0 w-full rounded-t-md px-4 py-1 text-center text-sm font-semibold shadow-sm">
               Draft Garden
             </div>
          )}
-        <div className="flex items-start justify-between space-x-3">
           <CardTitle className="line-clamp-2 text-xl font-bold transition-colors duration-300 hover:text-primary">
             <Link to={`/garden/${encodeURIComponent(garden.doi)}`}>{garden.title}</Link>
           </CardTitle>

--- a/garden/src/features/search/components/SearchResult.tsx
+++ b/garden/src/features/search/components/SearchResult.tsx
@@ -32,8 +32,20 @@ export const SearchResult = ({ garden, verbose }: { garden: Garden; verbose: boo
     setShowMore(!showMore);
   }
   return (
-    <Card className="transition-colors hover:bg-gray-50 hover:shadow-lg">
+    <Card className={`relative transition-colors hover:shadow-lg ${garden.is_archived ? "bg-gray-100" : "hover:bg-gray-50"}`}>
       <CardHeader>
+        {garden.is_archived && (
+          <div style={{backgroundColor: "#DBE9FF", color: "#28487B"}}
+            className="absolute top-0 left-0 w-full rounded-t-md px-4 py-1 text-center text-sm font-semibold shadow-sm">
+              Archived Garden
+          </div>
+         )}
+         {garden.doi_is_draft && (
+          <div style={{backgroundColor: "#C2E6CA", color: "#11451F"}}
+            className="absolute top-0 left-0 w-full rounded-t-md px-4 py-1 text-center text-sm font-semibold shadow-sm">
+              Draft Garden
+            </div>
+         )}
         <div className="flex items-start justify-between space-x-3">
           <CardTitle className="line-clamp-2 text-xl font-bold transition-colors duration-300 hover:text-primary">
             <Link to={`/garden/${encodeURIComponent(garden.doi)}`}>{garden.title}</Link>
@@ -48,6 +60,12 @@ export const SearchResult = ({ garden, verbose }: { garden: Garden; verbose: boo
           to={`/garden/${encodeURIComponent(garden.doi)}`}
         >
           DOI: {garden.doi}
+          {garden.marked_for_deletion && (
+            <div style={{backgroundColor: "#F0C2BD", color: "#411528"}}
+              className="ml-2 inline-block rounded px-2 py-0.5 text-xs font-medium">
+                Marked for Deletion
+            </div>
+          )}
         </Link>
 
         <CardDescription className="flex items-center space-x-2 text-muted-foreground">


### PR DESCRIPTION
## Garden Indicator Update
### Resolves #248 + #344 + #347 
---
- Edited `SearchResult.tsx` to display a banner indication for published, archived and draft gardens, and a tag for gardens marked for deletion.
---
#### Originally, gardens would not display any indication to the user if they were a draft, published, archived, or marked for deletion.
![image](https://github.com/user-attachments/assets/9f6053e6-faf5-40be-a9af-269ef5e0552a)

#### Implemented banners to indicate if a garden is currently a draft, published or archived. 
#### Added a gray background for archived gardens. 
#### Added a tag alongside the DOI to indicate if a garden is currently marked for deletion. 

#### Tested the color contrast for the new indicators and they all scored very well!
![image](https://github.com/user-attachments/assets/73e992d7-48e3-4445-96cc-ee41262dc0e6)
![image](https://github.com/user-attachments/assets/d168ed89-eb61-4bd7-9ec0-12e9f2f76b0c)

