### PR TITLE
State Indication Update - Issue #372

### DIFF
--- a/garden/src/features/search/components/SearchResult.tsx
+++ b/garden/src/features/search/components/SearchResult.tsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
-
 import { Garden } from "@/types";
-
 import { Badge } from "@/components/shadcn/badge";
 import { ScrollArea } from "@/components/shadcn/scroll-area";
 import { Avatar, AvatarFallback } from "@/components/shadcn/avatar";
@@ -24,33 +22,34 @@ import { PersonIcon } from "@radix-ui/react-icons";
 import SaveGardenButton from "../../gardens/components/SaveGardenButton";
 import { Button } from "@/components/shadcn/button";
 
-export const SearchResult = ({ garden, verbose }: { garden: Garden; verbose: boolean }) => {
-  const functions = [...(garden.entrypoints ?? []), ...(garden.modal_functions ?? [])];
-  const [showMore, setShowMore] = useState(false);
+export const SearchResult = ({ garden, verbose, showPublishedBanner = true, 
+  }: { garden: Garden; verbose: boolean; showPublishedBanner?:boolean; }) => {
+    const functions = [...(garden.entrypoints ?? []), ...(garden.modal_functions ?? [])];
+    const [showMore, setShowMore] = useState(false);
 
   const handleShowMore = () => {
     setShowMore(!showMore);
   }
   return (
     <Card className={`relative transition-colors hover:shadow-lg ${garden.is_archived ? "bg-gray-100" : "hover:bg-gray-50"}`}>
-      <CardHeader>
-         {(
+      <CardHeader className={`${(showPublishedBanner || garden.is_archived || garden.doi_is_draft) ? "pt-8" : ""}`}>
+         {showPublishedBanner && (
           <div style={{backgroundColor: "#C2E6CA", color: "#11451F"}}
             className="absolute top-0 left-0 w-full rounded-t-md px-4 py-1 text-center text-sm font-semibold shadow-sm">
-              Published Garden
+              Published
             </div>
          )}
         <div className="flex items-start justify-between space-x-3">
           {garden.is_archived && (
           <div style={{backgroundColor: "#D2D1F7", color: "#3C2F67"}}
             className="absolute top-0 left-0 w-full rounded-t-md px-4 py-1 text-center text-sm font-semibold shadow-sm">
-              Archived Garden
+              Archived
           </div>
          )}
          {garden.doi_is_draft && (
           <div style={{backgroundColor: "#DBE9FF", color: "#28487B"}}
             className="absolute top-0 left-0 w-full rounded-t-md px-4 py-1 text-center text-sm font-semibold shadow-sm">
-              Draft Garden
+              Draft
             </div>
          )}
           <CardTitle className="line-clamp-2 text-xl font-bold transition-colors duration-300 hover:text-primary">
@@ -66,7 +65,7 @@ export const SearchResult = ({ garden, verbose }: { garden: Garden; verbose: boo
           to={`/garden/${encodeURIComponent(garden.doi)}`}
         >
           DOI: {garden.doi}
-          {garden.marked_for_deletion && (
+          {garden.marked_for_deletion && garden.doi_is_draft &&(
             <div style={{backgroundColor: "#F0C2BD", color: "#411528"}}
               className="ml-2 inline-block rounded px-2 py-0.5 text-xs font-medium">
                 Marked for Deletion

--- a/garden/src/features/search/components/SearchResultsList.tsx
+++ b/garden/src/features/search/components/SearchResultsList.tsx
@@ -37,7 +37,7 @@ export const SearchResultsList = ({
         </div>
       )}
       {gardens.map((garden: any, index: number) => (
-        <SearchResult key={index} garden={garden} verbose={verboseSearchResults} />
+        <SearchResult key={index} garden={garden} verbose={verboseSearchResults} showPublishedBanner={false}/>
       ))}
     </div>
   );


### PR DESCRIPTION
## State Indication Update

### **Resolves #372**
---

- Edited `SearchResult.tsx` to remove the word “Garden” from banner text, add additional formatting, add conditional logic for “Published” banner, and add conditional logic for the “Marked for Deletion” tag.
- Edited `SearchResultsList.tsx` to pass additional input for conditional logic to not render “Published” banner.

---

### Originally, the “Published” banner was displayed both on the “My Gardens” tab, as well as the search page, which was redundant in this context as all gardens within the search page are published.

### Additionally, the “Marked for Deletion” tag would remain for up to an hour following the publication of a draft garden, which is inaccurate.

![image](https://github.com/user-attachments/assets/8740afa7-d43f-4d49-ab3c-145e081e95ea)

### Added conditional logic so the “Marked for Deletion” tag will only display on draft gardens.

### Added conditional logic to not display “Published” banner within the search page.

### Edited all banners to not say “Garden” and added additional padding between the banner and the garden title.
![image](https://github.com/user-attachments/assets/d367c26c-05d9-4a90-902c-1ece4c79e674)
![image](https://github.com/user-attachments/assets/4086b2c2-dc9d-42be-a927-58268f376725)

