### PR TITLE
Optimize build chunking, lazy loading of components

### DIFF
--- a/garden/src/app/router.tsx
+++ b/garden/src/app/router.tsx
@@ -1,79 +1,84 @@
-import React from "react";
+import React, { Suspense } from "react";
+import { lazy } from "react";
 import { Navigate, Outlet, Routes, Route, useLocation, useNavigate } from "react-router-dom";
 
 import { LoadingOverlay } from "@/components/LoadingOverlay";
 import NotFoundPage from "@/components/NotFoundPage";
 import RootLayout from "@/components/Layout";
-import SuperuserRoute from "@/components/SuperuserRoute";
 
-import EntrypointTombstonePage from "@/components/EntrypointTombstonePage";
-import CreateGardenPage from "@/features/gardens/components/create/CreateGardenPage";
-import GardenPage from "@/features/gardens/components/GardenPage";
-import HomePage from "@/components/HomePage";
-import LoginPage from "@/features/auth/components/LoginPage";
-import ModalFunctionPage from "@/features/modal/components/ModalFunctionPage";
-import SearchPage from "@/features/search/components/SearchPage";
-import TeamsPage from "@/features/team/components/TeamsPage";
-import UserProfilePage from "@/features/users/components/UserProfilePage";
 import { useGlobusAuth } from "@globus/react-auth-context";
-import ModelDeploymentPage from "@/features/model-deployments/ModelDeploymentPage";
-import { CreateModelDeploymentPage } from "@/features/model-deployments/CreateModelDeploymentPage";
-import ModalAppUploadPage from "@/features/modal/components/ModalAppUploadPage";
-import { BenchmarksPage } from "@/features/benchmarks/BenchmarksPage";
-import MetricsDashboard from "@/features/metrics/components/MetricsDashboard";
+
+const EntrypointTombstonePage = lazy(() => import("@/components/EntrypointTombstonePage"));
+const CreateGardenPage = lazy(() => import("@/features/gardens/components/create/CreateGardenPage"));
+const GardenPage = lazy(() => import("@/features/gardens/components/GardenPage"));
+const HomePage = lazy(() => import("@/components/HomePage"));
+const LoginPage = lazy(() => import("@/features/auth/components/LoginPage"));
+const ModalFunctionPage = lazy(() => import("@/features/modal/components/ModalFunctionPage"));
+const SearchPage = lazy(() => import("@/features/search/components/SearchPage"));
+const TeamsPage = lazy(() => import("@/features/team/components/TeamsPage"));
+const UserProfilePage = lazy(() => import("@/features/users/components/UserProfilePage"));
+const ModelDeploymentPage = lazy(() => import("@/features/model-deployments/ModelDeploymentPage"));
+const CreateModelDeploymentPage = lazy(() => import("@/features/model-deployments/CreateModelDeploymentPage"));
+const ModalAppUploadPage = lazy(() => import("@/features/modal/components/ModalAppUploadPage"));
+const BenchmarksPage = lazy(() => import("@/features/benchmarks/BenchmarksPage"));
+
+const WrappedLazyComponent = ({ child }: { child: React.ReactNode }) => {
+  return (
+    <Suspense fallback={<LoadingOverlay />}>
+      {child}
+    </Suspense>
+  )
+}
 
 const Router: React.FC = () => {
   const navigate = useNavigate();
   return (
     <Routes>
       <Route element={<RootLayout />}>
-        <Route index element={<HomePage />} />
-        <Route path="search" element={<SearchPage />} />
+        <Route index element={<WrappedLazyComponent child={<HomePage />} />} />
+        <Route path="search" element={<WrappedLazyComponent child={<SearchPage />} />} />
 
         {/* Garden Routes */}
         <Route path="garden">
           <Route element={<PrivateRoutes />}>
-            <Route path="create" element={<CreateGardenPage />} />
+            <Route path="create" element={<WrappedLazyComponent child={<CreateGardenPage />} />} />
           </Route>
-          <Route path=":doi" element={<GardenPage />} />
-          <Route path=":doi/modal-functions/:id" element={<ModalFunctionPage />} />
+          <Route path=":doi" element={<WrappedLazyComponent child={<GardenPage />} />} />
+          <Route path=":doi/modal-functions/:id" element={<WrappedLazyComponent child={<ModalFunctionPage />} />} />
         </Route>
 
         {/* Entrypoint Routes - All archived */}
-        <Route path="entrypoint/*" element={<EntrypointTombstonePage />} />
+        <Route path="entrypoint/*" element={<WrappedLazyComponent child={<EntrypointTombstonePage />} />} />
 
         {/* Modal Routes */}
         <Route path="modal-functions">
-          <Route path=":id" element={<ModalFunctionPage />} />
+          <Route path=":id" element={<WrappedLazyComponent child={<ModalFunctionPage />} />} />
         </Route>
 
         <Route element={<PrivateRoutes />}>
           <Route path="modal-app/create" element={
-            <CreateModelDeploymentPage
-              form={<ModalAppUploadPage onSuccess={(id: number) => { navigate(`/model-deployments/${id}`) }} />}
-              onSuccess={(id: number) => { navigate(`/model-deployments/${id}`) }}
-            />
+            <WrappedLazyComponent child={
+              <CreateModelDeploymentPage
+                form={<ModalAppUploadPage onSuccess={(id: number) => { navigate(`/model-deployments/${id}`) }} />}
+                onSuccess={(id: number) => { navigate(`/model-deployments/${id}`) }}
+              />
+            } />
           } />
         </Route>
 
         {/* Model Deployment Routes */}
         <Route element={<PrivateRoutes />}>
-          <Route path="model-deployments/:id" element={<ModelDeploymentPage />} />
-        </Route>
-
-        {/* Superuser Routes */}
-        <Route element={<SuperuserRoute />}>
-          <Route path="metrics" element={<MetricsDashboard />} />
+          <Route path="model-deployments/:id" element={<WrappedLazyComponent child={<ModelDeploymentPage />} />} />
         </Route>
 
         {/* Misc Routes */}
-        <Route path="team" element={<TeamsPage />} />
-        <Route path="login" element={<LoginPage />} />
-        <Route path="user" element={<UserProfilePage />} />
-        <Route path="benchmarks" element={<BenchmarksPage />} />
+        <Route path="team" element={<WrappedLazyComponent child={<TeamsPage />} />} />
+        <Route path="login" element={<WrappedLazyComponent child={<LoginPage />} />} />
+        <Route path="user" element={<WrappedLazyComponent child={<UserProfilePage />} />} />
+        <Route path="benchmarks" element={<WrappedLazyComponent child={<BenchmarksPage />} />} />
       </Route>
       <Route path="*" element={<NotFoundPage />} />
-    </Routes>
+    </Routes >
   );
 };
 

--- a/garden/src/features/benchmarks/BenchmarksPage.tsx
+++ b/garden/src/features/benchmarks/BenchmarksPage.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useState, useMemo, useEffect } from "react";
 import {
     Card,
@@ -113,9 +114,9 @@ export const BenchmarksPage = () => {
     // Collect metrics from all tasks for the selected benchmark
     const allBenchmarkMetrics = useMemo(() => {
         if (!selectedBenchmark?.tasks) return new Set<string>();
-        
+
         const metrics = new Set<string>();
-        
+
         // Always show common MatBench metrics that we have definitions for
         if (isMatBenchDiscovery(selectedBenchmark.name) || showMockData) {
             // Add common MatBench metrics (prefer uppercase versions for display)
@@ -125,7 +126,7 @@ export const BenchmarksPage = () => {
                 }
             });
         }
-        
+
         // If showing mock data, add all mock metrics
         if (showMockData) {
             Object.keys(mockBenchmarkResults[0]).forEach(key => {
@@ -134,7 +135,7 @@ export const BenchmarksPage = () => {
                 }
             });
         }
-        
+
         return metrics;
     }, [selectedBenchmark, showMockData]);
 
@@ -216,7 +217,7 @@ export const BenchmarksPage = () => {
 
                             {/* Task Description - Context After Engagement */}
                             {displayResults.length > 0 && (
-                                <TaskDescription 
+                                <TaskDescription
                                     taskName={task.function.function_name}
                                     functionName={task.function.title || task.function.function_name}
                                 />
@@ -383,7 +384,7 @@ export const BenchmarksPage = () => {
                                     <ChevronDown className="h-4 w-4 animate-bounce" />
                                     <span>Scroll down for benchmark details and metric explanations</span>
                                 </div>
-                                
+
                                 {/* Quick Metrics Guide */}
                                 <Button
                                     variant="ghost"
@@ -421,7 +422,7 @@ export const BenchmarksPage = () => {
                                         <Info className="h-5 w-5 text-muted-foreground" />
                                         <h2 className="text-xl font-semibold">Understanding the Metrics</h2>
                                     </div>
-                                    
+
                                     {(() => {
                                         const metricsArray = Array.from(allBenchmarkMetrics)
                                             .map(key => ({ key, info: MATBENCH_METRICS[key] }))
@@ -432,7 +433,7 @@ export const BenchmarksPage = () => {
                                                 if (!a.info?.isPrimaryMetric && b.info?.isPrimaryMetric) return 1;
                                                 return a.info?.name.localeCompare(b.info?.name) || 0;
                                             });
-                                        
+
                                         return metricsArray.length > 0 ? (
                                             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                                                 {metricsArray.map(({ key, info }) => (
@@ -539,3 +540,5 @@ export const BenchmarksPage = () => {
         </div>
     );
 }
+
+export default BenchmarksPage;

--- a/garden/src/features/gardens/components/GardenBox.tsx
+++ b/garden/src/features/gardens/components/GardenBox.tsx
@@ -1,4 +1,5 @@
-import { Card, CardContent, CardHeader, CardTitle, CardFooter, MarkdownCardContent } from "../../../components/shadcn/card";
+import React from "react";
+import { Card, CardHeader, CardTitle, CardFooter, MarkdownCardContent } from "../../../components/shadcn/card";
 import { useNavigate } from "react-router-dom";
 import { TagIcon } from "lucide-react";
 import { Garden } from "@/types";
@@ -9,10 +10,15 @@ const GardenBox = ({ garden, allowEdits }: { garden: Garden, allowEdits: boolean
   const navigate = useNavigate();
 
   const { data: currUserInfo } = useGetUserInfo();
-  const { data: userGardens } = useGetGardens({ owner_uuid: currUserInfo?.identity_id });
+
+  let userGardens;
+  if (allowEdits) {
+    const { data: gardens } = useGetGardens({ owner_uuid: currUserInfo?.identity_id });
+    userGardens = gardens;
+  }
 
   const canEditGarden =
-    !!garden && !!userGardens && userGardens.some((userGarden) => userGarden.doi === garden.doi);
+    !!garden && !!userGardens && userGardens.some((userGarden: Garden) => userGarden.doi === garden.doi);
 
   const { title, description, doi, tags } = garden;
 
@@ -34,7 +40,7 @@ const GardenBox = ({ garden, allowEdits }: { garden: Garden, allowEdits: boolean
         <CardHeader className="">
           <CardTitle className="text-ellipsis text-xl">{title}</CardTitle>
         </CardHeader>
-        <MarkdownCardContent 
+        <MarkdownCardContent
           className="flex-grow overflow-hidden"
           content={description || ""}
         />

--- a/garden/src/features/model-deployments/CreateModelDeploymentPage.tsx
+++ b/garden/src/features/model-deployments/CreateModelDeploymentPage.tsx
@@ -36,3 +36,5 @@ export const CreateModelDeploymentPage = ({
         </div>
     );
 };
+
+export default CreateModelDeploymentPage;


### PR DESCRIPTION
Part one of #370 

This PR achieves a significant performance increase loading the home page of the website. 

This is accomplished by utilizing react's lazy component loading in the router definiton, which vite picks up on and splits the large js bundle we are serving into many smaller chunks that are not loaded until the first time they are rendered

Another large chunk of data was being loaded by the `GardenBox` component hitting the `/gardens` route, pulling down every garden in the database. I added a check to the `GardenBox` that only fetches gardens if the logged in user can edit the garden being rendered in the box. This could use a refactor since we probably don't need to fetch all gardens inside this component anyway, but for now this check defers loading gardens until we really need them. This lets us render the hard-coded gardens on the homepage without fetching any data we don't need.

**Before**

A production build generates a single `index-*.js` that comes in over 2MB:

<img width="854" alt="image" src="https://github.com/user-attachments/assets/8eda52d4-0cae-46a1-87d3-909922a40dcf" />

Loading the home page downloads over 5MB of data taking ~500ms on my local setup.
<img width="854" alt="image" src="https://github.com/user-attachments/assets/9ef51bcf-87c6-4057-983d-998f478d209e" />

**After**
Many smaller files are generated (truncated becuase there are too many to show), none of which are over the 500KB size vite warns us about.

<img width="854" alt="image" src="https://github.com/user-attachments/assets/65929c1a-561e-4464-b1c5-5e315dd2929d" />

We are only loading ~1.5MB when hitting the home page! That's about a 75% reduction in data transferred!

<img width="854" alt="image" src="https://github.com/user-attachments/assets/67a899ef-43d8-40ac-b266-d9bd9268a640" />

# Testing
Manually

