### PR TITLE
fix potential infinite re-renders

### DIFF
--- a/garden/src/app/app.tsx
+++ b/garden/src/app/app.tsx
@@ -15,6 +15,9 @@ const App = () => {
             element: <Router />,
           },
         ])}
+        future={{
+         v7_startTransition: true,
+        }}
       />
       <ReactQueryDevtools initialIsOpen={false}></ReactQueryDevtools>
     </>

--- a/garden/src/components/EditableCodeField.tsx
+++ b/garden/src/components/EditableCodeField.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useEffect, useRef, useState } from 'react';
 import { EditorState } from '@codemirror/state';
 import { EditorView, keymap } from '@codemirror/view';
@@ -5,7 +6,7 @@ import { python } from '@codemirror/lang-python';
 import { defaultKeymap, indentWithTab } from '@codemirror/commands';
 import { syntaxHighlighting, defaultHighlightStyle } from '@codemirror/language';
 import { Button } from './shadcn/button';
-import { XIcon, CheckIcon, PencilIcon, Loader2Icon, EditIcon } from 'lucide-react';
+import { XIcon, CheckIcon, Loader2Icon, EditIcon } from 'lucide-react';
 import CopyButton from './CopyButton';
 import SyntaxHighlighter from './SyntaxHighlighter';
 
@@ -62,7 +63,7 @@ export const EditableCodeField = ({
   useEffect(() => {
     if (isEditing && editorRef.current && !editorViewRef.current) {
       const startState = EditorState.create({
-        doc: editValue,
+        doc: value || '',
         extensions: [
           python(),
           ...basicSetup,
@@ -88,12 +89,14 @@ export const EditableCodeField = ({
         editorViewRef.current = undefined;
       };
     }
-  }, [isEditing]);
+  }, [isEditing, value]);
 
-  // Reset edit value when value prop changes
+  // Initialize edit value when editing starts
   useEffect(() => {
-    setEditValue(value || '');
-  }, [value]);
+    if (isEditing) {
+      setEditValue(value || '');
+    }
+  }, [isEditing, value]);
 
   const handleSave = async () => {
     try {

--- a/garden/src/components/Navbar.tsx
+++ b/garden/src/components/Navbar.tsx
@@ -69,21 +69,21 @@ const Navbar = () => {
 
         {/* Everything under this div is on the right side of the nav bar */}
         <div className="flex items-center justify-start">
-          <button
-            className="flex gap-1 p-2 hover:bg-gray-100 rounded"
-            onClick={() => { navigate('/garden/create?deploy=modal-app') }}
-          >
-            <TooltipProvider>
-              <Tooltip delayDuration={100}>
-                <TooltipTrigger>
+          <TooltipProvider>
+            <Tooltip delayDuration={100}>
+              <TooltipTrigger asChild>
+                <button
+                  className="flex gap-1 p-2 hover:bg-gray-100 rounded"
+                  onClick={() => { navigate('/garden/create?deploy=modal-app') }}
+                >
                   <Plus size={24} className="hover:text-green" />
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>Make a Garden</p>
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </button>
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Make a Garden</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
 
 
           {/* Links menu */}

--- a/garden/src/components/shared/metadata/EditableMetadataField.tsx
+++ b/garden/src/components/shared/metadata/EditableMetadataField.tsx
@@ -51,7 +51,7 @@ const EditableMetadataField = ({
   useEffect(() => {
     const newValue = value || (isArray ? [] : "");
     setInputValue(newValue);
-  }, [value, isArray, fieldName]);
+  }, [value, isArray]);
 
 
   const handleSave = async () => {

--- a/garden/src/features/materials/components/ModalAssociatedMaterials.tsx
+++ b/garden/src/features/materials/components/ModalAssociatedMaterials.tsx
@@ -1,8 +1,9 @@
+import React from "react";
 import { ModalFunction, Dataset, Paper, Repository, Notebook } from "@/types";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/shadcn/tabs";
 import { Card, CardContent, CardHeader, CardTitle, MarkdownCardContent } from "@/components/shadcn/card";
 import { DatabaseIcon, BookIcon, CodeIcon, ScrollTextIcon, FileTextIcon, AppWindowIcon, PlusCircle, LucideIcon, FunctionSquare } from "lucide-react";
-import { useModalFunctionMaterials } from "../hooks/useModalFunctionMaterials";
+import { useModalFunctionMaterials } from "@/features/materials";
 import SyntaxHighlighter from "@/components/SyntaxHighlighter";
 import CopyButton from "@/components/CopyButton";
 import { Button } from "@/components/shadcn/button";

--- a/garden/src/features/modal/api/usePatchModalFunction.ts
+++ b/garden/src/features/modal/api/usePatchModalFunction.ts
@@ -21,8 +21,8 @@ export const usePatchModalFunction = () => {
 
       // Snapshot the previous value
       const previousModalFunction = queryClient.getQueryData<ModalFunction>([
-        "modalFunction",
-        id.toString(),
+        "modalFunctions",
+        id,
       ]);
 
       // Optimistically update to the new value
@@ -43,10 +43,10 @@ export const usePatchModalFunction = () => {
         queryClient.setQueryData(["modalFunctions", id], context.previousModalFunction);
       }
     },
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ["modalFunctions", data.id] });
+    onSuccess: async (data) => {
+      await queryClient.invalidateQueries({ queryKey: ["modalFunctions", data.id] });
       // Invalidate all garden queries since we don't know which gardens contain this function
-      queryClient.invalidateQueries({ queryKey: ["gardens"] });
+      await queryClient.invalidateQueries({ queryKey: ["gardens"] });
     },
   });
 };

--- a/garden/src/features/modal/components/ModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/ModalFunctionPage.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useCallback } from "react";
 import { useParams } from "react-router-dom";
 
 import { useGetModalFunction } from "../api/useGetModalFunction";
@@ -90,17 +90,19 @@ const ModalFunctionHeader = ({ modalFunction, gardenDOI, ownsThisFunction }: {
 }) => {
   const { mutateAsync: patchModalFunction } = usePatchModalFunction();
 
+  const handleUpdate = useCallback(async (updateData) => {
+    await patchModalFunction({
+      id: modalFunction.id,
+      modalFunction: updateData
+    });
+  }, [patchModalFunction, modalFunction.id]);
+
   return (
     <div className="mb-3 flex items-center justify-between gap-2">
       <EditableTitle
         entity={modalFunction}
         ownsThisEntity={ownsThisFunction}
-        onUpdate={async (updateData) => {
-          await patchModalFunction({
-            id: modalFunction.id,
-            modalFunction: updateData
-          });
-        }}
+        onUpdate={handleUpdate}
       />
       <div className="flex items-center gap-2">
         <CopyButton
@@ -117,7 +119,14 @@ const ModalFunctionHeader = ({ modalFunction, gardenDOI, ownsThisFunction }: {
 };
 
 const ModalFunctionBody = ({ modalFunction, ownsThisFunction }: { modalFunction: ModalFunction; ownsThisFunction: boolean }) => {
-  const { mutate: patchModalFunction } = usePatchModalFunction();
+  const { mutateAsync: patchModalFunction } = usePatchModalFunction();
+
+  const handleUpdate = useCallback(async (updateData) => {
+    await patchModalFunction({
+      id: modalFunction.id,
+      modalFunction: updateData,
+    });
+  }, [patchModalFunction, modalFunction.id]);
 
   return (
     <div className="space-y-3 py-2">
@@ -127,12 +136,7 @@ const ModalFunctionBody = ({ modalFunction, ownsThisFunction }: { modalFunction:
         fieldName="description"
         entity={modalFunction}
         ownsThisEntity={ownsThisFunction}
-        onUpdate={async (updateData) => {
-          await patchModalFunction({
-            id: modalFunction.id,
-            modalFunction: updateData
-          });
-        }}
+        onUpdate={handleUpdate}
       />
       <Separator className="my-3" />
     </div>
@@ -152,14 +156,14 @@ my_garden = client.get_garden(${doiExpression})
 input = ['Data Here']
 return my_garden.${modalFunction.function_name}(input)`;
 
-  const handleSave = async (newValue: string) => {
+  const handleSave = useCallback(async (newValue: string) => {
     await patchModalFunction({
       id: modalFunction.id,
       modalFunction: {
         example_usage: newValue
       }
     });
-  };
+  }, [patchModalFunction, modalFunction.id]);
 
   return (
     <EditableCodeField

--- a/garden/src/features/modal/components/ModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/ModalFunctionPage.tsx
@@ -90,7 +90,7 @@ const ModalFunctionHeader = ({ modalFunction, gardenDOI, ownsThisFunction }: {
 }) => {
   const { mutateAsync: patchModalFunction } = usePatchModalFunction();
 
-  const handleUpdate = useCallback(async (updateData) => {
+  const handleUpdate = useCallback(async (updateData: ModalFunction) => {
     await patchModalFunction({
       id: modalFunction.id,
       modalFunction: updateData
@@ -121,7 +121,7 @@ const ModalFunctionHeader = ({ modalFunction, gardenDOI, ownsThisFunction }: {
 const ModalFunctionBody = ({ modalFunction, ownsThisFunction }: { modalFunction: ModalFunction; ownsThisFunction: boolean }) => {
   const { mutateAsync: patchModalFunction } = usePatchModalFunction();
 
-  const handleUpdate = useCallback(async (updateData) => {
+  const handleUpdate = useCallback(async (updateData: ModalFunction) => {
     await patchModalFunction({
       id: modalFunction.id,
       modalFunction: updateData,


### PR DESCRIPTION
Resolves: #388 (hopefully)

This PR contains a handful of minor tweaks to component that are likely culprits of the infinite re-render loop when viewing a function page.

- Fix code editor state management (I think this is what was causing the error)
- remove some unused props from various places that could have been triggering unnecessary re-renders
- fix a cache key mismatch in the modal function patch hook
- get rid of the 'nested button' error in the navbar
- memoize some in-line callbacks so they aren't redefined every render
- silence a react-router warning (this wasn't causing an error, but the warning was cluttering my console)

## Testing
Tested a production build locally and could not get the error to surface.