### PR TITLE
Benchmark UI update

### DIFF
--- a/garden/package.json
+++ b/garden/package.json
@@ -58,6 +58,7 @@
     "react-multi-select-component": "^4.3.4",
     "react-router-dom": "^6.23.1",
     "react-syntax-highlighter": "^15.5.0",
+    "recharts": "^2.15.3",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",

--- a/garden/src/components/shadcn/chart.tsx
+++ b/garden/src/components/shadcn/chart.tsx
@@ -1,0 +1,363 @@
+import * as React from "react"
+import * as RechartsPrimitive from "recharts"
+
+import { cn } from "@/utils/form.utils"
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: "", dark: ".dark" } as const
+
+export type ChartConfig = {
+  [k in string]: {
+    label?: React.ReactNode
+    icon?: React.ComponentType
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  )
+}
+
+type ChartContextProps = {
+  config: ChartConfig
+}
+
+const ChartContext = React.createContext<ChartContextProps | null>(null)
+
+function useChart() {
+  const context = React.useContext(ChartContext)
+
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />")
+  }
+
+  return context
+}
+
+const ChartContainer = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div"> & {
+    config: ChartConfig
+    children: React.ComponentProps<
+      typeof RechartsPrimitive.ResponsiveContainer
+    >["children"]
+  }
+>(({ id, className, children, config, ...props }, ref) => {
+  const uniqueId = React.useId()
+  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-chart={chartId}
+        ref={ref}
+        className={cn(
+          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          className
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer>
+          {children}
+        </RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  )
+})
+ChartContainer.displayName = "Chart"
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(
+    ([, config]) => config.theme || config.color
+  )
+
+  if (!colorConfig.length) {
+    return null
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color =
+      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
+      itemConfig.color
+    return color ? `  --color-${key}: ${color};` : null
+  })
+  .join("\n")}
+}
+`
+          )
+          .join("\n"),
+      }}
+    />
+  )
+}
+
+const ChartTooltip = RechartsPrimitive.Tooltip
+
+const ChartTooltipContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+    React.ComponentProps<"div"> & {
+      hideLabel?: boolean
+      hideIndicator?: boolean
+      indicator?: "line" | "dot" | "dashed"
+      nameKey?: string
+      labelKey?: string
+    }
+>(
+  (
+    {
+      active,
+      payload,
+      className,
+      indicator = "dot",
+      hideLabel = false,
+      hideIndicator = false,
+      label,
+      labelFormatter,
+      labelClassName,
+      formatter,
+      color,
+      nameKey,
+      labelKey,
+    },
+    ref
+  ) => {
+    const { config } = useChart()
+
+    const tooltipLabel = React.useMemo(() => {
+      if (hideLabel || !payload?.length) {
+        return null
+      }
+
+      const [item] = payload
+      const key = `${labelKey || item?.dataKey || item?.name || "value"}`
+      const itemConfig = getPayloadConfigFromPayload(config, item, key)
+      const value =
+        !labelKey && typeof label === "string"
+          ? config[label as keyof typeof config]?.label || label
+          : itemConfig?.label
+
+      if (labelFormatter) {
+        return (
+          <div className={cn("font-medium", labelClassName)}>
+            {labelFormatter(value, payload)}
+          </div>
+        )
+      }
+
+      if (!value) {
+        return null
+      }
+
+      return <div className={cn("font-medium", labelClassName)}>{value}</div>
+    }, [
+      label,
+      labelFormatter,
+      payload,
+      hideLabel,
+      labelClassName,
+      config,
+      labelKey,
+    ])
+
+    if (!active || !payload?.length) {
+      return null
+    }
+
+    const nestLabel = payload.length === 1 && indicator !== "dot"
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
+          className
+        )}
+      >
+        {!nestLabel ? tooltipLabel : null}
+        <div className="grid gap-1.5">
+          {payload.map((item, index) => {
+            const key = `${nameKey || item.name || item.dataKey || "value"}`
+            const itemConfig = getPayloadConfigFromPayload(config, item, key)
+            const indicatorColor = color || item.payload.fill || item.color
+
+            return (
+              <div
+                key={item.dataKey}
+                className={cn(
+                  "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
+                  indicator === "dot" && "items-center"
+                )}
+              >
+                {formatter && item?.value !== undefined && item.name ? (
+                  formatter(item.value, item.name, item, index, item.payload)
+                ) : (
+                  <>
+                    {itemConfig?.icon ? (
+                      <itemConfig.icon />
+                    ) : (
+                      !hideIndicator && (
+                        <div
+                          className={cn(
+                            "shrink-0 rounded-[2px] border-[--color-border] bg-[--color-bg]",
+                            {
+                              "h-2.5 w-2.5": indicator === "dot",
+                              "w-1": indicator === "line",
+                              "w-0 border-[1.5px] border-dashed bg-transparent":
+                                indicator === "dashed",
+                              "my-0.5": nestLabel && indicator === "dashed",
+                            }
+                          )}
+                          style={
+                            {
+                              "--color-bg": indicatorColor,
+                              "--color-border": indicatorColor,
+                            } as React.CSSProperties
+                          }
+                        />
+                      )
+                    )}
+                    <div
+                      className={cn(
+                        "flex flex-1 justify-between leading-none",
+                        nestLabel ? "items-end" : "items-center"
+                      )}
+                    >
+                      <div className="grid gap-1.5">
+                        {nestLabel ? tooltipLabel : null}
+                        <span className="text-muted-foreground">
+                          {itemConfig?.label || item.name}
+                        </span>
+                      </div>
+                      {item.value && (
+                        <span className="font-mono font-medium tabular-nums text-foreground">
+                          {item.value.toLocaleString()}
+                        </span>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    )
+  }
+)
+ChartTooltipContent.displayName = "ChartTooltip"
+
+const ChartLegend = RechartsPrimitive.Legend
+
+const ChartLegendContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<"div"> &
+    Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
+      hideIcon?: boolean
+      nameKey?: string
+    }
+>(
+  (
+    { className, hideIcon = false, payload, verticalAlign = "bottom", nameKey },
+    ref
+  ) => {
+    const { config } = useChart()
+
+    if (!payload?.length) {
+      return null
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "flex items-center justify-center gap-4",
+          verticalAlign === "top" ? "pb-3" : "pt-3",
+          className
+        )}
+      >
+        {payload.map((item) => {
+          const key = `${nameKey || item.dataKey || "value"}`
+          const itemConfig = getPayloadConfigFromPayload(config, item, key)
+
+          return (
+            <div
+              key={item.value}
+              className={cn(
+                "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground"
+              )}
+            >
+              {itemConfig?.icon && !hideIcon ? (
+                <itemConfig.icon />
+              ) : (
+                <div
+                  className="h-2 w-2 shrink-0 rounded-[2px]"
+                  style={{
+                    backgroundColor: item.color,
+                  }}
+                />
+              )}
+              {itemConfig?.label}
+            </div>
+          )
+        })}
+      </div>
+    )
+  }
+)
+ChartLegendContent.displayName = "ChartLegend"
+
+// Helper to extract item config from a payload.
+function getPayloadConfigFromPayload(
+  config: ChartConfig,
+  payload: unknown,
+  key: string
+) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined
+  }
+
+  const payloadPayload =
+    "payload" in payload &&
+    typeof payload.payload === "object" &&
+    payload.payload !== null
+      ? payload.payload
+      : undefined
+
+  let configLabelKey: string = key
+
+  if (
+    key in payload &&
+    typeof payload[key as keyof typeof payload] === "string"
+  ) {
+    configLabelKey = payload[key as keyof typeof payload] as string
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+  ) {
+    configLabelKey = payloadPayload[
+      key as keyof typeof payloadPayload
+    ] as string
+  }
+
+  return configLabelKey in config
+    ? config[configLabelKey]
+    : config[key as keyof typeof config]
+}
+
+export {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+}

--- a/garden/src/features/benchmarks/BenchmarksPage.tsx
+++ b/garden/src/features/benchmarks/BenchmarksPage.tsx
@@ -13,13 +13,14 @@ import {
     DialogTitle,
 } from "@/components/shadcn/dialog";
 import { Button } from "@/components/shadcn/button";
-import { Loader2, Play, RefreshCw } from "lucide-react";
+import { Loader2, Play, RefreshCw, Menu, X } from "lucide-react";
 
 import { BenchmarksTable } from "./benchmarks-table/BenchmarksTable";
 import { useGetBenchmarkResults } from "./api/useGetBenchmarkResults";
 import { BenchmarkFunctionDialog } from "./components/BenchmarkFunctionDialog";
 import { BenchmarkInfo } from "./components/BenchmarkInfo";
 import { TaskDescription } from "./components/TaskDescription";
+import { TaskVisualization } from "./components/TaskVisualization";
 import { BenchmarkResult } from "@/types";
 import { useGetBenchmarks } from "./api/useGetBenchmarks";
 import { Benchmark, BenchmarkTask } from "./types";
@@ -96,6 +97,7 @@ export const BenchmarksPage = () => {
     const [showCreateDialog, setShowCreateDialog] = useState(false);
     const [showBenchmarkDialog, setShowBenchmarkDialog] = useState(false);
     const [showMockData, setShowMockData] = useState(false); // Toggle for mock data
+    const [sidebarOpen, setSidebarOpen] = useState(false); // Mobile sidebar state
 
     // Get benchmark data
     const { data: benchmarkMetadata = [] } = useGetBenchmarks();
@@ -154,20 +156,14 @@ export const BenchmarksPage = () => {
                     )}
                 </CardHeader>
                 <CardContent>
-                    {/* Task Description */}
-                    <TaskDescription 
-                        taskName={task.function.function_name}
-                        functionName={task.function.title || task.function.function_name}
-                    />
-                    
                     {isLoading ? (
                         <div className="flex justify-center items-center py-8">
                             <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
                         </div>
                     ) : (
-                        <div>
+                        <div className="space-y-6">
                             {hasPendingResults && (
-                                <div className="mb-4 p-3 bg-yellow-50 border border-yellow-200 rounded-md">
+                                <div className="p-3 bg-yellow-50 border border-yellow-200 rounded-md">
                                     <div className="flex items-center gap-2">
                                         <RefreshCw className="h-4 w-4 animate-spin text-yellow-500" />
                                         <span className="text-yellow-800 text-sm">
@@ -177,8 +173,9 @@ export const BenchmarksPage = () => {
                                 </div>
                             )}
 
+                            {/* Visualizations First - Main Attraction */}
                             {displayResults.length > 0 ? (
-                                <BenchmarksTable
+                                <TaskVisualization
                                     data={displayResults}
                                     benchmarkName={selectedBenchmark?.name}
                                 />
@@ -186,6 +183,14 @@ export const BenchmarksPage = () => {
                                 <div className="text-center py-6 border rounded-md bg-gray-50">
                                     <p className="text-gray-500">No results available for this task.</p>
                                 </div>
+                            )}
+
+                            {/* Task Description - Context After Engagement */}
+                            {displayResults.length > 0 && (
+                                <TaskDescription 
+                                    taskName={task.function.function_name}
+                                    functionName={task.function.title || task.function.function_name}
+                                />
                             )}
                         </div>
                     )}
@@ -195,9 +200,32 @@ export const BenchmarksPage = () => {
     };
 
     return (
-        <div className="flex h-full">
+        <div className="flex h-full relative">
+            {/* Mobile Menu Button */}
+            <Button
+                variant="outline"
+                size="sm"
+                className="lg:hidden fixed top-4 left-4 z-50 bg-background shadow-md"
+                onClick={() => setSidebarOpen(!sidebarOpen)}
+            >
+                {sidebarOpen ? <X className="h-4 w-4" /> : <Menu className="h-4 w-4" />}
+            </Button>
+
+            {/* Mobile Overlay */}
+            {sidebarOpen && (
+                <div
+                    className="lg:hidden fixed inset-0 bg-black/50 z-40"
+                    onClick={() => setSidebarOpen(false)}
+                />
+            )}
+
             {/* Benchmarks Sidebar */}
-            <div className="w-64 border-r h-full p-4 flex flex-col">
+            <div className={cn(
+                "w-64 border-r h-full p-4 flex flex-col bg-background z-40",
+                "lg:relative lg:translate-x-0 lg:block",
+                "fixed inset-y-0 left-0 transform transition-transform",
+                sidebarOpen ? "translate-x-0" : "-translate-x-full"
+            )}>
                 <div className="flex justify-between items-center mb-4">
                     <h2 className="font-semibold text-lg">Benchmarks</h2>
                 </div>
@@ -212,7 +240,10 @@ export const BenchmarksPage = () => {
                                     ? "bg-primary text-primary-foreground"
                                     : "hover:bg-muted"
                             )}
-                            onClick={() => handleBenchmarkSelection(benchmark.id)}
+                            onClick={() => {
+                                handleBenchmarkSelection(benchmark.id);
+                                setSidebarOpen(false); // Close sidebar on mobile after selection
+                            }}
                         >
                             <div className="font-medium truncate">{benchmark.name}</div>
                             {selectedBenchmarkId === benchmark.id && (
@@ -249,7 +280,7 @@ export const BenchmarksPage = () => {
             </div>
 
             {/* Main Content Area */}
-            <div className="flex-1 p-6 overflow-y-auto">
+            <div className="flex-1 p-6 overflow-y-auto lg:pl-6 pl-16">
                 {selectedBenchmark ? (
                     <>
                         {/* Clean Header Section */}

--- a/garden/src/features/benchmarks/BenchmarksPage.tsx
+++ b/garden/src/features/benchmarks/BenchmarksPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect } from "react";
 import {
     Card,
     CardContent,
@@ -15,9 +15,10 @@ import {
 import { Button } from "@/components/shadcn/button";
 import { Loader2, Play, RefreshCw } from "lucide-react";
 
-import { BenchmarksTable, generateColumnsFromData } from "./benchmarks-table/BenchmarksTable";
+import { BenchmarksTable } from "./benchmarks-table/BenchmarksTable";
 import { useGetBenchmarkResults } from "./api/useGetBenchmarkResults";
 import { BenchmarkFunctionDialog } from "./components/BenchmarkFunctionDialog";
+import { BenchmarkInfo } from "./components/BenchmarkInfo";
 import { BenchmarkResult } from "@/types";
 import { useGetBenchmarks } from "./api/useGetBenchmarks";
 import { Benchmark, BenchmarkTask } from "./types";
@@ -25,57 +26,67 @@ import { useGlobusAuth } from "@globus/react-auth-context";
 import { SUPER_USERS } from "@/utils/utils";
 import { cn } from "@/utils/form.utils";
 
-// Mock data for visualizing tables when API data isn't available
+// Mock data for visualizing tables when API data isn't available (MatBench-style)
 const mockBenchmarkResults = [
     {
         function_id: 1,
         date_invoked: new Date().toISOString(),
-        accuracy: 0.95,
-        f1_score: 0.92,
-        precision: 0.93,
-        recall: 0.91,
+        f1_score: 0.925,
+        daf: 6.12,
+        accuracy: 0.94,
+        precision: 0.91,
+        recall: 0.93,
+        rmsd: 0.045,
         latency_ms: 125,
-        loss: 0.05,
+        thermal_conductivity_mae: 0.021,
     },
     {
         function_id: 2,
         date_invoked: new Date(Date.now() - 86400000).toISOString(), // Yesterday
-        accuracy: 0.78,
-        f1_score: 0.72,
-        precision: 0.75,
-        recall: 0.68,
+        f1_score: 0.857,
+        daf: 4.85,
+        accuracy: 0.88,
+        precision: 0.82,
+        recall: 0.89,
+        rmsd: 0.067,
         latency_ms: 98,
-        loss: 0.21,
+        thermal_conductivity_mae: 0.034,
     },
     {
         function_id: 3,
         date_invoked: new Date(Date.now() - 172800000).toISOString(), // 2 days ago
-        accuracy: 0.52,
-        f1_score: 0.48,
-        precision: 0.51,
-        recall: 0.45,
+        f1_score: 0.742,
+        daf: 3.21,
+        accuracy: 0.76,
+        precision: 0.69,
+        recall: 0.80,
+        rmsd: 0.089,
         latency_ms: 145,
-        loss: 0.48,
+        thermal_conductivity_mae: 0.052,
     },
     {
         function_id: 4,
         date_invoked: new Date(Date.now() - 259200000).toISOString(), // 3 days ago
-        accuracy: 0.31,
-        f1_score: 0.27,
-        precision: 0.30,
-        recall: 0.25,
+        f1_score: 0.623,
+        daf: 2.14,
+        accuracy: 0.65,
+        precision: 0.58,
+        recall: 0.69,
+        rmsd: 0.112,
         latency_ms: 167,
-        loss: 0.67,
+        thermal_conductivity_mae: 0.078,
     },
     {
-        function_id: 1,
+        function_id: 5,
         date_invoked: new Date(Date.now() - 345600000).toISOString(), // 4 days ago
-        accuracy: 0.09,
-        f1_score: 0.04,
-        precision: 0.06,
-        recall: 0.03,
+        f1_score: 0.485,
+        daf: 1.23,
+        accuracy: 0.51,
+        precision: 0.42,
+        recall: 0.56,
+        rmsd: 0.156,
         latency_ms: 211,
-        loss: 0.94,
+        thermal_conductivity_mae: 0.105,
     }
 ];
 
@@ -129,13 +140,6 @@ export const BenchmarksPage = () => {
         // Add mock data if no real data available and showMockData is enabled
         const displayResults = showMockData ? mockBenchmarkResults : processedResults;
 
-        // Generate columns from available results
-        const columns = useMemo(() => {
-            return displayResults.length > 0
-                ? generateColumnsFromData(displayResults)
-                : [];
-        }, [displayResults]);
-
         return (
             <Card className="mb-6">
                 <CardHeader>
@@ -163,8 +167,8 @@ export const BenchmarksPage = () => {
 
                             {displayResults.length > 0 ? (
                                 <BenchmarksTable
-                                    columns={columns}
                                     data={displayResults}
+                                    benchmarkName={selectedBenchmark?.name}
                                 />
                             ) : (
                                 <div className="text-center py-6 border rounded-md bg-gray-50">
@@ -236,9 +240,12 @@ export const BenchmarksPage = () => {
             <div className="flex-1 p-6 overflow-y-auto">
                 {selectedBenchmark ? (
                     <>
-                        <div className="mb-6">
-                            <h1 className="text-2xl font-bold">{selectedBenchmark.name}</h1>
-                            <p className="text-muted-foreground mt-1">{selectedBenchmark.description || "No description available"}</p>
+                        <div className="mb-8">
+                            <BenchmarkInfo
+                                benchmarkName={selectedBenchmark.name}
+                                description={selectedBenchmark.description}
+                                taskCount={selectedBenchmark.tasks?.length}
+                            />
                         </div>
 
                         {selectedBenchmark.tasks && selectedBenchmark.tasks.length > 0 ? (

--- a/garden/src/features/benchmarks/BenchmarksPage.tsx
+++ b/garden/src/features/benchmarks/BenchmarksPage.tsx
@@ -13,7 +13,7 @@ import {
     DialogTitle,
 } from "@/components/shadcn/dialog";
 import { Button } from "@/components/shadcn/button";
-import { Loader2, Play, RefreshCw, Menu, X } from "lucide-react";
+import { Loader2, Play, RefreshCw, Menu, X, ChevronDown, Info, ExternalLink } from "lucide-react";
 
 import { BenchmarksTable } from "./benchmarks-table/BenchmarksTable";
 import { useGetBenchmarkResults } from "./api/useGetBenchmarkResults";
@@ -27,6 +27,7 @@ import { Benchmark, BenchmarkTask } from "./types";
 import { useGlobusAuth } from "@globus/react-auth-context";
 import { SUPER_USERS } from "@/utils/utils";
 import { cn } from "@/utils/form.utils";
+import { MATBENCH_BENCHMARKS, MATBENCH_METRICS, isMatBenchDiscovery, hasMatBenchMetrics } from "./utils/matbench";
 
 // Mock data for visualizing tables when API data isn't available (MatBench-style)
 const mockBenchmarkResults = [
@@ -108,6 +109,34 @@ export const BenchmarksPage = () => {
     const selectedBenchmark = useMemo(() =>
         benchmarkMetadata.find((benchmark: Benchmark) => benchmark.id === selectedBenchmarkId),
         [benchmarkMetadata, selectedBenchmarkId]);
+
+    // Collect metrics from all tasks for the selected benchmark
+    const allBenchmarkMetrics = useMemo(() => {
+        if (!selectedBenchmark?.tasks) return new Set<string>();
+        
+        const metrics = new Set<string>();
+        
+        // Always show common MatBench metrics that we have definitions for
+        if (isMatBenchDiscovery(selectedBenchmark.name) || showMockData) {
+            // Add common MatBench metrics (prefer uppercase versions for display)
+            ['F1', 'DAF', 'Accuracy', 'Precision', 'Recall', 'MAE', 'RMSE'].forEach(metric => {
+                if (MATBENCH_METRICS[metric]) {
+                    metrics.add(metric);
+                }
+            });
+        }
+        
+        // If showing mock data, add all mock metrics
+        if (showMockData) {
+            Object.keys(mockBenchmarkResults[0]).forEach(key => {
+                if (key !== 'function_id' && key !== 'date_invoked') {
+                    metrics.add(key);
+                }
+            });
+        }
+        
+        return metrics;
+    }, [selectedBenchmark, showMockData]);
 
     // Use the first benchmark by default if none is selected
     useEffect(() => {
@@ -283,13 +312,91 @@ export const BenchmarksPage = () => {
             <div className="flex-1 p-6 overflow-y-auto lg:pl-6 pl-16">
                 {selectedBenchmark ? (
                     <>
-                        {/* Clean Header Section */}
-                        <div className="mb-6">
-                            <div className="flex items-center justify-between mb-2">
+                        {/* Enhanced Header Section */}
+                        <div className="mb-6 space-y-4">
+                            {/* Title and Task Count */}
+                            <div className="flex items-center justify-between">
                                 <h1 className="text-2xl font-bold">{selectedBenchmark.name}</h1>
                                 <div className="text-sm text-muted-foreground">
                                     {selectedBenchmark.tasks?.length} evaluation task{selectedBenchmark.tasks?.length !== 1 ? 's' : ''}
                                 </div>
+                            </div>
+
+                            {/* MatBench Links and Info Bar */}
+                            {isMatBenchDiscovery(selectedBenchmark.name) && (
+                                <div className="bg-gradient-to-r from-blue-50 to-green-50 border border-blue-200 rounded-lg p-4">
+                                    <div className="flex flex-col sm:flex-row gap-4 justify-between items-start">
+                                        <div className="flex items-start gap-3">
+                                            <div className="bg-blue-100 rounded-full p-1 mt-0.5">
+                                                <Info className="h-4 w-4 text-blue-600" />
+                                            </div>
+                                            <div>
+                                                <h3 className="font-medium text-blue-900 mb-1">
+                                                    MatBench Discovery Benchmark
+                                                </h3>
+                                                <p className="text-sm text-blue-800">
+                                                    Evaluating AI models for accelerated materials discovery and crystal structure prediction
+                                                </p>
+                                            </div>
+                                        </div>
+                                        <div className="flex gap-2">
+                                            <Button
+                                                variant="outline"
+                                                size="sm"
+                                                asChild
+                                                className="bg-white/50 hover:bg-white/80"
+                                            >
+                                                <a
+                                                    href="https://matbench-discovery.materialsproject.org/"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    className="flex items-center gap-1"
+                                                >
+                                                    Website
+                                                    <ExternalLink className="h-3 w-3" />
+                                                </a>
+                                            </Button>
+                                            <Button
+                                                variant="outline"
+                                                size="sm"
+                                                asChild
+                                                className="bg-white/50 hover:bg-white/80"
+                                            >
+                                                <a
+                                                    href="https://doi.org/10.1038/s41467-023-43490-1"
+                                                    target="_blank"
+                                                    rel="noopener noreferrer"
+                                                    className="flex items-center gap-1"
+                                                >
+                                                    Paper
+                                                    <ExternalLink className="h-3 w-3" />
+                                                </a>
+                                            </Button>
+                                        </div>
+                                    </div>
+                                </div>
+                            )}
+
+                            {/* Navigation Hints */}
+                            <div className="flex flex-col sm:flex-row gap-3 justify-between items-start sm:items-center">
+                                <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                    <ChevronDown className="h-4 w-4 animate-bounce" />
+                                    <span>Scroll down for benchmark details and metric explanations</span>
+                                </div>
+                                
+                                {/* Quick Metrics Guide */}
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    onClick={() => {
+                                        const metricsSection = document.getElementById('metrics-info');
+                                        metricsSection?.scrollIntoView({ behavior: 'smooth' });
+                                    }}
+                                    className="flex items-center gap-1 text-xs"
+                                >
+                                    <Info className="h-3 w-3" />
+                                    What do these metrics mean?
+                                </Button>
                             </div>
                         </div>
 
@@ -303,6 +410,71 @@ export const BenchmarksPage = () => {
                         ) : (
                             <div className="text-center py-12 border rounded-md bg-gray-50">
                                 <p className="text-gray-500">No benchmark tasks available for this benchmark.</p>
+                            </div>
+                        )}
+
+                        {/* Metrics Information Panel */}
+                        {selectedBenchmark.tasks && selectedBenchmark.tasks.length > 0 && (
+                            <div className="mt-12 pt-8 border-t" id="metrics-info">
+                                <div className="space-y-4">
+                                    <div className="flex items-center gap-2 mb-4">
+                                        <Info className="h-5 w-5 text-muted-foreground" />
+                                        <h2 className="text-xl font-semibold">Understanding the Metrics</h2>
+                                    </div>
+                                    
+                                    {(() => {
+                                        const metricsArray = Array.from(allBenchmarkMetrics)
+                                            .map(key => ({ key, info: MATBENCH_METRICS[key] }))
+                                            .filter(({ info }) => info)
+                                            .sort((a, b) => {
+                                                // Sort primary metrics first
+                                                if (a.info?.isPrimaryMetric && !b.info?.isPrimaryMetric) return -1;
+                                                if (!a.info?.isPrimaryMetric && b.info?.isPrimaryMetric) return 1;
+                                                return a.info?.name.localeCompare(b.info?.name) || 0;
+                                            });
+                                        
+                                        return metricsArray.length > 0 ? (
+                                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                                {metricsArray.map(({ key, info }) => (
+                                                    <Card key={key} className={cn(
+                                                        "p-4",
+                                                        info.isPrimaryMetric && "border-primary/50 bg-primary/5"
+                                                    )}>
+                                                        <div className="space-y-2">
+                                                            <div className="flex items-center justify-between">
+                                                                <h4 className="font-medium flex items-center gap-2">
+                                                                    <span className="font-bold text-primary">{key}</span>
+                                                                    <span className="text-muted-foreground">-</span>
+                                                                    <span>{info.name}</span>
+                                                                    {info.isPrimaryMetric && (
+                                                                        <span className="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded">
+                                                                            Key Metric
+                                                                        </span>
+                                                                    )}
+                                                                </h4>
+                                                                <div className="text-xs text-muted-foreground">
+                                                                    {info.betterIs === 'higher' ? '↗️ Higher is better' : '↘️ Lower is better'}
+                                                                </div>
+                                                            </div>
+                                                            <p className="text-sm text-muted-foreground">
+                                                                {info.description}
+                                                            </p>
+                                                            {info.unit && (
+                                                                <div className="text-xs text-muted-foreground">
+                                                                    Unit: {info.unit}
+                                                                </div>
+                                                            )}
+                                                        </div>
+                                                    </Card>
+                                                ))}
+                                            </div>
+                                        ) : (
+                                            <div className="text-center py-6 border rounded-md bg-gray-50">
+                                                <p className="text-gray-500">No metric information available.</p>
+                                            </div>
+                                        );
+                                    })()}
+                                </div>
                             </div>
                         )}
 

--- a/garden/src/features/benchmarks/BenchmarksPage.tsx
+++ b/garden/src/features/benchmarks/BenchmarksPage.tsx
@@ -19,6 +19,7 @@ import { BenchmarksTable } from "./benchmarks-table/BenchmarksTable";
 import { useGetBenchmarkResults } from "./api/useGetBenchmarkResults";
 import { BenchmarkFunctionDialog } from "./components/BenchmarkFunctionDialog";
 import { BenchmarkInfo } from "./components/BenchmarkInfo";
+import { TaskDescription } from "./components/TaskDescription";
 import { BenchmarkResult } from "@/types";
 import { useGetBenchmarks } from "./api/useGetBenchmarks";
 import { Benchmark, BenchmarkTask } from "./types";
@@ -141,13 +142,24 @@ export const BenchmarksPage = () => {
         const displayResults = showMockData ? mockBenchmarkResults : processedResults;
 
         return (
-            <Card className="mb-6">
-                <CardHeader>
-                    <CardTitle className="text-lg">
+            <Card>
+                <CardHeader className="pb-4">
+                    <CardTitle className="text-xl font-semibold">
                         {task.function.title || task.function.function_name}
                     </CardTitle>
+                    {displayResults.length > 0 && (
+                        <div className="text-sm text-muted-foreground">
+                            {displayResults.length} model{displayResults.length !== 1 ? 's' : ''} evaluated
+                        </div>
+                    )}
                 </CardHeader>
                 <CardContent>
+                    {/* Task Description */}
+                    <TaskDescription 
+                        taskName={task.function.function_name}
+                        functionName={task.function.title || task.function.function_name}
+                    />
+                    
                     {isLoading ? (
                         <div className="flex justify-center items-center py-8">
                             <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
@@ -240,16 +252,19 @@ export const BenchmarksPage = () => {
             <div className="flex-1 p-6 overflow-y-auto">
                 {selectedBenchmark ? (
                     <>
-                        <div className="mb-8">
-                            <BenchmarkInfo
-                                benchmarkName={selectedBenchmark.name}
-                                description={selectedBenchmark.description}
-                                taskCount={selectedBenchmark.tasks?.length}
-                            />
+                        {/* Clean Header Section */}
+                        <div className="mb-6">
+                            <div className="flex items-center justify-between mb-2">
+                                <h1 className="text-2xl font-bold">{selectedBenchmark.name}</h1>
+                                <div className="text-sm text-muted-foreground">
+                                    {selectedBenchmark.tasks?.length} evaluation task{selectedBenchmark.tasks?.length !== 1 ? 's' : ''}
+                                </div>
+                            </div>
                         </div>
 
+                        {/* Main Data Tables */}
                         {selectedBenchmark.tasks && selectedBenchmark.tasks.length > 0 ? (
-                            <div>
+                            <div className="space-y-6">
                                 {selectedBenchmark.tasks.map((task) => (
                                     <TaskResultPanel key={task.id} task={task} />
                                 ))}
@@ -259,6 +274,15 @@ export const BenchmarksPage = () => {
                                 <p className="text-gray-500">No benchmark tasks available for this benchmark.</p>
                             </div>
                         )}
+
+                        {/* Benchmark Information - Moved to Bottom */}
+                        <div className="mt-12 pt-8 border-t">
+                            <BenchmarkInfo
+                                benchmarkName={selectedBenchmark.name}
+                                description={selectedBenchmark.description}
+                                taskCount={selectedBenchmark.tasks?.length}
+                            />
+                        </div>
                     </>
                 ) : (
                     <div className="flex items-center justify-center h-full">

--- a/garden/src/features/benchmarks/benchmarks-table/BenchmarksTable.tsx
+++ b/garden/src/features/benchmarks/benchmarks-table/BenchmarksTable.tsx
@@ -45,6 +45,7 @@ interface BenchmarksTableProps<TData, TValue> {
     data: TData[]
     generateColumns?: boolean
     benchmarkName?: string
+    compact?: boolean
 }
 
 // Default column sizes
@@ -264,12 +265,19 @@ const getNumericValue = (value: unknown): number | null => {
 const FunctionNameCell = ({ functionId }: { functionId: string }) => {
     const { data, isLoading, error } = useGetModalFunction(functionId);
 
-    if (isLoading) return <span>Loading...</span>;
-    if (error) return <span>Error loading function</span>;
+    if (isLoading) return <span className="text-muted-foreground text-sm">Loading...</span>;
+    if (error) return <span className="text-destructive text-sm">Error loading function</span>;
 
     return (
         <div className="flex flex-col">
-            <Link to={`/modal-functions/${functionId}`} className="font-medium">{data?.title || "Unknown Function"}</Link>
+            <Link 
+                to={`/modal-functions/${functionId}`} 
+                className="font-semibold text-primary hover:text-primary/80 transition-colors truncate"
+                title={data?.title || "Unknown Function"}
+            >
+                {data?.title || "Unknown Function"}
+            </Link>
+            <span className="text-xs text-muted-foreground">ID: {functionId}</span>
         </div>
     );
 };
@@ -317,6 +325,7 @@ export const BenchmarksTable = <TData extends Record<string, unknown>, TValue>({
     columns,
     data,
     benchmarkName,
+    compact = false,
 }: BenchmarksTableProps<TData, TValue>) => {
     const [sorting, setSorting] = useState<SortingState>([]);
     const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
@@ -360,18 +369,18 @@ export const BenchmarksTable = <TData extends Record<string, unknown>, TValue>({
     const columnCount = table.getAllColumns().length;
 
     return (
-        <div className="space-y-2">
-            <div className="flex justify-end">
+        <div className={`${compact ? 'flex flex-col h-full text-sm' : 'space-y-2'}`}>
+            <div className={`flex justify-end ${compact ? 'flex-shrink-0' : ''}`}>
                 <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                         <Button
                             variant="outline"
                             size="sm"
-                            className="ml-auto flex items-center gap-1"
+                            className={`ml-auto flex items-center gap-1 ${compact ? 'h-7 px-2 text-xs' : ''}`}
                         >
-                            <EyeOff className="h-4 w-4" />
-                            <span>Columns</span>
-                            <ChevronDown className="h-4 w-4" />
+                            <EyeOff className={compact ? "h-3 w-3" : "h-4 w-4"} />
+                            <span className={compact ? "hidden" : ""}>Columns</span>
+                            <ChevronDown className={compact ? "h-3 w-3" : "h-4 w-4"} />
                         </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
@@ -421,7 +430,8 @@ export const BenchmarksTable = <TData extends Record<string, unknown>, TValue>({
                     </DropdownMenuContent>
                 </DropdownMenu>
             </div>
-            <div className="rounded-md border overflow-x-auto">
+            <div className={`rounded-lg border border-border/50 overflow-hidden shadow-sm ${compact ? 'flex-1 min-h-0' : 'w-full'}`}>
+                <div className="overflow-x-auto">
                 <Table className="w-full" style={{ width: table.getCenterTotalSize() }}>
                     <TableHeader>
                         {table.getHeaderGroups().map((headerGroup) => (
@@ -429,7 +439,7 @@ export const BenchmarksTable = <TData extends Record<string, unknown>, TValue>({
                                 {headerGroup.headers.map((header) => (
                                     <TableHead
                                         key={header.id}
-                                        className="whitespace-nowrap px-2 relative"
+                                        className={`whitespace-nowrap relative font-semibold ${compact ? 'px-3 py-2 text-xs' : 'px-4 py-3'}`}
                                         style={{ width: header.getSize() }}
                                     >
                                         {header.column.getCanSort() ? (
@@ -453,7 +463,7 @@ export const BenchmarksTable = <TData extends Record<string, unknown>, TValue>({
                                             <div
                                                 onMouseDown={header.getResizeHandler()}
                                                 onTouchStart={header.getResizeHandler()}
-                                                className={`absolute right-0 top-0 h-full w-0.5 cursor-col-resize select-none touch-none hover:bg-gray-400 ${header.column.getIsResizing() ? 'bg-blue-500' : 'bg-gray-200'
+                                                className={`absolute right-0 top-0 h-full w-0.5 cursor-col-resize select-none touch-none hover:bg-primary/60 transition-colors ${header.column.getIsResizing() ? 'bg-primary' : 'bg-border'
                                                     }`}
                                             />
                                         )}
@@ -464,8 +474,11 @@ export const BenchmarksTable = <TData extends Record<string, unknown>, TValue>({
                     </TableHeader>
                     <TableBody>
                         {table.getRowModel().rows.length > 0 ? (
-                            table.getRowModel().rows.map((row) => (
-                                <TableRow key={row.id}>
+                            table.getRowModel().rows.map((row, rowIndex) => (
+                                <TableRow 
+                                    key={row.id}
+                                    className={`hover:bg-muted/30 transition-colors ${rowIndex % 2 === 0 ? 'bg-background' : 'bg-muted/20'}`}
+                                >
                                     {row.getVisibleCells().map((cell) => {
                                         const value = cell.getValue();
                                         const style: React.CSSProperties = {
@@ -475,18 +488,22 @@ export const BenchmarksTable = <TData extends Record<string, unknown>, TValue>({
                                         // Get numeric value and direction for coloring
                                         const coloringInfo = getNumericValueForColoring(value, cell.column, isMatBench);
 
-                                        // Apply background color for numeric values
+                                        // Apply background color for numeric values with better opacity
                                         if (coloringInfo !== null && coloringInfo.value >= 0) {
-                                            style.backgroundColor = getColorForValue(coloringInfo.value, coloringInfo.betterIs);
+                                            const baseColor = getColorForValue(coloringInfo.value, coloringInfo.betterIs);
+                                            // Reduce opacity for better readability
+                                            style.backgroundColor = baseColor.replace('0.3)', '0.15)');
                                         }
 
                                         return (
                                             <TableCell
                                                 key={cell.id}
-                                                className="px-2"
+                                                className={`font-medium transition-colors ${compact ? 'px-3 py-2.5 text-xs' : 'px-4 py-3'}`}
                                                 style={style}
                                             >
-                                                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                                <div className="flex items-center">
+                                                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                                                </div>
                                             </TableCell>
                                         );
                                     })}
@@ -494,13 +511,14 @@ export const BenchmarksTable = <TData extends Record<string, unknown>, TValue>({
                             ))
                         ) : (
                             <TableRow>
-                                <TableCell colSpan={columnCount} className="h-24 text-center">
-                                    No results.
+                                <TableCell colSpan={columnCount} className={`h-24 text-center text-muted-foreground ${compact ? 'text-xs' : ''}`}>
+                                    No results available.
                                 </TableCell>
                             </TableRow>
                         )}
                     </TableBody>
                 </Table>
+                </div>
             </div>
         </div>
     );

--- a/garden/src/features/benchmarks/benchmarks-table/BenchmarksTable.tsx
+++ b/garden/src/features/benchmarks/benchmarks-table/BenchmarksTable.tsx
@@ -31,11 +31,20 @@ import {
     DropdownMenuSeparator,
     DropdownMenuItem,
 } from "@/components/shadcn/dropdown-menu";
+import { MetricDisplay, MetricHeader } from "../components/MetricDisplay";
+import { 
+    MATBENCH_METRICS, 
+    formatMetricValue, 
+    getPerformanceTier,
+    isMatBenchDiscovery,
+    hasMatBenchMetrics 
+} from "../utils/matbench";
 
 interface BenchmarksTableProps<TData, TValue> {
     columns?: ColumnDef<TData, TValue>[]
     data: TData[]
     generateColumns?: boolean
+    benchmarkName?: string
 }
 
 // Default column sizes
@@ -43,16 +52,36 @@ const DEFAULT_COLUMN_SIZE = 100;
 const FUNCTION_COLUMN_SIZE = 180;
 const DATE_COLUMN_SIZE = 120;
 
-// Helper function to generate a red-yellow-green background color based on value
-const getColorForValue = (value: number): string => {
-    // For values > 1, use a special shade of green with intensity based on magnitude
-    if (value > 1) {
-        const intensity = Math.min(0.6, 0.3 + Math.log10(value) * 0.15);
-        return `rgba(0, 180, 0, ${intensity})`;
+// Helper function to generate a red-yellow-green background color based on value and metric direction
+const getColorForValue = (value: number, betterIs: 'higher' | 'lower' = 'higher'): string => {
+    let normalizedValue = value;
+    
+    // For "lower is better" metrics, we need to invert the color logic
+    if (betterIs === 'lower') {
+        // For lower-is-better metrics, smaller values should be green
+        // We'll map the value to a 0-1 scale where 0 = green (best) and 1 = red (worst)
+        if (value <= 0) {
+            // Perfect score for lower-is-better (0 or negative) = bright green
+            return `rgba(0, 180, 0, 0.4)`;
+        } else if (value >= 1) {
+            // Very bad score for lower-is-better (1 or higher) = use log scale
+            const intensity = Math.min(0.6, 0.3 + Math.log10(value) * 0.15);
+            return `rgba(255, 0, 0, ${intensity})`;
+        } else {
+            // Invert the value so that 0 = 1 (green) and 1 = 0 (red)
+            normalizedValue = 1 - value;
+        }
+    } else {
+        // For "higher is better" metrics (original logic)
+        if (value > 1) {
+            const intensity = Math.min(0.6, 0.3 + Math.log10(value) * 0.15);
+            return `rgba(0, 180, 0, ${intensity})`;
+        }
+        normalizedValue = value;
     }
 
     // Ensure value is between 0 and 1 for color interpolation
-    const clampedValue = Math.max(0, Math.min(1, value));
+    const clampedValue = Math.max(0, Math.min(1, normalizedValue));
 
     // Red-Yellow-Green transition
     // For values 0-0.5: red to yellow
@@ -80,9 +109,12 @@ const getColorForValue = (value: number): string => {
 
 // Helper function to generate columns from data
 export const generateColumnsFromData = <TData extends Record<string, unknown>, TValue>(
-    data: TData[]
+    data: TData[],
+    benchmarkName?: string
 ): ColumnDef<TData, TValue>[] => {
     if (!data.length) return [];
+
+    const isMatBench = (benchmarkName && isMatBenchDiscovery(benchmarkName)) || hasMatBenchMetrics(data);
 
     // Get all unique keys from all data objects
     const allKeys = new Set<string>();
@@ -95,8 +127,15 @@ export const generateColumnsFromData = <TData extends Record<string, unknown>, T
         });
     });
 
-    // Convert to array and sort alphabetically
-    const keys = Array.from(allKeys).sort();
+    // Convert to array and sort - prioritize primary metrics for MatBench
+    let keys = Array.from(allKeys);
+    if (isMatBench) {
+        const primaryMetrics = ['F1', 'DAF', 'Accuracy', 'f1_score', 'daf', 'accuracy'];
+        const otherKeys = keys.filter(k => !primaryMetrics.includes(k)).sort();
+        keys = [...primaryMetrics.filter(k => keys.includes(k)), ...otherKeys];
+    } else {
+        keys = keys.sort();
+    }
 
     // Define function column first
     const functionColumn = {
@@ -138,13 +177,43 @@ export const generateColumnsFromData = <TData extends Record<string, unknown>, T
     // Create column definitions for other fields
     const dynamic_columns = keys.map(key => ({
         accessorKey: key,
-        header: key, // Use the exact key name as the header
+        header: ({ column }) => {
+            if (isMatBench && MATBENCH_METRICS[key]) {
+                return (
+                    <MetricHeader
+                        metricKey={key}
+                        sortable={true}
+                        onSort={() => column.toggleSorting()}
+                        sortDirection={column.getIsSorted() || null}
+                    />
+                );
+            }
+            return key; // Use the exact key name as the header for non-MatBench
+        },
         enableSorting: true,
         enableHiding: true,
         enableResizing: true,
         size: DEFAULT_COLUMN_SIZE,
         cell: ({ row }) => {
             const value = row.getValue(key);
+            
+            if (isMatBench && MATBENCH_METRICS[key]) {
+                // Get F1 score and DAF for performance tier calculation (try both cases)
+                const f1Score = getNumericValue(row.getValue('F1')) || getNumericValue(row.getValue('f1_score'));
+                const daf = getNumericValue(row.getValue('DAF')) || getNumericValue(row.getValue('daf'));
+                
+                return (
+                    <MetricDisplay
+                        metricKey={key}
+                        value={value}
+                        f1Score={f1Score || undefined}
+                        daf={daf || undefined}
+                        compact={true}
+                    />
+                );
+            }
+
+            // Default formatting for non-MatBench metrics
             let displayValue: string | number | null = null;
 
             // Handle complex objects with parsedValue
@@ -171,19 +240,24 @@ export const generateColumnsFromData = <TData extends Record<string, unknown>, T
         meta: {
             isMetricColumn: true,
             getNumericValue: (value: unknown): number | null => {
-                if (typeof value === 'number') {
-                    return value;
-                }
-                if (value && typeof value === 'object' && 'parsedValue' in value) {
-                    const parsedValue = (value as { parsedValue: unknown }).parsedValue;
-                    return typeof parsedValue === 'number' ? parsedValue : null;
-                }
-                return null;
+                return getNumericValue(value);
             }
         }
     })) as ColumnDef<TData, TValue>[];
 
     return [functionColumn, dateColumn, ...dynamic_columns];
+};
+
+// Helper function to extract numeric values
+const getNumericValue = (value: unknown): number | null => {
+    if (typeof value === 'number') {
+        return value;
+    }
+    if (value && typeof value === 'object' && 'parsedValue' in value) {
+        const parsedValue = (value as { parsedValue: unknown }).parsedValue;
+        return typeof parsedValue === 'number' ? parsedValue : null;
+    }
+    return null;
 };
 
 // Component to fetch and display function name
@@ -206,40 +280,54 @@ interface ColumnMeta {
     getNumericValue?: (value: unknown) => number | null;
 }
 
-// Helper function to check if a value can be colored (is numeric)
+// Helper function to check if a value can be colored (is numeric) and get color direction
 const getNumericValueForColoring = (
     value: unknown,
-    column: { columnDef: { meta?: ColumnMeta } }
-): number | null => {
+    column: { columnDef: { meta?: ColumnMeta }; id: string },
+    isMatBench: boolean
+): { value: number; betterIs: 'higher' | 'lower' } | null => {
     // Only apply coloring to metric columns (not function names or dates)
     if (!column.columnDef.meta?.isMetricColumn) {
         return null;
     }
 
-    // If the column has a getNumericValue function in meta, use it
+    // Get the numeric value
+    let numericValue: number | null = null;
     if (column.columnDef.meta?.getNumericValue) {
-        return column.columnDef.meta.getNumericValue(value);
+        numericValue = column.columnDef.meta.getNumericValue(value);
+    } else if (typeof value === 'number') {
+        numericValue = value;
     }
 
-    // Default handling for numeric values
-    if (typeof value === 'number') {
-        return value;
+    if (numericValue === null) {
+        return null;
     }
 
-    return null;
+    // Determine direction based on metric type
+    let betterIs: 'higher' | 'lower' = 'higher'; // default
+    
+    if (isMatBench && MATBENCH_METRICS[column.id]) {
+        betterIs = MATBENCH_METRICS[column.id].betterIs;
+    }
+
+    return { value: numericValue, betterIs };
 };
 
 export const BenchmarksTable = <TData extends Record<string, unknown>, TValue>({
     columns,
     data,
+    benchmarkName,
 }: BenchmarksTableProps<TData, TValue>) => {
     const [sorting, setSorting] = useState<SortingState>([]);
     const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
     const columnResizeMode: ColumnResizeMode = 'onChange';
+    
+    // Determine if this is MatBench data for coloring purposes
+    const isMatBench = (benchmarkName && isMatBenchDiscovery(benchmarkName)) || hasMatBenchMetrics(data);
 
     const table = useReactTable({
         data,
-        columns: columns || [],
+        columns: columns || generateColumnsFromData(data, benchmarkName),
         getCoreRowModel: getCoreRowModel(),
         onSortingChange: setSorting,
         getSortedRowModel: getSortedRowModel(),
@@ -384,12 +472,12 @@ export const BenchmarksTable = <TData extends Record<string, unknown>, TValue>({
                                             width: cell.column.getSize()
                                         };
 
-                                        // Get numeric value for coloring
-                                        const numericValue = getNumericValueForColoring(value, cell.column);
+                                        // Get numeric value and direction for coloring
+                                        const coloringInfo = getNumericValueForColoring(value, cell.column, isMatBench);
 
-                                        // Apply background color for numeric values (including those > 1)
-                                        if (numericValue !== null && numericValue >= 0) {
-                                            style.backgroundColor = getColorForValue(numericValue);
+                                        // Apply background color for numeric values
+                                        if (coloringInfo !== null && coloringInfo.value >= 0) {
+                                            style.backgroundColor = getColorForValue(coloringInfo.value, coloringInfo.betterIs);
                                         }
 
                                         return (

--- a/garden/src/features/benchmarks/components/BenchmarkInfo.tsx
+++ b/garden/src/features/benchmarks/components/BenchmarkInfo.tsx
@@ -32,12 +32,8 @@ export const BenchmarkInfo: React.FC<BenchmarkInfoProps> = ({
       <div className="flex items-start justify-between">
         <div className="space-y-2">
           <div className="flex items-center gap-2">
-            <h1 className="text-2xl font-bold">{displayName}</h1>
-            {isMatBench && (
-              <Badge variant="default" className="text-xs">
-                Materials Science
-              </Badge>
-            )}
+            <BookOpen className="h-5 w-5 text-muted-foreground" />
+            <h2 className="text-xl font-semibold">About This Benchmark</h2>
           </div>
           
           {purpose && (

--- a/garden/src/features/benchmarks/components/BenchmarkInfo.tsx
+++ b/garden/src/features/benchmarks/components/BenchmarkInfo.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { ExternalLink, BookOpen, Target, Lightbulb } from 'lucide-react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/shadcn/card';
+import { Badge } from '@/components/shadcn/badge';
+import { Button } from '@/components/shadcn/button';
+import { MATBENCH_BENCHMARKS, isMatBenchDiscovery } from '../utils/matbench';
+
+interface BenchmarkInfoProps {
+  benchmarkName: string;
+  description?: string;
+  taskCount?: number;
+  lastUpdated?: string;
+}
+
+export const BenchmarkInfo: React.FC<BenchmarkInfoProps> = ({
+  benchmarkName,
+  description,
+  taskCount,
+  lastUpdated,
+}) => {
+  const isMatBench = isMatBenchDiscovery(benchmarkName);
+  const matbenchInfo = isMatBench ? MATBENCH_BENCHMARKS['matbench-discovery'] : null;
+
+  const displayName = matbenchInfo?.name || benchmarkName;
+  const displayDescription = matbenchInfo?.detailedDescription || description || 'No description available';
+  const purpose = matbenchInfo?.purpose;
+  const learnMoreUrl = matbenchInfo?.learnMoreUrl;
+
+  return (
+    <div className="space-y-4">
+      {/* Header Section */}
+      <div className="flex items-start justify-between">
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-bold">{displayName}</h1>
+            {isMatBench && (
+              <Badge variant="default" className="text-xs">
+                Materials Science
+              </Badge>
+            )}
+          </div>
+          
+          {purpose && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Target className="h-4 w-4" />
+              <span className="italic">{purpose}</span>
+            </div>
+          )}
+        </div>
+
+        {learnMoreUrl && (
+          <Button 
+            variant="outline" 
+            size="sm" 
+            asChild 
+            className="flex items-center gap-1"
+          >
+            <a href={learnMoreUrl} target="_blank" rel="noopener noreferrer">
+              <BookOpen className="h-4 w-4" />
+              Learn More
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          </Button>
+        )}
+      </div>
+
+      {/* Description Card */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-lg flex items-center gap-2">
+            <Lightbulb className="h-5 w-5 text-yellow-500" />
+            What This Benchmark Does
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <p className="text-muted-foreground leading-relaxed">
+            {displayDescription}
+          </p>
+
+          {isMatBench && (
+            <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
+              <h4 className="font-medium text-blue-900 mb-2">
+                Key Evaluation Areas:
+              </h4>
+              <ul className="text-sm text-blue-800 space-y-1">
+                <li>• <strong>Stability Prediction:</strong> Can the model identify which crystal structures will be stable?</li>
+                <li>• <strong>Discovery Speed:</strong> How much faster can it find promising materials vs random search?</li>
+                <li>• <strong>Structure Optimization:</strong> Can it predict the final stable shape of crystals?</li>
+              </ul>
+            </div>
+          )}
+
+          {/* Metadata */}
+          <div className="flex items-center gap-4 text-sm text-muted-foreground pt-2 border-t">
+            {taskCount && (
+              <span>
+                <strong>{taskCount}</strong> evaluation tasks
+              </span>
+            )}
+            {lastUpdated && (
+              <span>
+                Last updated: {new Date(lastUpdated).toLocaleDateString()}
+              </span>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {isMatBench && (
+        <div className="bg-gradient-to-r from-green-50 to-blue-50 border border-green-200 rounded-lg p-4">
+          <div className="flex items-start gap-3">
+            <div className="bg-green-100 rounded-full p-1">
+              <Target className="h-4 w-4 text-green-600" />
+            </div>
+            <div>
+              <h4 className="font-medium text-green-900 mb-1">
+                Why This Matters for Materials Science
+              </h4>
+              <p className="text-sm text-green-800">
+                Finding new materials traditionally takes decades of lab work. These AI models can 
+                pre-screen millions of potential materials in days, helping scientists focus their 
+                efforts on the most promising candidates for solar panels, batteries, and other technologies.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/garden/src/features/benchmarks/components/MetricDisplay.tsx
+++ b/garden/src/features/benchmarks/components/MetricDisplay.tsx
@@ -160,7 +160,7 @@ export const MetricHeader: React.FC<MetricHeaderProps> = ({
   const content = (
     <div className="flex items-center gap-1">
       <span className={metric.isPrimaryMetric ? 'font-semibold' : ''}>
-        {metric.name}
+        {metricKey}
       </span>
       <TrendIcon className={`h-3 w-3 ${trendColor}`} />
       {metric.isPrimaryMetric && (

--- a/garden/src/features/benchmarks/components/MetricDisplay.tsx
+++ b/garden/src/features/benchmarks/components/MetricDisplay.tsx
@@ -1,0 +1,202 @@
+import React from 'react';
+import { Info, TrendingUp, TrendingDown } from 'lucide-react';
+import { Badge } from '@/components/shadcn/badge';
+import { 
+  Tooltip, 
+  TooltipContent, 
+  TooltipProvider, 
+  TooltipTrigger 
+} from '@/components/shadcn/tooltip';
+import { 
+  MATBENCH_METRICS, 
+  formatMetricValue, 
+  getPerformanceTier,
+  getPracticalImpact,
+  type MetricInfo 
+} from '../utils/matbench';
+
+interface MetricDisplayProps {
+  metricKey: string;
+  value: unknown;
+  f1Score?: number;
+  daf?: number;
+  showTier?: boolean;
+  showImpact?: boolean;
+  compact?: boolean;
+}
+
+export const MetricDisplay: React.FC<MetricDisplayProps> = ({
+  metricKey,
+  value,
+  f1Score,
+  daf,
+  showTier = false,
+  showImpact = false,
+  compact = false,
+}) => {
+  const metric = MATBENCH_METRICS[metricKey];
+  
+  if (!metric) {
+    return <span>{String(value)}</span>;
+  }
+
+  const formattedValue = formatMetricValue(value, metricKey);
+  const performanceTier = showTier ? getPerformanceTier(f1Score, daf) : null;
+  const impact = showImpact ? getPracticalImpact(f1Score, daf) : null;
+
+  const TrendIcon = metric.betterIs === 'higher' ? TrendingUp : TrendingDown;
+  const trendColor = metric.betterIs === 'higher' ? 'text-green-600' : 'text-red-600';
+
+  if (compact) {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="font-medium cursor-help">
+              {formattedValue}
+              {metric.unit && ` ${metric.unit}`}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="top" className="max-w-xs">
+            <div className="space-y-1">
+              <div className="font-medium flex items-center gap-1">
+                {metric.name}
+                <TrendIcon className={`h-3 w-3 ${trendColor}`} />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {metric.description}
+              </p>
+              {metric.betterIs && (
+                <p className="text-xs font-medium">
+                  {metric.betterIs === 'higher' ? 'Higher is better' : 'Lower is better'}
+                </p>
+              )}
+            </div>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <span className="font-medium">
+          {formattedValue}
+          {metric.unit && ` ${metric.unit}`}
+        </span>
+        
+        {metric.isPrimaryMetric && (
+          <Badge variant="secondary" className="text-xs">
+            Key Metric
+          </Badge>
+        )}
+
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className="h-4 w-4 text-muted-foreground cursor-help" />
+            </TooltipTrigger>
+            <TooltipContent side="top" className="max-w-xs">
+              <div className="space-y-1">
+                <div className="font-medium flex items-center gap-1">
+                  {metric.name}
+                  <TrendIcon className={`h-3 w-3 ${trendColor}`} />
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {metric.description}
+                </p>
+                {metric.betterIs && (
+                  <p className="text-xs font-medium">
+                    Better is {metric.betterIs}
+                  </p>
+                )}
+              </div>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+
+      {performanceTier && (
+        <Badge 
+          variant="outline" 
+          className={`text-xs ${performanceTier.color}`}
+        >
+          {performanceTier.description}
+        </Badge>
+      )}
+
+      {impact && (
+        <p className="text-xs text-muted-foreground italic">
+          {impact}
+        </p>
+      )}
+    </div>
+  );
+};
+
+interface MetricHeaderProps {
+  metricKey: string;
+  sortable?: boolean;
+  onSort?: () => void;
+  sortDirection?: 'asc' | 'desc' | null;
+}
+
+export const MetricHeader: React.FC<MetricHeaderProps> = ({
+  metricKey,
+  sortable = true,
+  onSort,
+  sortDirection,
+}) => {
+  const metric = MATBENCH_METRICS[metricKey];
+  
+  if (!metric) {
+    return <span>{metricKey}</span>;
+  }
+
+  const TrendIcon = metric.betterIs === 'higher' ? TrendingUp : TrendingDown;
+  const trendColor = metric.betterIs === 'higher' ? 'text-green-600' : 'text-red-600';
+
+  const content = (
+    <div className="flex items-center gap-1">
+      <span className={metric.isPrimaryMetric ? 'font-semibold' : ''}>
+        {metric.name}
+      </span>
+      <TrendIcon className={`h-3 w-3 ${trendColor}`} />
+      {metric.isPrimaryMetric && (
+        <Badge variant="secondary" className="text-xs ml-1">
+          Key
+        </Badge>
+      )}
+    </div>
+  );
+
+  if (!sortable) {
+    return content;
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            onClick={onSort}
+            className="flex items-center gap-1 cursor-pointer hover:text-foreground transition-colors"
+          >
+            {content}
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-xs">
+          <div className="space-y-1">
+            <p className="text-xs text-muted-foreground">
+              {metric.description}
+            </p>
+            <p className="text-xs font-medium">
+              {metric.betterIs === 'higher' ? 'Higher is better' : 'Lower is better'}
+            </p>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};

--- a/garden/src/features/benchmarks/components/RadarChart.tsx
+++ b/garden/src/features/benchmarks/components/RadarChart.tsx
@@ -1,0 +1,316 @@
+import React, { useMemo } from 'react';
+import { 
+  Radar, 
+  RadarChart, 
+  PolarGrid, 
+  PolarAngleAxis, 
+  PolarRadiusAxis,
+  ResponsiveContainer,
+  Legend
+} from 'recharts';
+import { 
+  ChartContainer, 
+  ChartTooltip,
+  ChartLegend,
+  ChartLegendContent,
+  type ChartConfig 
+} from '@/components/shadcn/chart';
+import { 
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/shadcn/select';
+import { Badge } from '@/components/shadcn/badge';
+import { 
+  MATBENCH_METRICS, 
+  formatMetricValue,
+  getPerformanceTier,
+  isMatBenchDiscovery,
+  hasMatBenchMetrics
+} from '../utils/matbench';
+import { useGetModalFunction } from '@/features/modal/api/useGetModalFunction';
+
+interface RadarChartProps {
+  data: Record<string, unknown>[];
+  benchmarkName?: string;
+  compact?: boolean;
+}
+
+// Helper function to extract numeric value
+const getNumericValue = (value: unknown): number | null => {
+  if (typeof value === 'number') return value;
+  if (value && typeof value === 'object' && 'parsedValue' in value) {
+    const parsedValue = (value as { parsedValue: unknown }).parsedValue;
+    return typeof parsedValue === 'number' ? parsedValue : null;
+  }
+  return null;
+};
+
+// Get available numeric metrics
+const getAvailableMetrics = (data: Record<string, unknown>[]): string[] => {
+  if (!data.length) return [];
+  
+  const numericKeys = new Set<string>();
+  data.forEach(item => {
+    Object.keys(item).forEach(key => {
+      if (key !== 'function_id' && key !== 'date_invoked') {
+        const value = getNumericValue(item[key]);
+        if (value !== null) {
+          numericKeys.add(key);
+        }
+      }
+    });
+  });
+  
+  return Array.from(numericKeys).sort();
+};
+
+// Normalize values to 0-100 scale for radar chart
+const normalizeValue = (value: number, metric: string, allValues: number[]): number => {
+  const metricInfo = MATBENCH_METRICS[metric];
+  const min = Math.min(...allValues);
+  const max = Math.max(...allValues);
+  
+  if (min === max) return 50; // If all values are the same
+  
+  let normalized;
+  if (metricInfo?.betterIs === 'lower') {
+    // For "lower is better" metrics, invert the scale
+    normalized = ((max - value) / (max - min)) * 100;
+  } else {
+    // For "higher is better" metrics
+    normalized = ((value - min) / (max - min)) * 100;
+  }
+  
+  return Math.round(normalized);
+};
+
+// Generate colors for different functions
+const FUNCTION_COLORS = [
+  '#2563eb', // blue-600
+  '#dc2626', // red-600
+  '#16a34a', // green-600
+  '#ca8a04', // yellow-600
+  '#9333ea', // purple-600
+  '#ea580c', // orange-600
+  '#0891b2', // cyan-600
+  '#c2410c', // orange-700
+];
+
+// Component to display function name from ID
+const FunctionName: React.FC<{ functionId: string | number }> = ({ functionId }) => {
+  const { data } = useGetModalFunction(String(functionId));
+  return <span>{data?.title || data?.function_name || `Function #${functionId}`}</span>;
+};
+
+export const RadarChartComponent: React.FC<RadarChartProps> = ({ data, benchmarkName, compact = false }) => {
+  const isMatBench = (benchmarkName && isMatBenchDiscovery(benchmarkName)) || hasMatBenchMetrics(data);
+  const availableMetrics = getAvailableMetrics(data);
+  
+  // Default metrics - prioritize key MatBench metrics
+  const defaultMetrics = isMatBench ? 
+    availableMetrics.filter(m => ['f1_score', 'F1', 'daf', 'DAF', 'accuracy', 'Accuracy', 'precision', 'Precision', 'recall', 'Recall'].includes(m)).slice(0, 5) :
+    availableMetrics.slice(0, 5);
+  
+  const [selectedMetrics, setSelectedMetrics] = React.useState(defaultMetrics);
+  const [maxFunctions, setMaxFunctions] = React.useState(5);
+  
+  // Process data for radar chart
+  const radarData = useMemo(() => {
+    if (!selectedMetrics.length) return [];
+    
+    // Get all values for each metric for normalization
+    const metricValues: Record<string, number[]> = {};
+    selectedMetrics.forEach(metric => {
+      metricValues[metric] = data.map(item => getNumericValue(item[metric])).filter(v => v !== null) as number[];
+    });
+    
+    // Create radar data structure
+    return selectedMetrics.map(metric => {
+      const metricInfo = MATBENCH_METRICS[metric];
+      const radarPoint: any = {
+        metric: metricInfo?.name || metric,
+        fullName: metricInfo?.name || metric,
+      };
+      
+      // Add data for each function (limited by maxFunctions)
+      data.slice(0, maxFunctions).forEach((item, index) => {
+        const value = getNumericValue(item[metric]);
+        if (value !== null) {
+          radarPoint[`function_${item.function_id}`] = normalizeValue(value, metric, metricValues[metric]);
+        }
+      });
+      
+      return radarPoint;
+    });
+  }, [data, selectedMetrics, maxFunctions]);
+  
+  // Hook to get function data for chart config
+  const functionQueries = data.slice(0, maxFunctions).map(item => 
+    useGetModalFunction(String(item.function_id))
+  );
+
+  // Generate chart config
+  const chartConfig: ChartConfig = useMemo(() => {
+    const config: ChartConfig = {};
+    data.slice(0, maxFunctions).forEach((item, index) => {
+      const functionData = functionQueries[index]?.data;
+      const functionName = functionData?.title || functionData?.function_name || `Function #${item.function_id}`;
+      
+      config[`function_${item.function_id}`] = {
+        label: functionName,
+        color: FUNCTION_COLORS[index % FUNCTION_COLORS.length],
+      };
+    });
+    return config;
+  }, [data, maxFunctions, functionQueries]);
+  
+  const handleMetricToggle = (metric: string) => {
+    setSelectedMetrics(prev => 
+      prev.includes(metric) 
+        ? prev.filter(m => m !== metric)
+        : [...prev, metric]
+    );
+  };
+  
+  if (availableMetrics.length < 3) {
+    return (
+      <div className="flex items-center justify-center h-64 text-muted-foreground">
+        <p>Need at least 3 metrics for radar chart visualization</p>
+      </div>
+    );
+  }
+  
+  return (
+    <div className={compact ? "flex flex-col h-full" : "space-y-4"}>
+      {/* Controls */}
+      <div className={`${compact ? 'space-y-3 flex-shrink-0' : 'space-y-4'}`}>
+        {/* Function Limit Selector */}
+        <div className="flex items-center gap-2">
+          <label className={`${compact ? 'text-xs' : 'text-sm'} font-medium text-muted-foreground whitespace-nowrap`}>
+            Show Functions:
+          </label>
+          <Select value={maxFunctions.toString()} onValueChange={(v) => setMaxFunctions(parseInt(v))}>
+            <SelectTrigger className={compact ? "w-16 h-8 text-xs" : "w-24"}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {(compact ? [3, 4, 5] : [3, 4, 5, 6, 7, 8]).map(num => (
+                <SelectItem key={num} value={num.toString()}>
+                  {num}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {!compact && (
+            <span className="text-xs text-muted-foreground">
+              (Top {maxFunctions} functions)
+            </span>
+          )}
+        </div>
+        
+        {/* Metric Selectors */}
+        <div>
+          <label className={`${compact ? 'text-xs' : 'text-sm'} font-medium text-muted-foreground mb-2 block`}>
+            Metrics to Compare:
+          </label>
+          <div className="flex flex-wrap gap-1">
+            {availableMetrics.map(metric => {
+              const metricInfo = MATBENCH_METRICS[metric];
+              const isSelected = selectedMetrics.includes(metric);
+              
+              return (
+                <Badge
+                  key={metric}
+                  variant={isSelected ? "default" : "outline"}
+                  className={`cursor-pointer transition-all hover:scale-105 ${compact ? 'text-xs py-0.5 px-1.5' : ''}`}
+                  onClick={() => handleMetricToggle(metric)}
+                >
+                  {metricInfo?.name || metric}
+                </Badge>
+              );
+            })}
+          </div>
+          <div className={`${compact ? 'text-xs' : 'text-xs'} text-muted-foreground mt-1`}>
+            Selected: {selectedMetrics.length} metrics
+          </div>
+        </div>
+      </div>
+      
+      {/* Radar Chart */}
+      {selectedMetrics.length > 0 && (
+        <ChartContainer config={chartConfig} className={compact ? "flex-1 min-h-0" : "h-96 w-full"}>
+          <RadarChart data={radarData}>
+            <PolarGrid />
+            <PolarAngleAxis 
+              dataKey="metric" 
+              tick={{ fontSize: 12 }}
+              className="text-xs"
+            />
+            <PolarRadiusAxis 
+              angle={90} 
+              domain={[0, 100]} 
+              tick={{ fontSize: 10 }}
+              tickCount={6}
+            />
+            
+            {/* Render a radar area for each function */}
+            {data.slice(0, maxFunctions).map((item, index) => {
+              const key = `function_${item.function_id}`;
+              const color = FUNCTION_COLORS[index % FUNCTION_COLORS.length];
+              const functionName = String(chartConfig[key]?.label || `Function #${item.function_id}`);
+              
+              return (
+                <Radar
+                  key={key}
+                  name={functionName}
+                  dataKey={key}
+                  stroke={color}
+                  fill={color}
+                  fillOpacity={0.1}
+                  strokeWidth={2}
+                />
+              );
+            })}
+            
+            <ChartTooltip 
+              content={({ active, payload, label }) => {
+                if (!active || !payload?.length) return null;
+                
+                return (
+                  <div className="rounded-lg border bg-background p-3 shadow-md">
+                    <div className="font-medium mb-2">{label}</div>
+                    <div className="space-y-1 text-sm">
+                      {payload.map((entry, index) => (
+                        <div key={index} className="flex justify-between gap-4">
+                          <span 
+                            className="text-muted-foreground flex items-center gap-1"
+                          >
+                            <div 
+                              className="w-2 h-2 rounded-full" 
+                              style={{ backgroundColor: entry.color }}
+                            />
+                            {entry.name}:
+                          </span>
+                          <span className="font-mono">{entry.value}/100</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                );
+              }}
+            />
+            
+            <Legend content={<ChartLegendContent />} />
+          </RadarChart>
+        </ChartContainer>
+      )}
+      
+      <div className="text-xs text-muted-foreground text-center">
+        Values are normalized to 0-100 scale for comparison. Higher values indicate better performance.
+      </div>
+    </div>
+  );
+};

--- a/garden/src/features/benchmarks/components/RadarChart.tsx
+++ b/garden/src/features/benchmarks/components/RadarChart.tsx
@@ -308,7 +308,7 @@ export const RadarChartComponent: React.FC<RadarChartProps> = ({ data, benchmark
               content={(props) => (
                 <div className="flex flex-wrap justify-center gap-4 mt-4">
                   {props.payload?.map((entry, index) => {
-                    const functionId = entry.dataKey?.replace('function_', '');
+                    const functionId = typeof entry.dataKey === 'string' ? entry.dataKey.replace('function_', '') : entry.dataKey?.toString();
                     return (
                       <div
                         key={index}

--- a/garden/src/features/benchmarks/components/RadarChart.tsx
+++ b/garden/src/features/benchmarks/components/RadarChart.tsx
@@ -31,6 +31,7 @@ import {
   hasMatBenchMetrics
 } from '../utils/matbench';
 import { useGetModalFunction } from '@/features/modal/api/useGetModalFunction';
+import { useNavigate } from 'react-router-dom';
 
 interface RadarChartProps {
   data: Record<string, unknown>[];
@@ -106,6 +107,7 @@ const FunctionName: React.FC<{ functionId: string | number }> = ({ functionId })
 };
 
 export const RadarChartComponent: React.FC<RadarChartProps> = ({ data, benchmarkName, compact = false }) => {
+  const navigate = useNavigate();
   const isMatBench = (benchmarkName && isMatBenchDiscovery(benchmarkName)) || hasMatBenchMetrics(data);
   const availableMetrics = getAvailableMetrics(data);
   
@@ -173,6 +175,7 @@ export const RadarChartComponent: React.FC<RadarChartProps> = ({ data, benchmark
         : [...prev, metric]
     );
   };
+
   
   if (availableMetrics.length < 3) {
     return (
@@ -301,13 +304,45 @@ export const RadarChartComponent: React.FC<RadarChartProps> = ({ data, benchmark
               }}
             />
             
-            <Legend content={<ChartLegendContent />} />
+            <Legend 
+              content={(props) => (
+                <div className="flex flex-wrap justify-center gap-4 mt-4">
+                  {props.payload?.map((entry, index) => {
+                    const functionId = entry.dataKey?.replace('function_', '');
+                    return (
+                      <div
+                        key={index}
+                        className="flex items-center gap-2 cursor-pointer hover:bg-muted/50 px-2 py-1 rounded transition-colors"
+                        onClick={() => {
+                          if (functionId) {
+                            navigate(`/modal-functions/${functionId}`);
+                          }
+                        }}
+                      >
+                        <div
+                          className="w-3 h-3 rounded-full"
+                          style={{ backgroundColor: entry.color }}
+                        />
+                        <span className="text-sm text-foreground hover:text-primary">
+                          {entry.value}
+                        </span>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            />
           </RadarChart>
         </ChartContainer>
       )}
       
-      <div className="text-xs text-muted-foreground text-center">
-        Values are normalized to 0-100 scale for comparison. Higher values indicate better performance.
+      <div className="space-y-1">
+        <div className="text-xs text-muted-foreground text-center">
+          Values are normalized to 0-100 scale for comparison. Higher values indicate better performance.
+        </div>
+        <div className="text-xs text-muted-foreground text-center">
+          💡 Click any function name in the legend to view function details
+        </div>
       </div>
     </div>
   );

--- a/garden/src/features/benchmarks/components/RadarChart.tsx
+++ b/garden/src/features/benchmarks/components/RadarChart.tsx
@@ -129,10 +129,9 @@ export const RadarChartComponent: React.FC<RadarChartProps> = ({ data, benchmark
     
     // Create radar data structure
     return selectedMetrics.map(metric => {
-      const metricInfo = MATBENCH_METRICS[metric];
       const radarPoint: any = {
-        metric: metricInfo?.name || metric,
-        fullName: metricInfo?.name || metric,
+        metric: metric,
+        fullName: metric,
       };
       
       // Add data for each function (limited by maxFunctions)
@@ -218,7 +217,6 @@ export const RadarChartComponent: React.FC<RadarChartProps> = ({ data, benchmark
           </label>
           <div className="flex flex-wrap gap-1">
             {availableMetrics.map(metric => {
-              const metricInfo = MATBENCH_METRICS[metric];
               const isSelected = selectedMetrics.includes(metric);
               
               return (
@@ -228,7 +226,7 @@ export const RadarChartComponent: React.FC<RadarChartProps> = ({ data, benchmark
                   className={`cursor-pointer transition-all hover:scale-105 ${compact ? 'text-xs py-0.5 px-1.5' : ''}`}
                   onClick={() => handleMetricToggle(metric)}
                 >
-                  {metricInfo?.name || metric}
+                  {metric}
                 </Badge>
               );
             })}

--- a/garden/src/features/benchmarks/components/ScatterPlot.tsx
+++ b/garden/src/features/benchmarks/components/ScatterPlot.tsx
@@ -29,6 +29,7 @@ import {
   hasMatBenchMetrics
 } from '../utils/matbench';
 import { useGetModalFunction } from '@/features/modal/api/useGetModalFunction';
+import { useNavigate } from 'react-router-dom';
 
 interface ScatterPlotProps {
   data: Record<string, unknown>[];
@@ -93,6 +94,7 @@ const FunctionName: React.FC<{ functionId: string | number }> = ({ functionId })
 };
 
 export const ScatterPlot: React.FC<ScatterPlotProps> = ({ data, benchmarkName, compact = false }) => {
+  const navigate = useNavigate();
   const isMatBench = (benchmarkName && isMatBenchDiscovery(benchmarkName)) || hasMatBenchMetrics(data);
   const availableMetrics = getAvailableMetrics(data);
   
@@ -106,6 +108,13 @@ export const ScatterPlot: React.FC<ScatterPlotProps> = ({ data, benchmarkName, c
   
   const [xMetric, setXMetric] = React.useState(defaultXMetric || '');
   const [yMetric, setYMetric] = React.useState(defaultYMetric || '');
+
+  // Handle point click to navigate to function details
+  const handlePointClick = (data: any) => {
+    if (data && data.functionId) {
+      navigate(`/modal-functions/${data.functionId}`);
+    }
+  };
   
   // Process data for the scatter plot
   const scatterData = useMemo(() => {
@@ -235,7 +244,12 @@ export const ScatterPlot: React.FC<ScatterPlotProps> = ({ data, benchmarkName, c
               );
             }}
           />
-          <Scatter dataKey="y" fill="hsl(var(--primary))">
+          <Scatter 
+            dataKey="y" 
+            fill="hsl(var(--primary))"
+            onClick={handlePointClick}
+            cursor="pointer"
+          >
             {scatterData.map((entry, index) => (
               <Cell 
                 key={`cell-${index}`} 
@@ -246,15 +260,20 @@ export const ScatterPlot: React.FC<ScatterPlotProps> = ({ data, benchmarkName, c
         </ScatterChart>
       </ChartContainer>
       
-      {isMatBench && (
+      <div className="space-y-1">
+        {isMatBench && (
+          <div className="text-xs text-muted-foreground text-center">
+            Colors indicate performance tiers: 
+            <span className="inline-block w-2 h-2 bg-green-600 rounded-full ml-2 mr-1"></span>Excellent
+            <span className="inline-block w-2 h-2 bg-blue-600 rounded-full ml-2 mr-1"></span>Good
+            <span className="inline-block w-2 h-2 bg-yellow-600 rounded-full ml-2 mr-1"></span>Fair
+            <span className="inline-block w-2 h-2 bg-red-600 rounded-full ml-2 mr-1"></span>Poor
+          </div>
+        )}
         <div className="text-xs text-muted-foreground text-center">
-          Colors indicate performance tiers: 
-          <span className="inline-block w-2 h-2 bg-green-600 rounded-full ml-2 mr-1"></span>Excellent
-          <span className="inline-block w-2 h-2 bg-blue-600 rounded-full ml-2 mr-1"></span>Good
-          <span className="inline-block w-2 h-2 bg-yellow-600 rounded-full ml-2 mr-1"></span>Fair
-          <span className="inline-block w-2 h-2 bg-red-600 rounded-full ml-2 mr-1"></span>Poor
+          💡 Click any point to view function details
         </div>
-      )}
+      </div>
     </div>
   );
 };

--- a/garden/src/features/benchmarks/components/ScatterPlot.tsx
+++ b/garden/src/features/benchmarks/components/ScatterPlot.tsx
@@ -129,10 +129,10 @@ export const ScatterPlot: React.FC<ScatterPlotProps> = ({ data, benchmarkName, c
   // Chart configuration
   const chartConfig: ChartConfig = {
     x: {
-      label: MATBENCH_METRICS[xMetric]?.name || xMetric,
+      label: xMetric,
     },
     y: {
-      label: MATBENCH_METRICS[yMetric]?.name || yMetric,
+      label: yMetric,
     },
   };
   
@@ -159,7 +159,7 @@ export const ScatterPlot: React.FC<ScatterPlotProps> = ({ data, benchmarkName, c
             <SelectContent>
               {availableMetrics.map(metric => (
                 <SelectItem key={metric} value={metric}>
-                  {MATBENCH_METRICS[metric]?.name || metric}
+                  {metric}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -177,7 +177,7 @@ export const ScatterPlot: React.FC<ScatterPlotProps> = ({ data, benchmarkName, c
             <SelectContent>
               {availableMetrics.map(metric => (
                 <SelectItem key={metric} value={metric}>
-                  {MATBENCH_METRICS[metric]?.name || metric}
+                  {metric}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -213,11 +213,11 @@ export const ScatterPlot: React.FC<ScatterPlotProps> = ({ data, benchmarkName, c
                   </div>
                   <div className="space-y-1 text-sm">
                     <div className="flex justify-between gap-4">
-                      <span className="text-muted-foreground">{chartConfig.x.label}:</span>
+                      <span className="text-muted-foreground">{xMetric}:</span>
                       <span className="font-mono">{formatMetricValue(data.x, xMetric)}</span>
                     </div>
                     <div className="flex justify-between gap-4">
-                      <span className="text-muted-foreground">{chartConfig.y.label}:</span>
+                      <span className="text-muted-foreground">{yMetric}:</span>
                       <span className="font-mono">{formatMetricValue(data.y, yMetric)}</span>
                     </div>
                     {isMatBench && (

--- a/garden/src/features/benchmarks/components/ScatterPlot.tsx
+++ b/garden/src/features/benchmarks/components/ScatterPlot.tsx
@@ -1,0 +1,260 @@
+import React, { useMemo } from 'react';
+import { 
+  ScatterChart, 
+  Scatter, 
+  XAxis, 
+  YAxis, 
+  CartesianGrid, 
+  ResponsiveContainer,
+  Cell
+} from 'recharts';
+import { 
+  ChartContainer, 
+  ChartTooltip, 
+  ChartTooltipContent,
+  type ChartConfig 
+} from '@/components/shadcn/chart';
+import { 
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/shadcn/select';
+import { 
+  MATBENCH_METRICS, 
+  formatMetricValue,
+  getPerformanceTier,
+  isMatBenchDiscovery,
+  hasMatBenchMetrics
+} from '../utils/matbench';
+import { useGetModalFunction } from '@/features/modal/api/useGetModalFunction';
+
+interface ScatterPlotProps {
+  data: Record<string, unknown>[];
+  benchmarkName?: string;
+  compact?: boolean;
+}
+
+// Helper function to extract numeric value from complex objects
+const getNumericValue = (value: unknown): number | null => {
+  if (typeof value === 'number') return value;
+  if (value && typeof value === 'object' && 'parsedValue' in value) {
+    const parsedValue = (value as { parsedValue: unknown }).parsedValue;
+    return typeof parsedValue === 'number' ? parsedValue : null;
+  }
+  return null;
+};
+
+// Get available numeric metrics from the data
+const getAvailableMetrics = (data: Record<string, unknown>[]): string[] => {
+  if (!data.length) return [];
+  
+  const numericKeys = new Set<string>();
+  data.forEach(item => {
+    Object.keys(item).forEach(key => {
+      if (key !== 'function_id' && key !== 'date_invoked') {
+        const value = getNumericValue(item[key]);
+        if (value !== null) {
+          numericKeys.add(key);
+        }
+      }
+    });
+  });
+  
+  return Array.from(numericKeys).sort();
+};
+
+// Generate colors based on performance tier for MatBench data
+const getPointColor = (point: any, isMatBench: boolean): string => {
+  if (!isMatBench) return 'hsl(var(--primary))';
+  
+  const f1Score = getNumericValue(point.f1_score) || getNumericValue(point.F1);
+  const daf = getNumericValue(point.daf) || getNumericValue(point.DAF);
+  
+  if (f1Score !== null && daf !== null) {
+    const tier = getPerformanceTier(f1Score, daf);
+    switch (tier.tier) {
+      case 'excellent': return '#16a34a'; // green-600
+      case 'good': return '#2563eb'; // blue-600
+      case 'fair': return '#ca8a04'; // yellow-600
+      case 'poor': return '#dc2626'; // red-600
+      default: return 'hsl(var(--primary))';
+    }
+  }
+  
+  return 'hsl(var(--primary))';
+};
+
+// Component to display function name from ID
+const FunctionName: React.FC<{ functionId: string | number }> = ({ functionId }) => {
+  const { data } = useGetModalFunction(String(functionId));
+  return <span>{data?.title || data?.function_name || `Function #${functionId}`}</span>;
+};
+
+export const ScatterPlot: React.FC<ScatterPlotProps> = ({ data, benchmarkName, compact = false }) => {
+  const isMatBench = (benchmarkName && isMatBenchDiscovery(benchmarkName)) || hasMatBenchMetrics(data);
+  const availableMetrics = getAvailableMetrics(data);
+  
+  // Default to F1 vs DAF for MatBench, or first two metrics for others
+  const defaultXMetric = isMatBench ? 
+    (availableMetrics.find(m => ['f1_score', 'F1'].includes(m)) || availableMetrics[0]) : 
+    availableMetrics[0];
+  const defaultYMetric = isMatBench ? 
+    (availableMetrics.find(m => ['daf', 'DAF'].includes(m)) || availableMetrics[1]) : 
+    availableMetrics[1];
+  
+  const [xMetric, setXMetric] = React.useState(defaultXMetric || '');
+  const [yMetric, setYMetric] = React.useState(defaultYMetric || '');
+  
+  // Process data for the scatter plot
+  const scatterData = useMemo(() => {
+    if (!xMetric || !yMetric) return [];
+    
+    return data.map((item, index) => {
+      const xValue = getNumericValue(item[xMetric]);
+      const yValue = getNumericValue(item[yMetric]);
+      
+      if (xValue === null || yValue === null) return null;
+      
+      return {
+        x: xValue,
+        y: yValue,
+        functionId: item.function_id,
+        ...item, // Include all original data for tooltip
+      };
+    }).filter(Boolean);
+  }, [data, xMetric, yMetric]);
+  
+  // Chart configuration
+  const chartConfig: ChartConfig = {
+    x: {
+      label: MATBENCH_METRICS[xMetric]?.name || xMetric,
+    },
+    y: {
+      label: MATBENCH_METRICS[yMetric]?.name || yMetric,
+    },
+  };
+  
+  if (availableMetrics.length < 2) {
+    return (
+      <div className="flex items-center justify-center h-64 text-muted-foreground">
+        <p>Need at least 2 metrics for scatter plot visualization</p>
+      </div>
+    );
+  }
+  
+  return (
+    <div className={compact ? "flex flex-col h-full" : "space-y-4"}>
+      {/* Metric Selectors */}
+      <div className={`flex ${compact ? 'flex-col gap-2 flex-shrink-0' : 'flex-wrap gap-4'}`}>
+        <div className="flex items-center gap-2 min-w-0">
+          <label className={`${compact ? 'text-xs' : 'text-sm'} font-medium text-muted-foreground whitespace-nowrap`}>
+            X-Axis:
+          </label>
+          <Select value={xMetric} onValueChange={setXMetric}>
+            <SelectTrigger className={compact ? "w-32 h-8 text-xs" : "w-40"}>
+              <SelectValue placeholder="Select metric" />
+            </SelectTrigger>
+            <SelectContent>
+              {availableMetrics.map(metric => (
+                <SelectItem key={metric} value={metric}>
+                  {MATBENCH_METRICS[metric]?.name || metric}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        
+        <div className="flex items-center gap-2 min-w-0">
+          <label className={`${compact ? 'text-xs' : 'text-sm'} font-medium text-muted-foreground whitespace-nowrap`}>
+            Y-Axis:
+          </label>
+          <Select value={yMetric} onValueChange={setYMetric}>
+            <SelectTrigger className={compact ? "w-32 h-8 text-xs" : "w-40"}>
+              <SelectValue placeholder="Select metric" />
+            </SelectTrigger>
+            <SelectContent>
+              {availableMetrics.map(metric => (
+                <SelectItem key={metric} value={metric}>
+                  {MATBENCH_METRICS[metric]?.name || metric}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      
+      {/* Scatter Plot */}
+      <ChartContainer config={chartConfig} className={compact ? "flex-1 min-h-0" : "h-80 w-full"}>
+        <ScatterChart data={scatterData}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis 
+            type="number" 
+            dataKey="x" 
+            name={String(chartConfig.x.label)}
+            tickFormatter={(value) => formatMetricValue(value, xMetric)}
+          />
+          <YAxis 
+            type="number" 
+            dataKey="y" 
+            name={String(chartConfig.y.label)}
+            tickFormatter={(value) => formatMetricValue(value, yMetric)}
+          />
+          <ChartTooltip 
+            content={({ active, payload }) => {
+              if (!active || !payload?.length) return null;
+              
+              const data = payload[0].payload;
+              return (
+                <div className="rounded-lg border bg-background p-3 shadow-md">
+                  <div className="font-medium mb-2">
+                    <FunctionName functionId={data.functionId} />
+                  </div>
+                  <div className="space-y-1 text-sm">
+                    <div className="flex justify-between gap-4">
+                      <span className="text-muted-foreground">{chartConfig.x.label}:</span>
+                      <span className="font-mono">{formatMetricValue(data.x, xMetric)}</span>
+                    </div>
+                    <div className="flex justify-between gap-4">
+                      <span className="text-muted-foreground">{chartConfig.y.label}:</span>
+                      <span className="font-mono">{formatMetricValue(data.y, yMetric)}</span>
+                    </div>
+                    {isMatBench && (
+                      <div className="pt-1 border-t">
+                        <span className="text-xs text-muted-foreground">
+                          Performance: {getPerformanceTier(
+                            getNumericValue(data.f1_score) || getNumericValue(data.F1) || 0,
+                            getNumericValue(data.daf) || getNumericValue(data.DAF) || 0
+                          ).description}
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              );
+            }}
+          />
+          <Scatter dataKey="y" fill="hsl(var(--primary))">
+            {scatterData.map((entry, index) => (
+              <Cell 
+                key={`cell-${index}`} 
+                fill={getPointColor(entry, isMatBench)}
+              />
+            ))}
+          </Scatter>
+        </ScatterChart>
+      </ChartContainer>
+      
+      {isMatBench && (
+        <div className="text-xs text-muted-foreground text-center">
+          Colors indicate performance tiers: 
+          <span className="inline-block w-2 h-2 bg-green-600 rounded-full ml-2 mr-1"></span>Excellent
+          <span className="inline-block w-2 h-2 bg-blue-600 rounded-full ml-2 mr-1"></span>Good
+          <span className="inline-block w-2 h-2 bg-yellow-600 rounded-full ml-2 mr-1"></span>Fair
+          <span className="inline-block w-2 h-2 bg-red-600 rounded-full ml-2 mr-1"></span>Poor
+        </div>
+      )}
+    </div>
+  );
+};

--- a/garden/src/features/benchmarks/components/TaskDescription.tsx
+++ b/garden/src/features/benchmarks/components/TaskDescription.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { Info, Zap } from 'lucide-react';
+import { Badge } from '@/components/shadcn/badge';
+
+interface TaskDescriptionProps {
+  taskName: string;
+  functionName?: string;
+}
+
+// Task descriptions based on MatBench Discovery paper (https://arxiv.org/abs/2308.14920)
+const TASK_DESCRIPTIONS: Record<string, {
+  name: string;
+  description: string;
+  note?: string;
+  type: 'discovery' | 'optimization' | 'prediction';
+}> = {
+  // Common MatBench Discovery task variants
+  'is2re_small': {
+    name: 'IS2RE (Small)',
+    description: 'Initial Structure to Relaxed Energy - predicts the final energy of a crystal structure after geometric relaxation. This is a quick evaluation using the first 25 structures from the benchmark dataset.',
+    note: 'Fast test run for development',
+    type: 'prediction',
+  },
+  'is2re': {
+    name: 'IS2RE',
+    description: 'Initial Structure to Relaxed Energy - predicts the final energy of a crystal structure after geometric relaxation. Critical for determining material stability.',
+    type: 'prediction',
+  },
+  's2ef': {
+    name: 'S2EF',
+    description: 'Structure to Energy and Forces - predicts both the energy and atomic forces for a given crystal structure. Essential for molecular dynamics simulations.',
+    type: 'prediction',
+  },
+  'is2rs': {
+    name: 'IS2RS',
+    description: 'Initial Structure to Relaxed Structure - predicts the final relaxed geometry of a crystal structure. Used to find the most stable atomic arrangements.',
+    type: 'optimization',
+  },
+  'discovery': {
+    name: 'Materials Discovery',
+    description: 'Evaluates how effectively the model can identify stable materials from a large candidate pool. Measures both accuracy (F1 score) and discovery acceleration factor (DAF).',
+    type: 'discovery',
+  },
+  'stability_prediction': {
+    name: 'Stability Prediction',
+    description: 'Binary classification task to determine whether a given crystal structure will be thermodynamically stable. Core capability for materials screening.',
+    type: 'discovery',
+  },
+};
+
+// Fallback for unknown tasks
+const getTaskInfo = (taskName: string, functionName?: string) => {
+  // Try exact match first
+  if (TASK_DESCRIPTIONS[taskName]) {
+    return TASK_DESCRIPTIONS[taskName];
+  }
+  
+  // Try partial matches
+  const lowerTaskName = taskName.toLowerCase();
+  for (const [key, info] of Object.entries(TASK_DESCRIPTIONS)) {
+    if (lowerTaskName.includes(key.toLowerCase()) || key.toLowerCase().includes(lowerTaskName)) {
+      return info;
+    }
+  }
+  
+  // Check function name for clues
+  const lowerFunctionName = functionName?.toLowerCase() || '';
+  if (lowerFunctionName.includes('is2re') && lowerFunctionName.includes('small')) {
+    return TASK_DESCRIPTIONS['is2re_small'];
+  } else if (lowerFunctionName.includes('is2re')) {
+    return TASK_DESCRIPTIONS['is2re'];
+  } else if (lowerFunctionName.includes('s2ef')) {
+    return TASK_DESCRIPTIONS['s2ef'];
+  } else if (lowerFunctionName.includes('is2rs')) {
+    return TASK_DESCRIPTIONS['is2rs'];
+  } else if (lowerFunctionName.includes('discovery')) {
+    return TASK_DESCRIPTIONS['discovery'];
+  } else if (lowerFunctionName.includes('stability')) {
+    return TASK_DESCRIPTIONS['stability_prediction'];
+  }
+  
+  // Generic fallback
+  return {
+    name: taskName,
+    description: 'This task evaluates model performance on materials science prediction problems.',
+    type: 'prediction' as const,
+  };
+};
+
+const getTypeConfig = (type: string) => {
+  switch (type) {
+    case 'discovery':
+      return {
+        color: 'bg-green-100 text-green-800 border-green-200',
+        icon: '🔍',
+      };
+    case 'optimization':
+      return {
+        color: 'bg-blue-100 text-blue-800 border-blue-200',
+        icon: '⚡',
+      };
+    case 'prediction':
+      return {
+        color: 'bg-purple-100 text-purple-800 border-purple-200',
+        icon: '🎯',
+      };
+    default:
+      return {
+        color: 'bg-gray-100 text-gray-800 border-gray-200',
+        icon: '📊',
+      };
+  }
+};
+
+export const TaskDescription: React.FC<TaskDescriptionProps> = ({
+  taskName,
+  functionName,
+}) => {
+  const taskInfo = getTaskInfo(taskName, functionName);
+  const typeConfig = getTypeConfig(taskInfo.type);
+
+  return (
+    <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-4">
+      <div className="flex items-start gap-3">
+        <div className="flex-shrink-0 mt-0.5">
+          <Info className="h-5 w-5 text-blue-600" />
+        </div>
+        <div className="flex-1 space-y-2">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h4 className="font-medium text-blue-900">
+              {taskInfo.name}
+            </h4>
+            <Badge variant="outline" className={typeConfig.color}>
+              <span className="mr-1">{typeConfig.icon}</span>
+              {taskInfo.type}
+            </Badge>
+            {taskInfo.note && (
+              <Badge variant="outline" className="bg-yellow-100 text-yellow-800 border-yellow-200">
+                <Zap className="h-3 w-3 mr-1" />
+                {taskInfo.note}
+              </Badge>
+            )}
+          </div>
+          <p className="text-sm text-blue-800 leading-relaxed">
+            {taskInfo.description}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/garden/src/features/benchmarks/components/TaskVisualization.tsx
+++ b/garden/src/features/benchmarks/components/TaskVisualization.tsx
@@ -1,0 +1,158 @@
+import React, { useState, useEffect } from 'react';
+import { BenchmarksTable } from '../benchmarks-table/BenchmarksTable';
+import { ScatterPlot } from './ScatterPlot';
+import { RadarChartComponent } from './RadarChart';
+import { VisualizationSelector, type VisualizationType } from './VisualizationSelector';
+import { Button } from '@/components/shadcn/button';
+import { Columns2, Columns } from 'lucide-react';
+import { cn } from '@/utils/form.utils';
+
+interface TaskVisualizationProps {
+  data: Record<string, unknown>[];
+  benchmarkName?: string;
+}
+
+export const TaskVisualization: React.FC<TaskVisualizationProps> = ({
+  data,
+  benchmarkName
+}) => {
+  const [primaryVisualization, setPrimaryVisualization] = useState<VisualizationType>('scatter');
+  const [secondaryVisualization, setSecondaryVisualization] = useState<VisualizationType>('radar');
+  const [showDualView, setShowDualView] = useState(false);
+  const [isLargeScreen, setIsLargeScreen] = useState(false);
+  const [hasInitialized, setHasInitialized] = useState(false);
+
+  // Check screen size and set dual view default only on first load
+  useEffect(() => {
+    const checkScreenSize = () => {
+      const newIsLargeScreen = window.innerWidth >= 1280; // xl breakpoint
+      setIsLargeScreen(newIsLargeScreen);
+      
+      // Enable dual view by default on large screens, but only on first initialization
+      if (!hasInitialized && newIsLargeScreen) {
+        setShowDualView(true);
+        setHasInitialized(true);
+      }
+    };
+    
+    checkScreenSize();
+    window.addEventListener('resize', checkScreenSize);
+    return () => window.removeEventListener('resize', checkScreenSize);
+  }, [hasInitialized]);
+
+  // Auto-disable dual view on smaller screens (but don't auto-enable)
+  useEffect(() => {
+    if (!isLargeScreen && showDualView) {
+      setShowDualView(false);
+    }
+  }, [isLargeScreen, showDualView]);
+  
+  const renderVisualization = (type: VisualizationType, isCompact = false) => {
+    switch (type) {
+      case 'scatter':
+        return <ScatterPlot data={data} benchmarkName={benchmarkName} compact={isCompact} />;
+      case 'radar':
+        return <RadarChartComponent data={data} benchmarkName={benchmarkName} compact={isCompact} />;
+      case 'table':
+      default:
+        return <BenchmarksTable data={data} benchmarkName={benchmarkName} compact={isCompact} />;
+    }
+  };
+
+  // For single view mode, use primary visualization
+  const singleVisualization = showDualView ? primaryVisualization : primaryVisualization;
+  
+  return (
+    <div className="space-y-4">
+      {/* Controls */}
+      <div className="flex flex-col sm:flex-row gap-4 justify-between items-start sm:items-center">
+        {/* Dual View Toggle (only show on large screens) */}
+        {isLargeScreen && (
+          <div className="flex items-center gap-2">
+            <Button
+              variant={showDualView ? "default" : "outline"}
+              size="sm"
+              onClick={() => setShowDualView(!showDualView)}
+              className="flex items-center gap-1.5"
+            >
+              {showDualView ? <Columns2 className="h-4 w-4" /> : <Columns className="h-4 w-4" />}
+              <span className="hidden sm:inline">
+                {showDualView ? 'Dual View' : 'Single View'}
+              </span>
+            </Button>
+            {showDualView && (
+              <span className="text-xs text-muted-foreground">
+                Compare visualizations side-by-side
+              </span>
+            )}
+          </div>
+        )}
+        
+        {/* Visualization Selectors */}
+        <div className="flex flex-col sm:flex-row gap-2 items-start sm:items-center">
+          {showDualView && isLargeScreen ? (
+            <>
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-muted-foreground whitespace-nowrap">Left:</span>
+                <VisualizationSelector
+                  selectedType={primaryVisualization}
+                  onTypeChange={setPrimaryVisualization}
+                  className="scale-90"
+                />
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="text-sm text-muted-foreground whitespace-nowrap">Right:</span>
+                <VisualizationSelector
+                  selectedType={secondaryVisualization}
+                  onTypeChange={setSecondaryVisualization}
+                  className="scale-90"
+                />
+              </div>
+            </>
+          ) : (
+            <VisualizationSelector
+              selectedType={singleVisualization}
+              onTypeChange={setPrimaryVisualization}
+            />
+          )}
+        </div>
+      </div>
+      
+      {/* Visualization Content */}
+      <div className="min-h-[200px]">
+        {showDualView && isLargeScreen ? (
+          // Dual view layout
+          <div className="grid grid-cols-2 gap-6">
+            <div className="space-y-2">
+              <h4 className="text-sm font-medium text-muted-foreground text-center">
+                {primaryVisualization.charAt(0).toUpperCase() + primaryVisualization.slice(1)} View
+              </h4>
+              <div className="border rounded-lg p-3 h-[500px] flex flex-col">
+                {renderVisualization(primaryVisualization, true)}
+              </div>
+            </div>
+            
+            <div className="space-y-2">
+              <h4 className="text-sm font-medium text-muted-foreground text-center">
+                {secondaryVisualization.charAt(0).toUpperCase() + secondaryVisualization.slice(1)} View
+              </h4>
+              <div className="border rounded-lg p-3 h-[500px] flex flex-col">
+                {renderVisualization(secondaryVisualization, true)}
+              </div>
+            </div>
+          </div>
+        ) : (
+          // Single view layout
+          renderVisualization(singleVisualization)
+        )}
+      </div>
+      
+      {/* Helpful hint for smaller screens */}
+      {!isLargeScreen && (
+        <div className="text-xs text-muted-foreground text-center">
+          💡 Use a larger screen (1280px+) to enable dual-view mode
+        </div>
+      )}
+    </div>
+  );
+};

--- a/garden/src/features/benchmarks/components/VisualizationSelector.tsx
+++ b/garden/src/features/benchmarks/components/VisualizationSelector.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import { BarChart3, ScatterChart as Scatter, RadarIcon as Radar, Table } from 'lucide-react';
+import { Button } from '@/components/shadcn/button';
+import { cn } from '@/utils/form.utils';
+
+export type VisualizationType = 'table' | 'scatter' | 'radar';
+
+interface VisualizationSelectorProps {
+  selectedType: VisualizationType;
+  onTypeChange: (type: VisualizationType) => void;
+  className?: string;
+}
+
+const visualizationOptions = [
+  {
+    type: 'table' as const,
+    label: 'Table',
+    icon: Table,
+    description: 'Detailed data table view'
+  },
+  {
+    type: 'scatter' as const,
+    label: 'Scatter Plot',
+    icon: Scatter,
+    description: 'Compare two metrics'
+  },
+  {
+    type: 'radar' as const,
+    label: 'Radar Chart',
+    icon: Radar,
+    description: 'Multi-metric comparison'
+  }
+];
+
+export const VisualizationSelector: React.FC<VisualizationSelectorProps> = ({
+  selectedType,
+  onTypeChange,
+  className
+}) => {
+  return (
+    <div className={cn("flex items-center gap-1 p-1 bg-muted rounded-lg", className)}>
+      {visualizationOptions.map((option) => {
+        const Icon = option.icon;
+        const isSelected = selectedType === option.type;
+        
+        return (
+          <Button
+            key={option.type}
+            variant={isSelected ? "default" : "ghost"}
+            size="sm"
+            onClick={() => onTypeChange(option.type)}
+            className={cn(
+              "flex items-center gap-1.5 transition-all",
+              isSelected 
+                ? "bg-background text-foreground shadow-sm" 
+                : "text-muted-foreground hover:text-foreground"
+            )}
+            title={option.description}
+          >
+            <Icon className="h-4 w-4" />
+            <span className="hidden sm:inline">{option.label}</span>
+          </Button>
+        );
+      })}
+    </div>
+  );
+};

--- a/garden/src/features/benchmarks/utils/matbench.ts
+++ b/garden/src/features/benchmarks/utils/matbench.ts
@@ -1,0 +1,304 @@
+// MatBench Discovery specific metadata and utilities
+// Hardcoded for now until backend provides rich benchmark metadata
+
+export interface MetricInfo {
+  name: string;
+  description: string;
+  betterIs: 'higher' | 'lower';
+  format: 'decimal' | 'percentage' | 'integer';
+  unit?: string;
+  decimalPlaces?: number;
+  isPrimaryMetric?: boolean;
+}
+
+export interface BenchmarkInfo {
+  id: string;
+  name: string;
+  description: string;
+  detailedDescription: string;
+  purpose: string;
+  learnMoreUrl?: string;
+}
+
+// MatBench Discovery metric definitions
+export const MATBENCH_METRICS: Record<string, MetricInfo> = {
+  // Lowercase versions (for mock data)
+  f1_score: {
+    name: 'F1 Score',
+    description: 'Harmonic mean of precision and recall for stability prediction accuracy',
+    betterIs: 'higher',
+    format: 'decimal',
+    decimalPlaces: 3,
+    isPrimaryMetric: true,
+  },
+  daf: {
+    name: 'Discovery Acceleration Factor',
+    description: 'How many times faster this model finds stable materials vs random search',
+    betterIs: 'higher',
+    format: 'decimal',
+    decimalPlaces: 2,
+    unit: 'x faster',
+    isPrimaryMetric: true,
+  },
+  accuracy: {
+    name: 'Accuracy',
+    description: 'Percentage of correct stability predictions',
+    betterIs: 'higher',
+    format: 'percentage',
+    decimalPlaces: 1,
+  },
+  precision: {
+    name: 'Precision',
+    description: 'Of predicted stable materials, what percentage are actually stable',
+    betterIs: 'higher',
+    format: 'decimal',
+    decimalPlaces: 3,
+  },
+  recall: {
+    name: 'Recall',
+    description: 'Of all stable materials, what percentage did the model find',
+    betterIs: 'higher',
+    format: 'decimal',
+    decimalPlaces: 3,
+  },
+  // Uppercase versions (for real backend data)
+  'F1': {
+    name: 'F1 Score',
+    description: 'Harmonic mean of precision and recall for stability prediction accuracy',
+    betterIs: 'higher',
+    format: 'decimal',
+    decimalPlaces: 3,
+    isPrimaryMetric: true,
+  },
+  'DAF': {
+    name: 'Discovery Acceleration Factor',
+    description: 'How many times faster this model finds stable materials vs random search',
+    betterIs: 'higher',
+    format: 'decimal',
+    decimalPlaces: 2,
+    unit: 'x faster',
+    isPrimaryMetric: true,
+  },
+  'Accuracy': {
+    name: 'Accuracy',
+    description: 'Percentage of correct stability predictions',
+    betterIs: 'higher',
+    format: 'decimal',
+    decimalPlaces: 3,
+  },
+  'Precision': {
+    name: 'Precision',
+    description: 'Of predicted stable materials, what percentage are actually stable',
+    betterIs: 'higher',
+    format: 'decimal',
+    decimalPlaces: 3,
+  },
+  'Recall': {
+    name: 'Recall',
+    description: 'Of all stable materials, what percentage did the model find',
+    betterIs: 'higher',
+    format: 'decimal',
+    decimalPlaces: 3,
+  },
+  'MAE': {
+    name: 'Mean Absolute Error',
+    description: 'Average absolute difference between predicted and actual values',
+    betterIs: 'lower',
+    format: 'decimal',
+    decimalPlaces: 4,
+  },
+  'RMSE': {
+    name: 'Root Mean Square Error',
+    description: 'Square root of the average squared differences between predicted and actual values',
+    betterIs: 'lower',
+    format: 'decimal',
+    decimalPlaces: 4,
+  },
+  'R2': {
+    name: 'R² Score',
+    description: 'Coefficient of determination - how well the model explains variance in the data',
+    betterIs: 'higher',
+    format: 'decimal',
+    decimalPlaces: 3,
+  },
+  'TPR': {
+    name: 'True Positive Rate',
+    description: 'Sensitivity - proportion of actual positives correctly identified',
+    betterIs: 'higher',
+    format: 'decimal',
+    decimalPlaces: 3,
+  },
+  'FPR': {
+    name: 'False Positive Rate',
+    description: 'Proportion of actual negatives incorrectly identified as positive',
+    betterIs: 'lower',
+    format: 'decimal',
+    decimalPlaces: 3,
+  },
+  'TNR': {
+    name: 'True Negative Rate',
+    description: 'Specificity - proportion of actual negatives correctly identified',
+    betterIs: 'higher',
+    format: 'decimal',
+    decimalPlaces: 3,
+  },
+  'FNR': {
+    name: 'False Negative Rate',
+    description: 'Proportion of actual positives incorrectly identified as negative',
+    betterIs: 'lower',
+    format: 'decimal',
+    decimalPlaces: 3,
+  },
+  // Legacy lowercase for compatibility
+  rmsd: {
+    name: 'RMSD',
+    description: 'Root Mean Square Displacement for structure optimization accuracy',
+    betterIs: 'lower',
+    format: 'decimal',
+    decimalPlaces: 3,
+    unit: 'Å',
+  },
+  latency_ms: {
+    name: 'Latency',
+    description: 'Average time to make a prediction',
+    betterIs: 'lower',
+    format: 'integer',
+    unit: 'ms',
+  },
+  thermal_conductivity_mae: {
+    name: 'Thermal Conductivity MAE',
+    description: 'Mean absolute error for thermal conductivity predictions',
+    betterIs: 'lower',
+    format: 'decimal',
+    decimalPlaces: 3,
+    unit: 'W/mK',
+  },
+};
+
+// MatBench Discovery benchmark definitions
+export const MATBENCH_BENCHMARKS: Record<string, BenchmarkInfo> = {
+  'matbench-discovery': {
+    id: 'matbench-discovery',
+    name: 'MatBench Discovery',
+    description: 'Evaluates ML models for predicting stable inorganic crystal structures',
+    detailedDescription: 'MatBench Discovery simulates high-throughput discovery of new stable inorganic crystals. Models are evaluated on their ability to predict which crystal structures will be thermodynamically stable, helping accelerate materials discovery.',
+    purpose: 'Find stable materials faster than traditional methods',
+    learnMoreUrl: 'https://matbench-discovery.materialsproject.org/',
+  },
+};
+
+// Get performance tier based on F1 score and DAF
+export const getPerformanceTier = (f1Score?: number, daf?: number): {
+  tier: 'excellent' | 'good' | 'fair' | 'poor';
+  description: string;
+  color: string;
+} => {
+  const f1 = f1Score || 0;
+  const acceleration = daf || 1;
+
+  if (f1 >= 0.85 && acceleration >= 4) {
+    return {
+      tier: 'excellent',
+      description: 'Excellent for production use',
+      color: 'text-green-700 bg-green-50 border-green-200',
+    };
+  } else if (f1 >= 0.7 && acceleration >= 2.5) {
+    return {
+      tier: 'good',
+      description: 'Good for most applications',
+      color: 'text-blue-700 bg-blue-50 border-blue-200',
+    };
+  } else if (f1 >= 0.5 && acceleration >= 1.5) {
+    return {
+      tier: 'fair',
+      description: 'Fair performance, consider for specific use cases',
+      color: 'text-yellow-700 bg-yellow-50 border-yellow-200',
+    };
+  } else {
+    return {
+      tier: 'poor',
+      description: 'Poor performance, needs improvement',
+      color: 'text-red-700 bg-red-50 border-red-200',
+    };
+  }
+};
+
+// Format metric value for display
+export const formatMetricValue = (value: unknown, metricKey: string): string => {
+  const metric = MATBENCH_METRICS[metricKey];
+  if (!metric) return String(value);
+
+  let numValue: number;
+  
+  // Handle complex objects with parsedValue
+  if (value && typeof value === 'object' && 'parsedValue' in value) {
+    numValue = (value as { parsedValue: number }).parsedValue;
+  } else if (typeof value === 'number') {
+    numValue = value;
+  } else {
+    return String(value);
+  }
+
+  switch (metric.format) {
+    case 'percentage':
+      return `${(numValue * 100).toFixed(metric.decimalPlaces || 1)}%`;
+    case 'integer':
+      return numValue.toFixed(0);
+    case 'decimal':
+      return numValue.toFixed(metric.decimalPlaces || 3);
+    default:
+      return numValue.toFixed(3);
+  }
+};
+
+// Get practical impact message for a model's performance
+export const getPracticalImpact = (f1Score?: number, daf?: number): string => {
+  const f1 = f1Score || 0;
+  const acceleration = daf || 1;
+
+  if (acceleration >= 5) {
+    return `Could save years of lab work by screening materials ${acceleration.toFixed(1)}x faster`;
+  } else if (acceleration >= 3) {
+    return `Significantly accelerates materials discovery (${acceleration.toFixed(1)}x faster)`;
+  } else if (acceleration >= 2) {
+    return `Modest acceleration for materials screening (${acceleration.toFixed(1)}x faster)`;
+  } else {
+    return `Limited acceleration over random search (${acceleration.toFixed(1)}x)`;
+  }
+};
+
+// Check if a benchmark is MatBench Discovery related
+export const isMatBenchDiscovery = (benchmarkName: string): boolean => {
+  const name = benchmarkName.toLowerCase();
+  return name.includes('matbench') || 
+         name.includes('discovery') ||
+         name.includes('materials') ||
+         name.includes('mat-bench') ||
+         name.includes('material') ||
+         // Add more specific patterns that might match your actual benchmark names
+         name.includes('crystal') ||
+         name.includes('stability') ||
+         // Fallback: if it has typical matbench metrics, treat it as matbench
+         false; // We'll add a data-based detection as backup
+};
+
+// Check if data contains MatBench-style metrics (fallback detection)
+export const hasMatBenchMetrics = (data: Record<string, unknown>[]): boolean => {
+  if (!data.length) return false;
+  
+  // Check if any of the data contains typical MatBench metrics (both cases)
+  const matbenchMetricKeys = [
+    'f1_score', 'daf', 'rmsd', 'thermal_conductivity_mae', // lowercase
+    'F1', 'DAF', 'MAE', 'RMSE', 'Precision', 'Recall', 'Accuracy' // uppercase
+  ];
+  const dataKeys = new Set<string>();
+  
+  data.forEach(item => {
+    Object.keys(item).forEach(key => dataKeys.add(key));
+  });
+  
+  // If we find 2 or more MatBench metrics, it's likely MatBench data
+  const foundMetrics = matbenchMetricKeys.filter(metric => dataKeys.has(metric));
+  
+  return foundMetrics.length >= 2;
+};


### PR DESCRIPTION
Resolves: #356 #361 #359 

*Note for the reviewer* - My apologies! This got a bit bigger than I originally intended! I saw that shadcn supports [charts](https://ui.shadcn.com/charts/area) and got a little carried away. A decent amount of the volume is due to hard-coded info about matbench and the metrics matbench discovery returns.

This PR updates the matbench page to (hopefully) be more in-line with what people looking for MLIP benchmarks will want to see. Namely, more data visualizations!

*Scatter Plot*
There is now a scatter plot that lets users select which metrics are on each axis. Clicking a data point takes you to the function page:

https://github.com/user-attachments/assets/2906722a-aa3e-4632-85e0-f4a432c2acaa

*Radar Chart*
A new radar chart that lets users select which metrics to include. Clicking a function name in the legend takes you to the function page:

https://github.com/user-attachments/assets/efeee3d8-4f0b-4e76-a5db-76893f9b0b82

*Table*
The table hasn't changed much.

*Charts can be viewed side-by-side on large screens*

https://github.com/user-attachments/assets/f4b760bb-049b-4773-9b47-3fcdef81bf58

*Page organization*
The data visualizations are now front and center! Details about the benchmark and metrics are below the charts. There are links to the matbench website and the matbench paper on arxiv.


https://github.com/user-attachments/assets/50f1d483-28ef-40c0-b61d-926115f32c6e


