### PR TITLE
Improve caching strategy

### DIFF
--- a/garden/src/app/app.tsx
+++ b/garden/src/app/app.tsx
@@ -1,19 +1,23 @@
 import React from "react";
 import { RouterProvider } from "react-router-dom";
 import { createHashRouter } from "react-router-dom";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 
 import Router from "./router";
 
 const App = () => {
   return (
-    <RouterProvider
-      router={createHashRouter([
-        {
-          path: "*",
-          element: <Router />,
-        },
-      ])}
-    />
+    <>
+      <RouterProvider
+        router={createHashRouter([
+          {
+            path: "*",
+            element: <Router />,
+          },
+        ])}
+      />
+      <ReactQueryDevtools initialIsOpen={false}></ReactQueryDevtools>
+    </>
   );
 };
 

--- a/garden/src/features/gardens/api/useCreateGarden.ts
+++ b/garden/src/features/gardens/api/useCreateGarden.ts
@@ -5,9 +5,7 @@ import { GardenCreateRequest } from "@/types";
 import { AxiosError } from "axios";
 import { ApiError } from "../utils/garden.utils";
 
-const createGarden = async (
-  garden: GardenCreateRequest,
-): Promise<Garden> => {
+const createGarden = async (garden: GardenCreateRequest): Promise<Garden> => {
   try {
     const response = await axios.post(`/gardens`, garden);
     return response.data;
@@ -24,10 +22,7 @@ export const useCreateGarden = () => {
   return useMutation<Garden, ApiError, GardenCreateRequest>({
     mutationFn: createGarden,
     onSuccess: (garden) => {
-      queryClient.invalidateQueries({ queryKey: ["garden"] });
-      queryClient.invalidateQueries({ queryKey: ["gardens"] });
-      // Set the specific garden data in cache
-      queryClient.setQueryData(["garden", garden.doi], garden);
+      queryClient.setQueryData(["gardens", garden.doi], garden);
     },
   });
 };

--- a/garden/src/features/gardens/api/useGetGarden.ts
+++ b/garden/src/features/gardens/api/useGetGarden.ts
@@ -1,6 +1,6 @@
 import { Garden } from "@/types";
 import axios from "@/lib/axios";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 const getGarden = async (doi: string): Promise<Garden> => {
   try {
@@ -12,8 +12,15 @@ const getGarden = async (doi: string): Promise<Garden> => {
 };
 
 export const useGetGarden = (doi: string) => {
+  const queryClient = useQueryClient();
   return useQuery<Garden, Error>({
     queryKey: ["gardens", doi],
     queryFn: () => getGarden(doi),
+    select: (garden) => {
+      garden.modal_functions?.forEach((fn) => {
+        queryClient.setQueryData(["modalFunctions", fn.id], fn);
+      });
+      return garden;
+    },
   });
 };

--- a/garden/src/features/gardens/api/useGetGarden.ts
+++ b/garden/src/features/gardens/api/useGetGarden.ts
@@ -13,7 +13,7 @@ const getGarden = async (doi: string): Promise<Garden> => {
 
 export const useGetGarden = (doi: string) => {
   return useQuery<Garden, Error>({
-    queryKey: ["garden", doi],
+    queryKey: ["gardens", doi],
     queryFn: () => getGarden(doi),
   });
 };

--- a/garden/src/features/gardens/api/useGetGardens.ts
+++ b/garden/src/features/gardens/api/useGetGardens.ts
@@ -1,6 +1,6 @@
 import { Garden } from "@/types";
 import axios from "@/lib/axios";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 interface GetGardensParams {
   doi?: string;
@@ -23,8 +23,15 @@ const getGardens = async (params: GetGardensParams): Promise<Garden[]> => {
 };
 
 export const useGetGardens = (params: GetGardensParams) => {
+  const queryClient = useQueryClient();
   return useQuery<Garden[], Error>({
     queryKey: ["gardens", params],
     queryFn: () => getGardens(params),
+    select: (gardens) => {
+      gardens.forEach((garden) => {
+        queryClient.setQueryData(["gardens", garden.doi], garden);
+      });
+      return gardens;
+    },
   });
 };

--- a/garden/src/features/gardens/api/useGetGardens.ts
+++ b/garden/src/features/gardens/api/useGetGardens.ts
@@ -31,6 +31,14 @@ export const useGetGardens = (params: GetGardensParams) => {
       gardens.forEach((garden) => {
         queryClient.setQueryData(["gardens", garden.doi], garden);
       });
+      // gardens currently contain their associated function metadata,
+      // cache them so we can avoid sending requests for functions
+      // we have already seen.
+      gardens.forEach((garden) => {
+        garden.modal_functions?.forEach((fn) => {
+          queryClient.setQueryData(["modalFunctions", fn.id], fn);
+        });
+      });
       return gardens;
     },
   });

--- a/garden/src/features/gardens/api/usePatchGarden.ts
+++ b/garden/src/features/gardens/api/usePatchGarden.ts
@@ -24,10 +24,10 @@ export const usePatchGarden = () => {
     mutationFn: patchGarden,
     onMutate: async ({ doi, garden }) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: ["garden", doi] });
+      await queryClient.cancelQueries({ queryKey: ["gardens", doi] });
 
       // Snapshot the previous value
-      const previousGarden = queryClient.getQueryData<Garden>(["garden", doi]);
+      const previousGarden = queryClient.getQueryData<Garden>(["gardens", doi]);
 
       // Optimistically update to the new value
       if (previousGarden) {
@@ -50,29 +50,27 @@ export const usePatchGarden = () => {
           tags: garden.tags ?? previousGarden.tags ?? [],
         };
 
-        queryClient.setQueryData<Garden>(["garden", doi], updatedGarden);
+        queryClient.setQueryData<Garden>(["gardens", doi], updatedGarden);
       }
 
       return { previousGarden };
     },
     onError: (err, { doi }, context) => {
-      console.error(err.message)
+      console.error(err.message);
       if (err.message.includes("409")) {
-        toast.error(`Failed to update garden: Garden must have at least one Model Author or one Gardener`);
+        toast.error(
+          `Failed to update garden: Garden must have at least one Model Author or one Gardener`,
+        );
       } else {
-        toast.error("Updating garden metadata failed! Try again, and if it fails contact the Garden team.")
+        toast.error(
+          "Updating garden metadata failed! Try again, and if it fails contact the Garden team.",
+        );
       }
-      queryClient.setQueryData(["garden", doi], context?.previousGarden);
+      queryClient.setQueryData(["gardens", doi], context?.previousGarden);
     },
     onSuccess: (data, input) => {
       // Update the cache with the new data
-      queryClient.setQueryData(["garden", data.doi], data);
-
-      // Invalidate related queries
-      queryClient.invalidateQueries({ queryKey: ["garden", data.doi] });
-      queryClient.invalidateQueries({ queryKey: ["gardens"] });
-      queryClient.invalidateQueries({ queryKey: ["search"] });
-
+      queryClient.setQueryData(["gardens", data.doi], data);
       // Use custom success message if provided, otherwise use default
       toast.success(input.successMessage || "Garden updated successfully!");
     },

--- a/garden/src/features/gardens/api/useSaveGarden.ts
+++ b/garden/src/features/gardens/api/useSaveGarden.ts
@@ -26,7 +26,7 @@ export const useSaveGarden = (doi: string) => {
   const uuid = auth?.authorization?.user?.sub;
   const queryClient = useQueryClient();
   return useMutation<Garden, Error>({
-    mutationKey: ["garden", "save", doi],
+    mutationKey: ["gardens", "save", doi],
     mutationFn: () => saveGarden({ doi, uuid }),
     onSuccess: () => {
       queryClient.setQueryData(["user", "me"], (oldData: any) => {

--- a/garden/src/features/gardens/api/useUnsaveGarden.ts
+++ b/garden/src/features/gardens/api/useUnsaveGarden.ts
@@ -26,7 +26,7 @@ export const useUnsaveGarden = (doi: string) => {
   const uuid = auth?.authorization?.user?.sub;
   const queryClient = useQueryClient();
   return useMutation({
-    mutationKey: ["garden", "unsave", doi],
+    mutationKey: ["gardens", "unsave", doi],
     mutationFn: () => unsaveGarden({ doi, uuid }),
     onSuccess: () => {
       queryClient.setQueryData(["user", "me"], (oldData: any) => {

--- a/garden/src/features/gardens/api/useUpdateGarden.ts
+++ b/garden/src/features/gardens/api/useUpdateGarden.ts
@@ -14,7 +14,7 @@ const updateGarden = async (variables: any): Promise<Garden> => {
 
 export const useUpdateGarden = (doi: string) => {
   return useMutation<Garden, Error>({
-    mutationKey: ["garden", doi],
+    mutationKey: ["gardens", doi],
     onMutate: updateGarden,
     onError: (error, variables, context) => {
       console.log("onError", error, variables, context);

--- a/garden/src/features/gardens/components/GardenDropdownOptions.tsx
+++ b/garden/src/features/gardens/components/GardenDropdownOptions.tsx
@@ -33,14 +33,23 @@ import { usePatchGarden } from "../api/usePatchGarden";
 
 import { SUPER_USERS } from "@/utils/utils";
 
-const GardenDropdownMenu = ({ garden, setIsPublishGardenModalOpen }: { garden: Garden, setIsPublishGardenModalOpen: (open: boolean) => void }) => {
+const GardenDropdownMenu = ({
+  garden,
+  setIsPublishGardenModalOpen,
+}: {
+  garden: Garden;
+  setIsPublishGardenModalOpen: (open: boolean) => void;
+}) => {
   const auth = useGlobusAuth();
 
   const [isDeleteGardenModalOpen, setIsDeleteGardenModalOpen] = React.useState(false);
   const [isArchiveGardenModalOpen, setIsArchiveGardenModalOpen] = React.useState(false);
 
   const isSuperUser = SUPER_USERS.includes(auth.authorization?.user?.sub);
-  if ((!auth.isAuthenticated || garden.owner_identity_id !== auth.authorization?.user?.sub) && !isSuperUser) {
+  if (
+    (!auth.isAuthenticated || garden.owner_identity_id !== auth.authorization?.user?.sub) &&
+    !isSuperUser
+  ) {
     return null;
   }
 
@@ -128,12 +137,12 @@ export const PublishGardenModal = ({
         garden: {
           doi_is_draft: false,
         },
-        successMessage: "Garden DOI registered successfully!"
+        successMessage: "Garden DOI registered successfully!",
       });
       setIsOpen(false);
       setInput("");
-      queryClient.invalidateQueries({ queryKey: ["search"] });
-      queryClient.setQueryData(["garden", doi], (oldData: Garden) => {
+      queryClient.invalidateQueries({ queryKey: ["gardens"] });
+      queryClient.setQueryData(["gardens", doi], (oldData: Garden) => {
         return { ...oldData, doi_is_draft: false, is_archived: false };
       });
     } catch (error) {
@@ -218,8 +227,8 @@ const DeleteGardenModal = ({
         setInput("");
         navigate("/");
         toast.success("Garden deleted successfully!");
-        queryClient.invalidateQueries({ queryKey: ["search"] });
-        queryClient.removeQueries({ queryKey: ["garden", doi] });
+        queryClient.invalidateQueries({ queryKey: ["gardens", "search"] });
+        queryClient.removeQueries({ queryKey: ["gardens", doi] });
       },
     });
   };
@@ -291,20 +300,18 @@ const ArchiveGardenModal = ({
 
   const handleArchiveGarden = () => {
     try {
-      updateGarden(
-        {
-          doi: doi,
-          garden: {
-            doi_is_draft: false,
-            is_archived: true,
-          },
-          successMessage: "Garden archived successfully!",
+      updateGarden({
+        doi: doi,
+        garden: {
+          doi_is_draft: false,
+          is_archived: true,
         },
-      );
+        successMessage: "Garden archived successfully!",
+      });
       setIsOpen(false);
       setInput("");
-      queryClient.invalidateQueries({ queryKey: ["search"] });
-      queryClient.setQueryData(["garden", doi], (oldData: Garden) => {
+      queryClient.invalidateQueries({ queryKey: ["gardens", "search"] });
+      queryClient.setQueryData(["gardens", doi], (oldData: Garden) => {
         return { ...oldData, is_archived: true };
       });
     } catch (error) {

--- a/garden/src/features/materials/hooks/useMaterialActions.ts
+++ b/garden/src/features/materials/hooks/useMaterialActions.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { toast } from "sonner";
-import { Garden, ModalFunction, Dataset, Paper, Repository, Notebook } from '@/types';
+import { Garden, ModalFunction, Dataset, Paper, Repository, Notebook } from "@/types";
 import { usePatchModalFunction } from "@/features/modal/api/usePatchModalFunction";
 import { useQueryClient } from "@tanstack/react-query";
 import axios from "@/lib/axios";
@@ -18,7 +18,7 @@ export type MaterialType = {
 };
 
 // Type for accessing material collections with proper types
-type MaterialCollectionKey = 'datasets' | 'papers' | 'repositories' | 'notebooks';
+type MaterialCollectionKey = "datasets" | "papers" | "repositories" | "notebooks";
 
 // Helper function to safely access material collections
 const getMaterialCollection = (func: ModalFunction, materialType: string): any[] => {
@@ -31,7 +31,7 @@ export interface UseMaterialActionsOptions<T extends MaterialType> {
   garden: Garden;
   findAffectedFunctions?: (doi: string) => ModalFunction[];
   onUpdate?: () => Promise<void>;
-  materialType: 'paper' | 'dataset' | 'repository' | 'notebook';
+  materialType: "paper" | "dataset" | "repository" | "notebook";
 }
 
 // Direct fetch function for getting modal function data
@@ -49,7 +49,7 @@ export function useMaterialActions<T extends MaterialType>({
   garden,
   findAffectedFunctions,
   onUpdate,
-  materialType
+  materialType,
 }: UseMaterialActionsOptions<T>) {
   const [expanded, setExpanded] = useState(false);
   const [confirmRemove, setConfirmRemove] = useState(false);
@@ -57,152 +57,158 @@ export function useMaterialActions<T extends MaterialType>({
   const [editSelectiveFunctions, setEditSelectiveFunctions] = useState<Record<number, boolean>>({});
   const [editingMaterial, setEditingMaterial] = useState<T | null>(null);
   const [editAffectedFunctions, setEditAffectedFunctions] = useState<ModalFunction[]>([]);
-  
+
   // Simplified version of setIsSelectiveEditing without debug logging
   const [isSelectiveEditing, setIsSelectiveEditing] = useState(false);
-  
+
   const [selectiveFunctions, setSelectiveFunctions] = useState<Record<number, boolean>>({});
   const [affectedFunctions, setAffectedFunctions] = useState<ModalFunction[]>([]);
   const [isSelectiveRemoval, setIsSelectiveRemoval] = useState(false);
   const { mutateAsync: patchModalFunction } = usePatchModalFunction();
   const queryClient = useQueryClient();
-  
+
   // Create a link from URL or DOI
-  const materialLink = material?.url || (material?.doi ? `https://doi.org/${material.doi}` : undefined);
-  
+  const materialLink =
+    material?.url || (material?.doi ? `https://doi.org/${material.doi}` : undefined);
+
   const prepareFunctionsForEdit = async (updatedMaterial: T) => {
-    const identifier = materialType === 'repository' || materialType === 'notebook'
-      ? (material.doi || material.url) 
-      : material.doi;
+    const identifier =
+      materialType === "repository" || materialType === "notebook"
+        ? material.doi || material.url
+        : material.doi;
     if (!identifier) {
       return;
     }
-    
+
     setEditAffectedFunctions([]);
     setEditSelectiveFunctions({});
-    
+
     try {
       setEditingMaterial(updatedMaterial);
       const functionsWithMaterial = await directlyCheckFunctionsWithMaterial(identifier);
       let allFunctions = [...(garden.modal_functions || [])];
-      
+
       if (functionsWithMaterial.length === 0 && allFunctions.length === 0) {
         toast.error("Could not find any functions to update");
         return;
       }
-      
-      const functionIdsWithMaterial = new Set(
-        functionsWithMaterial.map(func => func.id)
-      );
-      
-      const allEligibleFunctions = allFunctions.map(func => ({
+
+      const functionIdsWithMaterial = new Set(functionsWithMaterial.map((func) => func.id));
+
+      const allEligibleFunctions = allFunctions.map((func) => ({
         ...func,
-        already_has_material: functionIdsWithMaterial.has(func.id)
+        already_has_material: functionIdsWithMaterial.has(func.id),
       }));
-      
+
       setEditAffectedFunctions(allEligibleFunctions);
-      
+
       const initialSelections: Record<number, boolean> = {};
-      allEligibleFunctions.forEach(func => {
-        if (typeof func.id === 'number') {
+      allEligibleFunctions.forEach((func) => {
+        if (typeof func.id === "number") {
           initialSelections[func.id] = func.already_has_material || false;
         }
       });
       setEditSelectiveFunctions(initialSelections);
-      
+
       setIsSelectiveEditing(true);
     } catch (error) {
       console.error("Error preparing functions for edit:", error);
       toast.error(`Failed to prepare functions for edit: ${error}`);
     }
   };
-  
+
   const handleEdit = async (updatedMaterial: T) => {
     prepareFunctionsForEdit(updatedMaterial);
   };
-  
+
   const applyEditToAllFunctions = async () => {
     // For repositories and notebooks, check either DOI or URL. For other materials, require DOI
-    const identifier = materialType === 'repository' || materialType === 'notebook'
-      ? (editingMaterial?.doi || editingMaterial?.url) 
-      : editingMaterial?.doi;
+    const identifier =
+      materialType === "repository" || materialType === "notebook"
+        ? editingMaterial?.doi || editingMaterial?.url
+        : editingMaterial?.doi;
     if (!editingMaterial || !identifier || editAffectedFunctions.length === 0) {
       setIsSelectiveEditing(false);
       return;
     }
-    
+
     try {
       // Create an array of promises for updating each affected function
-      const updatePromises = editAffectedFunctions.map(func => {
-        // Ensure func.id exists and is a number
-        if (typeof func.id !== 'number') {
-          console.error('Function ID is not a number:', func);
-          return Promise.resolve(); // Skip this function
-        }
+      const updatePromises = editAffectedFunctions
+        .map((func) => {
+          // Ensure func.id exists and is a number
+          if (typeof func.id !== "number") {
+            console.error("Function ID is not a number:", func);
+            return Promise.resolve(); // Skip this function
+          }
 
-        // Get current materials based on type
-        const currentMaterials = materialType === 'repository' || materialType === 'notebook'
-          ? func[materialType === 'repository' ? 'repositories' : 'notebooks'] || []
-          : func[`${materialType}s`] || [];
-        
-        // Replace the material being edited
-        const updatedMaterials = currentMaterials.map((m: any) => {
-          if (materialType === 'repository' || materialType === 'notebook') {
-            // For repositories and notebooks, match on either DOI or URL
-            if ((m.doi && m.doi === identifier) || (!m.doi && m.url && m.url === identifier)) {
-              return editingMaterial;
+          // Get current materials based on type
+          const currentMaterials =
+            materialType === "repository" || materialType === "notebook"
+              ? func[materialType === "repository" ? "repositories" : "notebooks"] || []
+              : func[`${materialType}s`] || [];
+
+          // Replace the material being edited
+          const updatedMaterials = currentMaterials.map((m: any) => {
+            if (materialType === "repository" || materialType === "notebook") {
+              // For repositories and notebooks, match on either DOI or URL
+              if ((m.doi && m.doi === identifier) || (!m.doi && m.url && m.url === identifier)) {
+                return editingMaterial;
+              }
+            } else {
+              // For other materials, match on DOI
+              if (m.doi === identifier) {
+                return editingMaterial;
+              }
             }
-          } else {
-            // For other materials, match on DOI
-            if (m.doi === identifier) {
-              return editingMaterial;
-            }
-          }
-          return m;
-        });
-        
-        // Patch the function with updated materials
-        return patchModalFunction({
-          id: func.id,
-          modalFunction: {
-            [materialType === 'repository' ? 'repositories' : `${materialType}s`]: updatedMaterials
-          }
-        });
-      }).filter(Boolean);
-      
+            return m;
+          });
+
+          // Patch the function with updated materials
+          return patchModalFunction({
+            id: func.id,
+            modalFunction: {
+              [materialType === "repository" ? "repositories" : `${materialType}s`]:
+                updatedMaterials,
+            },
+          });
+        })
+        .filter(Boolean);
+
       // Wait for all updates to complete
       await Promise.all(updatePromises);
-      
-      toast.success(`${materialType.charAt(0).toUpperCase() + materialType.slice(1)} updated across ${updatePromises.length} function(s)`);
-      
+
+      toast.success(
+        `${materialType.charAt(0).toUpperCase() + materialType.slice(1)} updated across ${updatePromises.length} function(s)`,
+      );
+
       // Reset all state completely to avoid stale references
       setEditingMaterial(null);
       setEditAffectedFunctions([]);
       setEditSelectiveFunctions({});
       setIsSelectiveEditing(false);
-      
+
       // Explicitly invalidate queries for the affected functions and garden
       for (const func of editAffectedFunctions) {
         if (func.id) {
-          await queryClient.invalidateQueries({ queryKey: ["modalFunction", func.id.toString()] });
-          await queryClient.refetchQueries({ queryKey: ["modalFunction", func.id.toString()] });
+          await queryClient.invalidateQueries({ queryKey: ["modalFunctions", func.id] });
+          await queryClient.refetchQueries({ queryKey: ["modalFunctions", func.id] });
         }
       }
-      
+
       if (garden.doi) {
-        await queryClient.invalidateQueries({ queryKey: ["garden", garden.doi] });
-        await queryClient.refetchQueries({ queryKey: ["garden", garden.doi] });
+        await queryClient.invalidateQueries({ queryKey: ["gardens", garden.doi] });
+        await queryClient.refetchQueries({ queryKey: ["gardens", garden.doi] });
       }
-      
+
       // Call the onUpdate callback to refresh the garden data
       if (onUpdate) {
         await onUpdate();
       }
-      
     } catch (error) {
       toast.error(`Failed to update ${materialType}`);
       console.error(`Error updating ${materialType}:`, error);
-      
+
       // Reset state even on error
       setEditingMaterial(null);
       setEditAffectedFunctions([]);
@@ -210,140 +216,147 @@ export function useMaterialActions<T extends MaterialType>({
       setIsSelectiveEditing(false);
     }
   };
-  
+
   const applySelectiveEdit = async () => {
-    const identifier = materialType === 'repository' ? 
-      (editingMaterial?.doi || editingMaterial?.url) : 
-      editingMaterial?.doi;
+    const identifier =
+      materialType === "repository"
+        ? editingMaterial?.doi || editingMaterial?.url
+        : editingMaterial?.doi;
 
     if (!editingMaterial || !identifier || editAffectedFunctions.length === 0) {
-      console.error('Missing required data for selective edit');
+      console.error("Missing required data for selective edit");
       setIsSelectiveEditing(false);
       return;
     }
-    
+
     try {
-      const functionsToUpdate = editAffectedFunctions.filter(func => 
-        typeof func.id === 'number' && editSelectiveFunctions[func.id]
+      const functionsToUpdate = editAffectedFunctions.filter(
+        (func) => typeof func.id === "number" && editSelectiveFunctions[func.id],
       );
-      
+
       if (functionsToUpdate.length === 0) {
         toast.error(`Please select at least one function to update the ${materialType} in`);
         return;
       }
-      
-      const updatePromises = functionsToUpdate.map(func => {
-        if (typeof func.id !== 'number') {
-          console.error('Function ID is not a number:', func);
-          return Promise.resolve();
-        }
 
-        const currentMaterials = materialType === 'repository' 
-          ? (func.repositories || [])
-          : (func[`${materialType}s`] || []);
-        
-        let updatedMaterials;
-        
-        const hasMaterial = currentMaterials.some((m: any) => {
-          if (materialType === 'repository') {
-            return (m.doi && m.doi === identifier) || 
-                   (!m.doi && m.url && m.url === identifier);
-          } else {
-            return m.doi === identifier;
+      const updatePromises = functionsToUpdate
+        .map((func) => {
+          if (typeof func.id !== "number") {
+            console.error("Function ID is not a number:", func);
+            return Promise.resolve();
           }
-        });
-        
-        if (hasMaterial) {
-          updatedMaterials = currentMaterials.map((m: any) => {
-            if (materialType === 'repository') {
-              if ((m.doi && m.doi === identifier) || 
-                  (!m.doi && m.url && m.url === identifier)) {
-                return editingMaterial;
-              }
+
+          const currentMaterials =
+            materialType === "repository"
+              ? func.repositories || []
+              : func[`${materialType}s`] || [];
+
+          let updatedMaterials;
+
+          const hasMaterial = currentMaterials.some((m: any) => {
+            if (materialType === "repository") {
+              return (m.doi && m.doi === identifier) || (!m.doi && m.url && m.url === identifier);
             } else {
-              if (m.doi === identifier) {
-                return editingMaterial;
-              }
+              return m.doi === identifier;
             }
-            return m;
           });
-        } else {
-          updatedMaterials = [...currentMaterials, editingMaterial];
-        }
-        
-        return patchModalFunction({
-          id: func.id,
-          modalFunction: {
-            [materialType === 'repository' ? 'repositories' : `${materialType}s`]: updatedMaterials
+
+          if (hasMaterial) {
+            updatedMaterials = currentMaterials.map((m: any) => {
+              if (materialType === "repository") {
+                if ((m.doi && m.doi === identifier) || (!m.doi && m.url && m.url === identifier)) {
+                  return editingMaterial;
+                }
+              } else {
+                if (m.doi === identifier) {
+                  return editingMaterial;
+                }
+              }
+              return m;
+            });
+          } else {
+            updatedMaterials = [...currentMaterials, editingMaterial];
           }
-        });
-      }).filter(Boolean);
-      
+
+          return patchModalFunction({
+            id: func.id,
+            modalFunction: {
+              [materialType === "repository" ? "repositories" : `${materialType}s`]:
+                updatedMaterials,
+            },
+          });
+        })
+        .filter(Boolean);
+
       await Promise.all(updatePromises);
-      
-      toast.success(`${materialType.charAt(0).toUpperCase() + materialType.slice(1)} updated in ${updatePromises.length} function(s)`);
-      
+
+      toast.success(
+        `${materialType.charAt(0).toUpperCase() + materialType.slice(1)} updated in ${updatePromises.length} function(s)`,
+      );
+
       setEditingMaterial(null);
       setEditAffectedFunctions([]);
       setEditSelectiveFunctions({});
       setIsSelectiveEditing(false);
-      
+
       for (const func of functionsToUpdate) {
         if (func.id) {
-          await queryClient.invalidateQueries({ queryKey: ["modalFunction", func.id.toString()] });
-          await queryClient.refetchQueries({ queryKey: ["modalFunction", func.id.toString()] });
+          await queryClient.invalidateQueries({ queryKey: ["modalFunctions", func.id] });
+          await queryClient.refetchQueries({ queryKey: ["modalFunctions", func.id] });
         }
       }
-      
+
       if (garden.doi) {
-        await queryClient.invalidateQueries({ queryKey: ["garden", garden.doi] });
-        await queryClient.refetchQueries({ queryKey: ["garden", garden.doi] });
+        await queryClient.invalidateQueries({ queryKey: ["gardens", garden.doi] });
+        await queryClient.refetchQueries({ queryKey: ["gardens", garden.doi] });
       }
-      
+
       if (onUpdate) {
         await onUpdate();
       }
-      
     } catch (error) {
       console.error("Error in applySelectiveEdit:", error);
       toast.error(`Failed to update ${materialType}`);
-      
+
       setEditingMaterial(null);
       setEditAffectedFunctions([]);
       setEditSelectiveFunctions({});
       setIsSelectiveEditing(false);
     }
   };
-  
+
   const toggleEditFunction = (id: number) => {
-    setEditSelectiveFunctions(prev => ({
+    setEditSelectiveFunctions((prev) => ({
       ...prev,
-      [id]: !prev[id]
+      [id]: !prev[id],
     }));
   };
-  
+
   const toggleEditAll = (value: boolean) => {
     const newSelections: Record<number, boolean> = {};
-    editAffectedFunctions.forEach(func => {
+    editAffectedFunctions.forEach((func) => {
       if (func.id) {
         newSelections[func.id] = value;
       }
     });
     setEditSelectiveFunctions(newSelections);
   };
-  
-  const directlyCheckFunctionsWithMaterial = async (identifier: string): Promise<ModalFunction[]> => {
+
+  const directlyCheckFunctionsWithMaterial = async (
+    identifier: string,
+  ): Promise<ModalFunction[]> => {
     // Get all functions in the garden
     const allFunctions = garden.modal_functions || [];
-    
+
     // Filter functions that have this material
-    const functionsWithMaterial = allFunctions.filter(func => {
-      const materials = materialType === 'repository' || materialType === 'notebook'
-        ? func[materialType === 'repository' ? 'repositories' : 'notebooks'] || []
-        : func[`${materialType}s`] || [];
-      
+    const functionsWithMaterial = allFunctions.filter((func) => {
+      const materials =
+        materialType === "repository" || materialType === "notebook"
+          ? func[materialType === "repository" ? "repositories" : "notebooks"] || []
+          : func[`${materialType}s`] || [];
+
       return materials.some((m: any) => {
-        if (materialType === 'repository' || materialType === 'notebook') {
+        if (materialType === "repository" || materialType === "notebook") {
           // For repositories and notebooks, match on either DOI or URL
           return (m.doi && m.doi === identifier) || (!m.doi && m.url && m.url === identifier);
         } else {
@@ -352,72 +365,75 @@ export function useMaterialActions<T extends MaterialType>({
         }
       });
     });
-    
+
     return functionsWithMaterial;
   };
 
   const prepareFunctionsForRemoval = async () => {
     // For repositories and notebooks, check either DOI or URL. For other materials, require DOI
-    const identifier = materialType === 'repository' || materialType === 'notebook'
-      ? (material.doi || material.url) 
-      : material.doi;
+    const identifier =
+      materialType === "repository" || materialType === "notebook"
+        ? material.doi || material.url
+        : material.doi;
     if (!identifier) {
       return;
     }
-    
+
     // Clear any previous state before starting the removal process
     setAffectedFunctions([]);
     setSelectiveFunctions({});
-    
+
     try {
       // CRITICAL FIX: Use our direct function checking method instead of findAffectedFunctions
       // This bypasses the cache and gets fresh data for each function
       const functionsWithMaterial = await directlyCheckFunctionsWithMaterial(identifier);
-      
+
       if (functionsWithMaterial.length === 0) {
         toast.error(`Could not find functions referencing this ${materialType}`);
         return;
       }
-      
+
       console.log(`Found ${functionsWithMaterial.length} functions with material ${identifier}`);
-      
+
       // Check if user owns all affected functions
-      const nonOwnedFunctions = functionsWithMaterial.filter(func => {
+      const nonOwnedFunctions = functionsWithMaterial.filter((func) => {
         // Use only garden.owner_identity_id since current_user_id is not in the type
         const currentUserId = garden.owner_identity_id;
         // Get owner ID from the modal app response
         const funcOwnerId = garden.owner_identity_id; // Default to garden owner if function owner not available
         return funcOwnerId !== currentUserId;
       });
-      
+
       if (nonOwnedFunctions.length > 0) {
-        toast.error(`Cannot remove - you don't own ${nonOwnedFunctions.length} function(s) that use this ${materialType}.`);
+        toast.error(
+          `Cannot remove - you don't own ${nonOwnedFunctions.length} function(s) that use this ${materialType}.`,
+        );
         return;
       }
-      
+
       // Mark all functions as having the material
       // For removal, we only want to show functions that already have the material
-      const functionsWithMaterialMarked = functionsWithMaterial.map(func => ({
+      const functionsWithMaterialMarked = functionsWithMaterial.map((func) => ({
         ...func,
-        already_has_material: true
+        already_has_material: true,
       }));
-      
+
       // Store the affected functions with already_has_material flag
       setAffectedFunctions(functionsWithMaterialMarked);
-      
+
       // Initialize the selective functions object with all functions selected by default
       const initialSelections: Record<number, boolean> = {};
-      functionsWithMaterialMarked.forEach(func => {
-        if (typeof func.id === 'number') {
+      functionsWithMaterialMarked.forEach((func) => {
+        if (typeof func.id === "number") {
           // All functions shown already have the material, so select them all by default
           initialSelections[func.id] = true;
         }
       });
       setSelectiveFunctions(initialSelections);
-      
+
       // Always go directly to selective removal mode
       setIsSelectiveRemoval(true);
-      
+
       // Open the confirmation dialog
       setConfirmRemove(true);
     } catch (error) {
@@ -425,21 +441,24 @@ export function useMaterialActions<T extends MaterialType>({
       toast.error(`Failed to prepare functions for removal: ${error}`);
     }
   };
-  
+
   const handleRemoveAll = async () => {
     try {
-      const identifier = materialType === 'repository' ? material.url :
-                        materialType === 'notebook' ? (material.doi || material.url) :
-                        material.doi;
+      const identifier =
+        materialType === "repository"
+          ? material.url
+          : materialType === "notebook"
+            ? material.doi || material.url
+            : material.doi;
       if (!identifier) {
-        console.warn('No identifier found for removal');
+        console.warn("No identifier found for removal");
         return;
       }
 
       const functionsToUpdate = await directlyCheckFunctionsWithMaterial(identifier);
-      
+
       if (functionsToUpdate.length === 0) {
-        console.warn('No functions found with material:', identifier);
+        console.warn("No functions found with material:", identifier);
         toast.error(`Could not find functions referencing this ${materialType}`);
         return;
       }
@@ -447,18 +466,20 @@ export function useMaterialActions<T extends MaterialType>({
       await Promise.all(
         functionsToUpdate.map(async (func) => {
           if (!func.id) {
-            console.warn('Function missing ID:', func);
+            console.warn("Function missing ID:", func);
             return;
           }
 
-          const materialsKey = materialType === 'repository' ? 'repositories' :
-                             `${materialType}s` as 'datasets' | 'papers' | 'repositories' | 'notebooks';
-          
+          const materialsKey =
+            materialType === "repository"
+              ? "repositories"
+              : (`${materialType}s` as "datasets" | "papers" | "repositories" | "notebooks");
+
           const currentMaterials = func[materialsKey] || [];
           const updatedMaterials = currentMaterials.filter((m: any) => {
-            if (materialType === 'repository') {
+            if (materialType === "repository") {
               return m.url !== identifier;
-            } else if (materialType === 'notebook') {
+            } else if (materialType === "notebook") {
               return !(m.doi === identifier || m.url === identifier);
             } else {
               return m.doi !== identifier;
@@ -470,80 +491,87 @@ export function useMaterialActions<T extends MaterialType>({
             papers: func.papers || [],
             repositories: func.repositories || [],
             notebooks: func.notebooks || [],
-            [materialsKey]: updatedMaterials
+            [materialsKey]: updatedMaterials,
           };
 
           await patchModalFunction({
             id: func.id,
-            modalFunction: patchData
+            modalFunction: patchData,
           });
 
           await Promise.all([
-            queryClient.invalidateQueries({ queryKey: ["modalFunction", func.id.toString()] }),
-            queryClient.invalidateQueries({ queryKey: ["modalFunction"] }),
-            queryClient.refetchQueries({ queryKey: ["modalFunction", func.id.toString()] })
+            queryClient.invalidateQueries({ queryKey: ["modalFunctions", func.id] }),
+            queryClient.invalidateQueries({ queryKey: ["modalFunctions"] }),
+            queryClient.refetchQueries({ queryKey: ["modalFunctions", func.id] }),
           ]);
-        })
+        }),
       );
-      
+
       if (garden.doi) {
         await Promise.all([
-          queryClient.invalidateQueries({ queryKey: ["garden", garden.doi] }),
-          queryClient.invalidateQueries({ queryKey: ["garden"] }),
-          queryClient.refetchQueries({ queryKey: ["garden", garden.doi] })
+          queryClient.invalidateQueries({ queryKey: ["gardens", garden.doi] }),
+          queryClient.invalidateQueries({ queryKey: ["gardens"] }),
+          queryClient.refetchQueries({ queryKey: ["gardens", garden.doi] }),
         ]);
       }
 
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
       if (onUpdate) {
         await onUpdate();
       }
-      
-      toast.success(`${materialType.charAt(0).toUpperCase() + materialType.slice(1)} removed successfully`);
+
+      toast.success(
+        `${materialType.charAt(0).toUpperCase() + materialType.slice(1)} removed successfully`,
+      );
       setConfirmRemove(false);
     } catch (error) {
-      console.error('Error removing material:', error);
-      toast.error('Failed to remove material');
+      console.error("Error removing material:", error);
+      toast.error("Failed to remove material");
       setConfirmRemove(false);
     }
   };
-  
+
   const handleSelectiveRemove = async () => {
-    const identifier = materialType === 'repository' ? material.url :
-                      materialType === 'notebook' ? (material.doi || material.url) :
-                      material.doi;
+    const identifier =
+      materialType === "repository"
+        ? material.url
+        : materialType === "notebook"
+          ? material.doi || material.url
+          : material.doi;
     if (!identifier || affectedFunctions.length === 0) {
       setIsSelectiveRemoval(false);
       setConfirmRemove(false);
       return;
     }
-    
+
     try {
-      const functionsToUpdate = affectedFunctions.filter(func => 
-        func.id && selectiveFunctions[func.id]
+      const functionsToUpdate = affectedFunctions.filter(
+        (func) => func.id && selectiveFunctions[func.id],
       );
-      
+
       if (functionsToUpdate.length === 0) {
         toast.error(`Please select at least one function to remove the ${materialType} from`);
         return;
       }
-      
-      const updatePromises = functionsToUpdate.map(async func => {
+
+      const updatePromises = functionsToUpdate.map(async (func) => {
         if (!func.id) {
-          console.warn('Function missing ID:', func);
+          console.warn("Function missing ID:", func);
           return;
         }
 
-        const materialsKey = materialType === 'repository' ? 'repositories' :
-                           `${materialType}s` as 'datasets' | 'papers' | 'repositories' | 'notebooks';
-        
+        const materialsKey =
+          materialType === "repository"
+            ? "repositories"
+            : (`${materialType}s` as "datasets" | "papers" | "repositories" | "notebooks");
+
         const currentMaterials = func[materialsKey] || [];
-        
+
         const updatedMaterials = currentMaterials.filter((m: any) => {
-          if (materialType === 'repository') {
+          if (materialType === "repository") {
             return m.url !== identifier;
-          } else if (materialType === 'notebook') {
+          } else if (materialType === "notebook") {
             return !(m.doi === identifier || m.url === identifier);
           } else {
             return m.doi !== identifier;
@@ -555,65 +583,66 @@ export function useMaterialActions<T extends MaterialType>({
           papers: func.papers || [],
           repositories: func.repositories || [],
           notebooks: func.notebooks || [],
-          [materialsKey]: updatedMaterials
+          [materialsKey]: updatedMaterials,
         };
 
         await patchModalFunction({
           id: func.id,
-          modalFunction: patchData
+          modalFunction: patchData,
         });
 
         await Promise.all([
-          queryClient.invalidateQueries({ queryKey: ["modalFunction", func.id.toString()] }),
-          queryClient.invalidateQueries({ queryKey: ["modalFunction"] }),
-          queryClient.refetchQueries({ queryKey: ["modalFunction", func.id.toString()] })
+          queryClient.invalidateQueries({ queryKey: ["modalFunctions", func.id] }),
+          queryClient.invalidateQueries({ queryKey: ["modalFunctions"] }),
+          queryClient.refetchQueries({ queryKey: ["modalFunctions", func.id] }),
         ]);
       });
-      
+
       await Promise.all(updatePromises);
-      
+
       if (garden.doi) {
         await Promise.all([
-          queryClient.invalidateQueries({ queryKey: ["garden", garden.doi] }),
-          queryClient.invalidateQueries({ queryKey: ["garden"] }),
-          queryClient.refetchQueries({ queryKey: ["garden", garden.doi] })
+          queryClient.invalidateQueries({ queryKey: ["gardens", garden.doi] }),
+          queryClient.invalidateQueries({ queryKey: ["gardens"] }),
+          queryClient.refetchQueries({ queryKey: ["gardens", garden.doi] }),
         ]);
       }
 
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
       if (onUpdate) {
         await onUpdate();
       }
-      
-      toast.success(`${materialType.charAt(0).toUpperCase() + materialType.slice(1)} removed from ${functionsToUpdate.length} function(s)`);
-      
+
+      toast.success(
+        `${materialType.charAt(0).toUpperCase() + materialType.slice(1)} removed from ${functionsToUpdate.length} function(s)`,
+      );
+
       setAffectedFunctions([]);
       setSelectiveFunctions({});
       setConfirmRemove(false);
       setIsSelectiveRemoval(false);
-      
     } catch (error) {
-      console.error('Error removing material:', error);
+      console.error("Error removing material:", error);
       toast.error(`Failed to remove ${materialType}`);
-      
+
       setAffectedFunctions([]);
       setSelectiveFunctions({});
       setConfirmRemove(false);
       setIsSelectiveRemoval(false);
     }
   };
-  
+
   const toggleFunction = (id: number) => {
-    setSelectiveFunctions(prev => ({
+    setSelectiveFunctions((prev) => ({
       ...prev,
-      [id]: !prev[id]
+      [id]: !prev[id],
     }));
   };
-  
+
   const toggleAll = (value: boolean) => {
     const newSelections: Record<number, boolean> = {};
-    affectedFunctions.forEach(func => {
+    affectedFunctions.forEach((func) => {
       if (func.id) {
         newSelections[func.id] = value;
       }
@@ -647,6 +676,6 @@ export function useMaterialActions<T extends MaterialType>({
     toggleEditFunction,
     toggleEditAll,
     applyEditToAllFunctions,
-    applySelectiveEdit
+    applySelectiveEdit,
   };
-} 
+}

--- a/garden/src/features/materials/hooks/useMaterialsManager.ts
+++ b/garden/src/features/materials/hooks/useMaterialsManager.ts
@@ -1,6 +1,6 @@
-import { useMemo, useCallback } from 'react';
-import { QueryClient } from '@tanstack/react-query';
-import { Dataset, Paper, Repository, Notebook, ModalFunction, Garden } from '@/types';
+import { useMemo, useCallback } from "react";
+import { QueryClient } from "@tanstack/react-query";
+import { Dataset, Paper, Repository, Notebook, ModalFunction, Garden } from "@/types";
 
 export interface MaterialsManager {
   allMaterials: {
@@ -52,75 +52,89 @@ export const useMaterialsManager = ({
   const allMaterials = useMemo(() => {
     return {
       datasets: deduplicateByDOI([
-        ...(garden.modal_functions?.map(func => func.datasets || []).flat() || [])
+        ...(garden.modal_functions?.map((func) => func.datasets || []).flat() || []),
       ]),
       papers: deduplicateByDOI([
-        ...(garden.modal_functions?.map(func => func.papers || []).flat() || [])
+        ...(garden.modal_functions?.map((func) => func.papers || []).flat() || []),
       ]),
       repositories: deduplicateRepositoriesByURL([
-        ...(garden.modal_functions?.map(func => func.repositories || []).flat() || [])
+        ...(garden.modal_functions?.map((func) => func.repositories || []).flat() || []),
       ]),
       notebooks: deduplicateNotebooksByURL([
-        ...(garden.modal_functions?.map(func => func.notebooks || []).flat() || [])
-      ])
+        ...(garden.modal_functions?.map((func) => func.notebooks || []).flat() || []),
+      ]),
     };
   }, [garden]);
 
   // Find functions that use a specific material
-  const findFunctionsWithMaterial = useCallback((doi: string): ModalFunction[] => {
-    if (!garden.doi) return [];
-    
-    // Get the freshest data directly from the query cache
-    const latestGardenData = queryClient.getQueryData(["garden", garden.doi]) as Garden;
-    const currentFunctions = [...(latestGardenData?.modal_functions || [])];
-    
-    if (!currentFunctions.length) {
-      console.warn('No functions found in the latest garden data');
-      return [];
-    }
-    
-    // Deep check to make sure each function's materials are properly examined
-    const functionsWithMaterial = currentFunctions.filter(func => {
-      if (!func) return false;
-      
-      const hasMaterialInDataset = Array.isArray(func.datasets) && 
-        func.datasets.some(dataset => dataset && dataset.doi === doi);
-      
-      const hasMaterialInPaper = Array.isArray(func.papers) && 
-        func.papers.some(paper => paper && paper.doi === doi);
-      
-      const hasMaterialInRepo = Array.isArray(func.repositories) && 
-        func.repositories.some(repo => repo && (repo.doi === doi || repo.url === doi));
-      
-      const hasMaterialInNotebook = Array.isArray(func.notebooks) && 
-        func.notebooks.some(notebook => notebook && notebook.url === doi);
-      
-      return hasMaterialInDataset || hasMaterialInPaper || hasMaterialInRepo || hasMaterialInNotebook;
-    }).map(func => ({
-      ...func,
-      already_has_material: true
-    }));
-    
-    return functionsWithMaterial;
-  }, [garden.doi, queryClient]);
+  const findFunctionsWithMaterial = useCallback(
+    (doi: string): ModalFunction[] => {
+      if (!garden.doi) return [];
+
+      // Get the freshest data directly from the query cache
+      const latestGardenData = queryClient.getQueryData(["gardens", garden.doi]) as Garden;
+      const currentFunctions = [...(latestGardenData?.modal_functions || [])];
+
+      if (!currentFunctions.length) {
+        console.warn("No functions found in the latest garden data");
+        return [];
+      }
+
+      // Deep check to make sure each function's materials are properly examined
+      const functionsWithMaterial = currentFunctions
+        .filter((func) => {
+          if (!func) return false;
+
+          const hasMaterialInDataset =
+            Array.isArray(func.datasets) &&
+            func.datasets.some((dataset) => dataset && dataset.doi === doi);
+
+          const hasMaterialInPaper =
+            Array.isArray(func.papers) && func.papers.some((paper) => paper && paper.doi === doi);
+
+          const hasMaterialInRepo =
+            Array.isArray(func.repositories) &&
+            func.repositories.some((repo) => repo && (repo.doi === doi || repo.url === doi));
+
+          const hasMaterialInNotebook =
+            Array.isArray(func.notebooks) &&
+            func.notebooks.some((notebook) => notebook && notebook.url === doi);
+
+          return (
+            hasMaterialInDataset || hasMaterialInPaper || hasMaterialInRepo || hasMaterialInNotebook
+          );
+        })
+        .map((func) => ({
+          ...func,
+          already_has_material: true,
+        }));
+
+      return functionsWithMaterial;
+    },
+    [garden.doi, queryClient],
+  );
 
   // Refresh all materials and related data
   const refreshMaterials = useCallback(async () => {
     // Invalidate function caches
     if (garden.modal_functions) {
-      await Promise.all(garden.modal_functions.map(async func => {
-        if (func.id) {
-          await queryClient.invalidateQueries({ queryKey: ["modalFunction", func.id.toString()] });
-        }
-      }));
+      await Promise.all(
+        garden.modal_functions.map(async (func) => {
+          if (func.id) {
+            await queryClient.invalidateQueries({
+              queryKey: ["modalFunctions", func.id],
+            });
+          }
+        }),
+      );
     }
-    
+
     // Invalidate garden cache and wait for it to complete
-    await queryClient.invalidateQueries({ queryKey: ["garden", garden.doi] });
-    
+    await queryClient.invalidateQueries({ queryKey: ["gardens", garden.doi] });
+
     // Refetch garden data and wait for completion
     await refetchGarden();
-    
+
     // Ensure the query client settles all pending operations
     await queryClient.resumePausedMutations();
   }, [garden, queryClient, refetchGarden]);
@@ -130,4 +144,4 @@ export const useMaterialsManager = ({
     findFunctionsWithMaterial,
     refreshMaterials,
   };
-}; 
+};

--- a/garden/src/features/modal/api/useGetModalFunction.tsx
+++ b/garden/src/features/modal/api/useGetModalFunction.tsx
@@ -13,7 +13,7 @@ const getModalFunction = async (id: string): Promise<ModalFunction> => {
 
 export const useGetModalFunction = (id: string) => {
   return useQuery({
-    queryKey: ["modalFunction", id],
+    queryKey: ["modalFunctions", Number(id)],
     queryFn: async () => {
       const response = await axios.get(`/modal-functions/${id}`);
       const modalFunction = response.data as ModalFunction;
@@ -22,7 +22,7 @@ export const useGetModalFunction = (id: string) => {
       const modalAppResponse = await axios.get(`/modal-apps/${modalFunction.modal_app_id}`);
       return {
         ...modalFunction,
-        owner_identity_id: modalAppResponse.data.owner_identity_id
+        owner_identity_id: modalAppResponse.data.owner_identity_id,
       };
     },
   });

--- a/garden/src/features/modal/api/useGetUserModalFunctions.tsx
+++ b/garden/src/features/modal/api/useGetUserModalFunctions.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "@/lib/axios";
 import { ModalFunction } from "@/types";
 import { useGlobusAuth } from "@globus/react-auth-context";
@@ -17,28 +17,32 @@ export const useGetUserModalFunctions = (options: UseGetUserModalFunctionsOption
   const { enabled = true, excludeFunctionIds = [] } = options;
   const auth = useGlobusAuth();
   const userUuid = auth?.authorization?.user?.sub;
-
+  const queryClient = useQueryClient();
   // Fetch the user's modal apps and their functions
   return useQuery<ModalFunction[]>({
     queryKey: ["userModalFunctions", userUuid, excludeFunctionIds],
     queryFn: async () => {
       // Get all modal functions for the user
       const response = await axios.get(`/modal-functions`, {
-        params: { owner_uuid: userUuid }
+        params: { owner_uuid: userUuid },
       });
-      
+
       const allFunctions = response.data || [];
-      
+
       // Filter out excluded function IDs if any
       if (excludeFunctionIds.length > 0) {
-        return allFunctions.filter((func: ModalFunction) => 
-          !excludeFunctionIds.includes(func.id)
-        );
+        return allFunctions.filter((func: ModalFunction) => !excludeFunctionIds.includes(func.id));
       }
-      
+
+      return allFunctions;
+    },
+    select: (allFunctions) => {
+      allFunctions.forEach((fn) => {
+        queryClient.setQueryData(["modalFunctions", fn.id], fn);
+      });
       return allFunctions;
     },
     enabled: enabled && !!userUuid,
     staleTime: 5 * 60 * 1000, // Cache for 5 minutes
   });
-}; 
+};

--- a/garden/src/features/modal/api/usePatchModalFunction.ts
+++ b/garden/src/features/modal/api/usePatchModalFunction.ts
@@ -17,18 +17,21 @@ export const usePatchModalFunction = () => {
     },
     onMutate: async ({ id, modalFunction }: PatchModalFunctionParams) => {
       // Cancel any outgoing refetches
-      await queryClient.cancelQueries({ queryKey: ["modalFunction", id.toString()] });
+      await queryClient.cancelQueries({ queryKey: ["modalFunctions", id] });
 
       // Snapshot the previous value
-      const previousModalFunction = queryClient.getQueryData<ModalFunction>(["modalFunction", id.toString()]);
+      const previousModalFunction = queryClient.getQueryData<ModalFunction>([
+        "modalFunction",
+        id.toString(),
+      ]);
 
       // Optimistically update to the new value
       if (previousModalFunction) {
-        queryClient.setQueryData<ModalFunction>(["modalFunction", id.toString()], {
+        queryClient.setQueryData<ModalFunction>(["modalFunctions", id], {
           ...previousModalFunction,
           ...Object.fromEntries(
-            Object.entries(modalFunction).filter(([_, value]) => value !== null)
-          )
+            Object.entries(modalFunction).filter(([_, value]) => value !== null),
+          ),
         });
       }
 
@@ -37,15 +40,13 @@ export const usePatchModalFunction = () => {
     onError: (err, { id }, context) => {
       // If the mutation fails, use the context returned from onMutate to roll back
       if (context?.previousModalFunction) {
-        queryClient.setQueryData(["modalFunction", id.toString()], context.previousModalFunction);
+        queryClient.setQueryData(["modalFunctions", id], context.previousModalFunction);
       }
     },
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ["modalFunction", data.id.toString()] });
+      queryClient.invalidateQueries({ queryKey: ["modalFunctions", data.id] });
       // Invalidate all garden queries since we don't know which gardens contain this function
-      queryClient.invalidateQueries({ queryKey: ["garden"] });
       queryClient.invalidateQueries({ queryKey: ["gardens"] });
-      queryClient.invalidateQueries({ queryKey: ["search"] });
     },
   });
-}; 
+};

--- a/garden/src/features/search/api/useSearchGardens.ts
+++ b/garden/src/features/search/api/useSearchGardens.ts
@@ -29,6 +29,11 @@ export const useSearchGardens = (searchOptions: GardenSearchRequest) => {
       searchResults.garden_meta.forEach((garden) => {
         queryClient.setQueryData(["gardens", garden.doi], garden);
       });
+      searchResults.garden_meta.forEach((garden) => {
+        garden.modal_functions?.forEach((fn) => {
+          queryClient.setQueryData(["modalFunctions", fn.id], fn);
+        });
+      });
       return searchResults;
     },
   });

--- a/garden/src/features/search/api/useSearchGardens.ts
+++ b/garden/src/features/search/api/useSearchGardens.ts
@@ -1,4 +1,4 @@
-import { keepPreviousData, useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Garden, GardenSearchFilter, GardenSearchRequest, GardenSearchResponse } from "@/types";
 import axios from "@/lib/axios";
 
@@ -12,8 +12,10 @@ const searchGardens = async (searchOptions: GardenSearchRequest): Promise<Garden
 };
 
 export const useSearchGardens = (searchOptions: GardenSearchRequest) => {
+  const queryClient = useQueryClient();
   return useQuery<GardenSearchResponse, Error>({
     queryKey: [
+      "gardens",
       "search",
       searchOptions.q,
       searchOptions.limit,
@@ -23,6 +25,12 @@ export const useSearchGardens = (searchOptions: GardenSearchRequest) => {
     ],
     queryFn: async () => searchGardens(searchOptions),
     placeholderData: keepPreviousData,
+    select: (searchResults) => {
+      searchResults.garden_meta.forEach((garden) => {
+        queryClient.setQueryData(["gardens", garden.doi], garden);
+      });
+      return searchResults;
+    },
   });
 };
 


### PR DESCRIPTION
Resolves: #370 

## Overview

This PR optimizes our data caching strategy. 

We had a few places where we would fetch a collection of gardens, cache them behind a key, then hit the `/gardens/{doi}` route to fetch garden metadata again that was already present in the cache, but unreachable by the hook since it doesn't know what the cache key is.

*Note:* A lot of the lines touched in this PR were hit by the auto-formatter in files we haven't edited since setting up the formatting.

## Details

**A specific example**
*The problem*
On the search page, we send a request to `/gardens/search` which returns a list of gardens matching the search query. Those gardens were cached behind a key that looked like `['search', ...searchParams]` which is useful for keeping the search results around if the user navigates away, then returns to search page. If the user clicks a garden card in the search results, the `useGetGarden` hook hits `/gardens/{doi}` route which fetches the garden metadata again and caches it with a key like `['garden', garden.doi]`. This means we have fetched the same metadata twice just to view a garden once.

Notice the short load between clicking the garden card on the search page and the garden page rendering, and then again when clicking a function card from the garden page:


https://github.com/user-attachments/assets/38712ed6-8ee6-4cf1-bacc-24eaa1885186


*The fix*
When getting the collection of search results back, we still cache the response from the search route under a key `['gardens', 'search', ...searchParams]`, but also iterate over the returned gardens and insert each one as a single record in the cache with a key `['gardens', garden.doi]`. This makes the individual garden's metadata available to the other hooks that use the same key structure for individual gardens. So in the case where a user makes a search query, then clicks a garden card to view the garden page, we have already cached the garden metadata that the `/gardens/{doi}` route will return, meaning we avoid the redundant API call and the garden page renders instantly.

We take the same approach for function metadata since gardens come from the backend with all of their associated function metadata. Any time we fetch a garden, we iterate over the functions in the garden metadata and cache them with a key `['modalFunctions', fn.id]`. This means whenever a user is viewing a garden page, we have already cached the function metadata, so if they click into a function page, it renders instantly without making another API call for data we already have.

No loading in between pages since we have the garden and function metadata hot in the cache:

https://github.com/user-attachments/assets/a4222e1c-e02c-4ef8-8429-80922b6baa1c

*The tradeoff*
This caching strategy greatly reduces the number of API calls we make, but does increase the memory footprint slightly since a garden could be in both the search query cache and the individual garden cache. I think the memory increase is pretty minimal because when we store the same object in the cache behind two different keys, we are really just storing two references to the same object in memory. I need to confirm that is really what is going on, but I have not observed a huge memory spike with this caching strategy. Regardless, most of our objects are only a few KB in memory, so if we store a couple of instances its not going to be a huge issue. I think the reduced network traffic and the resulting latency reduction in page loads is worth a slight memory increase.

### Other tweaks
- change the search cache keys from `['search', ...params]` to `['gardens', 'search', ...params]` so that we don't need to invalidate both `gardens` and `search` caches manually and can just invalidate `gardens` which will grab anything with a key like `['gardens', ...otherMoreSpecificKeyStructures]`
- added react-query-devtools for easier cache debugging. It is automatically removed from the `app.tsx` file in production builds.
- made our cache keys more consistent. We had both `['garden']`and `['gardens']` keys, and in some places we were caching functions with a string id and an integer id in other places.

## Testing
Manually
