### PR TITLE
fix: error on function page

### DIFF
--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -140,8 +140,12 @@ const GardenPage = () => {
   const isSuperUser = SUPER_USERS.includes(auth?.authorization?.user?.sub)
   const ownsThisGarden = auth?.isAuthenticated && (garden.owner_identity_id === auth?.authorization?.user?.sub || isSuperUser);
 
+  const memoizedRefetch = React.useCallback(async () => {
+    await refetch();
+  }, [refetch]);
+
   return (
-    <MaterialsProvider garden={garden} refetchGarden={async () => { await refetch(); }}>
+    <MaterialsProvider garden={garden} refetchGarden={memoizedRefetch}>
       <GardenContent
         garden={garden}
         ownsThisGarden={ownsThisGarden}


### PR DESCRIPTION
Resolves: #388 

This PR (along with a commit I accidentally pushed directly to staging) hopefully fixes the issue where function pages fail to render with a cryptic error from react.

The issue I found was with the `refetch` function that gets called when a garden's metadata changes. It sometimes would get called between when the function page renders and after unmounting the garden page component which results in an infinite loop of `refetch` calls leading to the error in #388. I believe this is a subtle effect from lazy loading both the garden page and function page components.

The fix wraps the `refetch` in a `useCallback` hook to avoid the infinite loop.

## Testing
It was a pain to solve because I can not get the error to trigger in my local environment unless I run a production build which minifies and obfuscates the stack trace.

I ran a production build locally and can't get the error to trigger. We will have to see if we observe the error in staging/prod.