### PR TITLE
Search Filter UI Update - Issue #368

### DIFF
--- a/garden/src/features/search/components/Filters.tsx
+++ b/garden/src/features/search/components/Filters.tsx
@@ -9,7 +9,6 @@ import { Checkbox } from "@/components/shadcn/checkbox";
 import { Label } from "@/components/shadcn/label";
 import { Button } from "@/components/shadcn/button";
 import { GardenSearchResult } from "../hooks/useSearchResults";
-
 import { useState } from "react";
 
 const SearchFilters = ({
@@ -37,35 +36,22 @@ const SearchFilters = ({
   if (!facets.length) return null;
 
   return (
-    // <div className="relative h-full">
     <div className="sticky top-16 max-h-[80vh] overflow-y-auto rounded-lg border shadow-md bg-white p-4 space-y-4">
-      {/* <div className="sticky top-12 space-y-4 divide-y-2 rounded-lg border px-4 py-6 shadow-md"> */}
-        {/* <div> */}
-          {/* <h3 className="mb-2 text-lg font-semibold"> */}
           <h3 className="text-lg font-semibold flex items-center mb-2">
-            {/* constructor(parameters) {
-              
-            } */}
-          {/* } */}
-            {/* <Filter className="mr-2 inline-block h-5" /> */}
             <Filter className="mr-2 h-5 w-5" />
             Filters
           </h3>
-
           <Accordion type="multiple" className="px-2" defaultValue={facets.map((f) => f.name)}>
             {facets.map((facet) => {
-
               const buckets = showAllFacets[facet.name]
                 ? facet.values
                 : facet.values.slice(0, 7);
-
               return (
                 <AccordionItem key={facet.name} value={facet.name}>
                   <AccordionTrigger>
                     <Label className="capitalize">{facet.name.split("_").join(" ")}</Label>
                   </AccordionTrigger>
                   <AccordionContent className="pl-2 max-h-48 overflow-y-auto pr-2">
-                    {/* {facet?.values?.slice(0, 7).map((bucket, index) => ( */}
                       {buckets.map((bucket, index) => (
                       <div key={index} className="mb-2 flex items-center gap-2">
                         <Checkbox
@@ -82,7 +68,6 @@ const SearchFilters = ({
                         </Label>
                       </div>
                     ))}
-
                     {facet.values.length > 7 && (
                       <button
                         type="button"
@@ -97,7 +82,6 @@ const SearchFilters = ({
                         {showAllFacets[facet.name] ? "Show Less" : "Show More"}
                       </button>
                     )}
-
                   </AccordionContent>
                 </AccordionItem>
               );
@@ -117,8 +101,6 @@ const SearchFilters = ({
             </Button>
           </div>
         </div>
-      // </div>
-    // </div>
   );
 };
 

--- a/garden/src/features/search/components/Filters.tsx
+++ b/garden/src/features/search/components/Filters.tsx
@@ -10,6 +10,8 @@ import { Label } from "@/components/shadcn/label";
 import { Button } from "@/components/shadcn/button";
 import { GardenSearchResult } from "../hooks/useSearchResults";
 
+import { useState } from "react";
+
 const SearchFilters = ({
   searchResult,
   selectedFilters,
@@ -19,6 +21,8 @@ const SearchFilters = ({
   selectedFilters: Record<string, string[]>;
   setSelectedFilters: (filters: Record<string, string[]>) => void;
 }) => {
+  const [showAllFacets, setShowAllFacets] = useState<Record<string, boolean>>({});
+
   const updateFilter = (facet: string, bucket: string, isChecked: boolean) => {
     const selected = selectedFilters[facet] || [];
     const updated = isChecked ? [...selected, bucket] : selected.filter((b: any) => b !== bucket);
@@ -33,23 +37,36 @@ const SearchFilters = ({
   if (!facets.length) return null;
 
   return (
-    <div className="relative h-full">
-      <div className="sticky top-12 space-y-4 divide-y-2 rounded-lg border px-4 py-6 shadow-md">
-        <div>
-          <h3 className="mb-2 text-lg font-semibold">
-            <Filter className="mr-2 inline-block h-5" />
+    // <div className="relative h-full">
+    <div className="sticky top-16 max-h-[80vh] overflow-y-auto rounded-lg border shadow-md bg-white p-4 space-y-4">
+      {/* <div className="sticky top-12 space-y-4 divide-y-2 rounded-lg border px-4 py-6 shadow-md"> */}
+        {/* <div> */}
+          {/* <h3 className="mb-2 text-lg font-semibold"> */}
+          <h3 className="text-lg font-semibold flex items-center mb-2">
+            {/* constructor(parameters) {
+              
+            } */}
+          {/* } */}
+            {/* <Filter className="mr-2 inline-block h-5" /> */}
+            <Filter className="mr-2 h-5 w-5" />
             Filters
           </h3>
 
           <Accordion type="multiple" className="px-2" defaultValue={facets.map((f) => f.name)}>
             {facets.map((facet) => {
+
+              const buckets = showAllFacets[facet.name]
+                ? facet.values
+                : facet.values.slice(0, 7);
+
               return (
                 <AccordionItem key={facet.name} value={facet.name}>
                   <AccordionTrigger>
                     <Label className="capitalize">{facet.name.split("_").join(" ")}</Label>
                   </AccordionTrigger>
-                  <AccordionContent className="pl-2">
-                    {facet?.values?.slice(0, 7).map((bucket, index) => (
+                  <AccordionContent className="pl-2 max-h-48 overflow-y-auto pr-2">
+                    {/* {facet?.values?.slice(0, 7).map((bucket, index) => ( */}
+                      {buckets.map((bucket, index) => (
                       <div key={index} className="mb-2 flex items-center gap-2">
                         <Checkbox
                           id={`${facet.name}-${bucket.value}`}
@@ -65,13 +82,29 @@ const SearchFilters = ({
                         </Label>
                       </div>
                     ))}
+
+                    {facet.values.length > 7 && (
+                      <button
+                        type="button"
+                        className="text-gray-600 text-xs mt-2 hover:underline"
+                        onClick={() =>
+                          setShowAllFacets((prev) => ({
+                            ...prev,
+                            [facet.name]: !prev[facet.name],
+                          }))
+                        }
+                      >
+                        {showAllFacets[facet.name] ? "Show Less" : "Show More"}
+                      </button>
+                    )}
+
                   </AccordionContent>
                 </AccordionItem>
               );
             })}
           </Accordion>
 
-          <div className="my-4 flex justify-center gap-4">
+          <div className="flex justify-center pt-4">
             <Button
               type="button"
               variant="secondary"
@@ -84,8 +117,8 @@ const SearchFilters = ({
             </Button>
           </div>
         </div>
-      </div>
-    </div>
+      // </div>
+    // </div>
   );
 };
 


### PR DESCRIPTION
## Search Filter UI Update

### **Resolves #368**

---

- Edited `Filters.tsx` to remove hard-coded list limit, added “Show More” / “Show Less” buttons, and allow the section to scroll independently.

---

### Originally, the ‘Filters’ section of the search page did not account for more than 7 model authors.

### The section also was hard to navigate as you had to scroll to the bottom of the search screen to reach the “Clear Filters” button, rather than scrolling within the section block independently.

![image](https://github.com/user-attachments/assets/e40a1ef3-1bf3-445f-95be-db839e39734f)

### Set the section to scroll independently from the whole page.

![image](https://github.com/user-attachments/assets/02f18110-3434-482c-a961-561036f59f14)
![image](https://github.com/user-attachments/assets/de59d5ec-c807-4782-a4b1-a1d88de1dc05)

### Implemented a “Show more” / “Show less” button within filter sections with more than 7 items.

![image](https://github.com/user-attachments/assets/5482d6ba-b39e-4352-8c6a-0428cbac03e6)
