### PR TITLE
Redeployment Flow Update - Issue #348

### DIFF
--- a/garden/src/features/gardens/api/useGetGarden.ts
+++ b/garden/src/features/gardens/api/useGetGarden.ts
@@ -1,3 +1,4 @@
+import React from "react";
 import { Garden } from "@/types";
 import axios from "@/lib/axios";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -6,21 +7,26 @@ const getGarden = async (doi: string): Promise<Garden> => {
   try {
     const response = await axios.get(`/gardens/${doi}`);
     return response.data;
-  } catch (error) {
+  } catch {
     throw new Error("Error fetching garden by DOI");
   }
 };
 
 export const useGetGarden = (doi: string) => {
   const queryClient = useQueryClient();
-  return useQuery<Garden, Error>({
+  const query = useQuery<Garden, Error>({
     queryKey: ["gardens", doi],
     queryFn: () => getGarden(doi),
-    select: (garden) => {
-      garden.modal_functions?.forEach((fn) => {
+  });
+
+  // Cache modal functions when garden data is successfully fetched
+  React.useEffect(() => {
+    if (query.data?.modal_functions) {
+      query.data.modal_functions.forEach((fn) => {
         queryClient.setQueryData(["modalFunctions", fn.id], fn);
       });
-      return garden;
-    },
-  });
+    }
+  }, [query.data, queryClient]);
+
+  return query;
 };

--- a/garden/src/features/gardens/api/useGetGardens.ts
+++ b/garden/src/features/gardens/api/useGetGardens.ts
@@ -1,3 +1,4 @@
+import React from "react";
 import { Garden } from "@/types";
 import axios from "@/lib/axios";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -24,22 +25,25 @@ const getGardens = async (params: GetGardensParams): Promise<Garden[]> => {
 
 export const useGetGardens = (params: GetGardensParams) => {
   const queryClient = useQueryClient();
-  return useQuery<Garden[], Error>({
+  const query = useQuery<Garden[], Error>({
     queryKey: ["gardens", params],
     queryFn: () => getGardens(params),
-    select: (gardens) => {
-      gardens.forEach((garden) => {
+  });
+
+  // Cache gardens and modal functions when gardens are successfully fetched
+  React.useEffect(() => {
+    if (query.data) {
+      query.data.forEach((garden) => {
         queryClient.setQueryData(["gardens", garden.doi], garden);
-      });
-      // gardens currently contain their associated function metadata,
-      // cache them so we can avoid sending requests for functions
-      // we have already seen.
-      gardens.forEach((garden) => {
+        // gardens currently contain their associated function metadata,
+        // cache them so we can avoid sending requests for functions
+        // we have already seen.
         garden.modal_functions?.forEach((fn) => {
           queryClient.setQueryData(["modalFunctions", fn.id], fn);
         });
       });
-      return gardens;
-    },
-  });
+    }
+  }, [query.data, queryClient]);
+
+  return query;
 };

--- a/garden/src/features/gardens/components/garden-page/ModalFunctionManager.tsx
+++ b/garden/src/features/gardens/components/garden-page/ModalFunctionManager.tsx
@@ -155,7 +155,7 @@ const ModalFunctionManager: React.FC<ModalFunctionManagerProps> = ({
   )}
 
       <Dialog open={isDeploymentDialogOpen} onOpenChange={setIsDeploymentDialogOpen}>
-        <DialogContent className="max-w-3xl">
+        <DialogContent className="max-w-2xl">
           <DialogHeader>
             <DialogTitle>Deployments in This Garden</DialogTitle>
           </DialogHeader>

--- a/garden/src/features/gardens/components/garden-page/ModalFunctionManager.tsx
+++ b/garden/src/features/gardens/components/garden-page/ModalFunctionManager.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { PlusCircle } from 'lucide-react';
+import { PlusCircle, ExternalLink, X } from 'lucide-react';
 import { Button } from '@/components/shadcn/button';
 import { Garden } from '@/types';
 import { Checkbox } from '@/components/shadcn/checkbox';
@@ -16,8 +16,9 @@ import { toast } from 'sonner';
 import { useGetUserModalFunctions } from '@/features/modal/api/useGetUserModalFunctions';
 import { usePatchGarden } from '@/features/gardens/api/usePatchGarden';
 import { Link, useNavigate } from 'react-router-dom';
-import { ExternalLink, X } from 'lucide-react';
 import LoadingSpinner from '@/components/LoadingSpinner';
+import { useGetModelDeployments } from '@/features/model-deployments/api/useGetModelDeployments';
+import { useGetUserInfo } from '@/features/users/api/useGetUserInfo';
 
 interface ModalFunctionManagerProps {
   garden: Garden;
@@ -29,6 +30,7 @@ const ModalFunctionManager: React.FC<ModalFunctionManagerProps> = ({
   onSuccess
 }) => {
   const navigate = useNavigate();
+  const { data: currentUser } = useGetUserInfo();
   const modalAppId = garden.modal_functions?.[0]?.modal_app_id;
 
   // Get current function IDs to exclude from the selection
@@ -38,6 +40,7 @@ const ModalFunctionManager: React.FC<ModalFunctionManagerProps> = ({
   const [selectedFunctionIds, setSelectedFunctionIds] = useState<number[]>(currentFunctionIds);
   const [showFullDescriptionIds, setShowFullDescriptionIds] = useState<number[]>([]);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isDeploymentDialogOpen, setIsDeploymentDialogOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [isConfirmClearOpen, setIsConfirmClearOpen] = useState(false);
 
@@ -54,9 +57,11 @@ const ModalFunctionManager: React.FC<ModalFunctionManagerProps> = ({
     refetch,
     isFetching,
     isLoading
-  } = useGetUserModalFunctions({ enabled: isDialogOpen });
+  } = useGetUserModalFunctions();
 
   const { mutateAsync: patchGarden } = usePatchGarden();
+
+  const { data: modelDeployments } = useGetModelDeployments();
 
   // Handle checkbox change
   const handleFunctionToggle = (functionId: number) => {
@@ -107,28 +112,111 @@ const ModalFunctionManager: React.FC<ModalFunctionManagerProps> = ({
     return queryWords.every((word) => haystack.includes(word));
   });
 
+  const deploymentIdsUsedInGarden = new Set(
+      garden.modal_functions?.map(f => f.modal_app_id).filter(Boolean)
+    );
+
+
+  const userOwnedDeployments = modelDeployments?.filter(d =>
+    d.originalData?.owner_identity_id === currentUser?.identity_id && (
+      d.modal_function_ids?.some(fid =>
+        garden.modal_functions?.some(gf => gf.id === fid)
+      ) || deploymentIdsUsedInGarden.has(d.id)
+    )
+  ) || [];
+
+  const shouldShowManageDeploymentsButton = userOwnedDeployments.length > 0;
+
   return (
     <>
-    {isDialogOpen !== undefined && (
+    {(garden.owner_identity_id === currentUser?.identity_id || shouldShowManageDeploymentsButton) && (
     <div className="flex gap-2 mt-2">
-      <Button
-        type="button"
-        variant="outline"
-        onClick={() => setIsDialogOpen(true)}
-      >
-        <PlusCircle className="mr-2 h-4 w-4" />
-        Add/Remove functions
-      </Button>
-
-      <Button
-        type="button"
-        variant="outline"
-        onClick={() => navigate(`/model-deployments/${modalAppId}`)}
-      >
-        Manage Deployment
-      </Button>
+      {garden.owner_identity_id === currentUser?.identity_id && (
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => setIsDialogOpen(true)}
+        >
+          <PlusCircle className="mr-2 h-4 w-4" />
+          Add/Remove Functions
+        </Button>
+      )}
+    
+      {shouldShowManageDeploymentsButton && (
+        <Button
+          type="button"
+          variant="outline"
+          onClick={() => setIsDeploymentDialogOpen(true)}
+        >
+          Manage Deployments
+        </Button>
+      )}
     </div>
-    )}
+  )}
+
+      <Dialog open={isDeploymentDialogOpen} onOpenChange={setIsDeploymentDialogOpen}>
+        <DialogContent className="max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>Deployments in This Garden</DialogTitle>
+          </DialogHeader>
+
+          <div className="mb-2 text-sm text-gray-500">
+            These are the model deployments currently used in this garden. You can click to view details or open your full deployments tab.
+          </div>
+
+          <div className="flex justify-end mt-4">
+            <Button
+              type="button"
+              onClick={() => navigate("/user?tab=model-deployments")}
+            >
+              View All Deployments
+            </Button>
+          </div>
+
+          {userOwnedDeployments.length === 0 ? (
+            <div className="text-sm text-gray-500 mt-4">No deployments you own are used in this garden.</div>
+          ) : (
+            <div className="relative mb-4 rounded-md border bg-white mt-4">
+              <div className="max-h-[420px] overflow-y-auto">
+                <Table>
+                  <TableHeader className="sticky top-0 bg-white z-10">
+                    <TableRow>
+                      <TableHead className="w-2/3">Deployment Name</TableHead>
+                      <TableHead className="w-1/3 text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {userOwnedDeployments.map((deployment) => (
+                      <TableRow 
+                        key={deployment.id}
+                        onClick={() => navigate(`/model-deployments/${deployment.id}`)}
+                        className="group cursor-pointer transition-all duration-200 ease-in-out hover:bg-[#eef5f1] border-y border-transparent hover:border-[#4FA86C]"
+                      >
+                        <TableCell className="text-[#1f3d2d font-semibold]">{deployment.name}</TableCell>
+                        <TableCell className="text-right">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="group-hover:bg-[#4FA86C] group-hover:text-white transition"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              navigate(`/model-deployments/${deployment.id}`)
+                            }}
+                          >
+                            View
+                            <ExternalLink size={14} className="mb-0.5 ml-1" />
+                          </Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </div>
+          )}
+
+        </DialogContent>
+      </Dialog>
 
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <DialogContent className="max-w-3xl">

--- a/garden/src/features/gardens/components/garden-page/ModalFunctionManager.tsx
+++ b/garden/src/features/gardens/components/garden-page/ModalFunctionManager.tsx
@@ -15,7 +15,7 @@ import {
 import { toast } from 'sonner';
 import { useGetUserModalFunctions } from '@/features/modal/api/useGetUserModalFunctions';
 import { usePatchGarden } from '@/features/gardens/api/usePatchGarden';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { ExternalLink, X } from 'lucide-react';
 import LoadingSpinner from '@/components/LoadingSpinner';
 
@@ -28,6 +28,9 @@ const ModalFunctionManager: React.FC<ModalFunctionManagerProps> = ({
   garden,
   onSuccess
 }) => {
+  const navigate = useNavigate();
+  const modalAppId = garden.modal_functions?.[0]?.modal_app_id;
+
   // Get current function IDs to exclude from the selection
   const currentFunctionIds = garden.modal_functions?.map(f => f.id) || [];
 
@@ -106,6 +109,8 @@ const ModalFunctionManager: React.FC<ModalFunctionManagerProps> = ({
 
   return (
     <>
+    {isDialogOpen !== undefined && (
+    <div className="flex gap-2 mt-2">
       <Button
         type="button"
         variant="outline"
@@ -114,6 +119,16 @@ const ModalFunctionManager: React.FC<ModalFunctionManagerProps> = ({
         <PlusCircle className="mr-2 h-4 w-4" />
         Add/Remove functions
       </Button>
+
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() => navigate(`/model-deployments/${modalAppId}`)}
+      >
+        Manage Deployment
+      </Button>
+    </div>
+    )}
 
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <DialogContent className="max-w-3xl">

--- a/garden/src/features/modal/api/useGetUserModalFunctions.tsx
+++ b/garden/src/features/modal/api/useGetUserModalFunctions.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "@/lib/axios";
 import { ModalFunction } from "@/types";
@@ -18,8 +19,9 @@ export const useGetUserModalFunctions = (options: UseGetUserModalFunctionsOption
   const auth = useGlobusAuth();
   const userUuid = auth?.authorization?.user?.sub;
   const queryClient = useQueryClient();
+
   // Fetch the user's modal apps and their functions
-  return useQuery<ModalFunction[]>({
+  const query = useQuery<ModalFunction[]>({
     queryKey: ["userModalFunctions", userUuid, excludeFunctionIds],
     queryFn: async () => {
       // Get all modal functions for the user
@@ -36,13 +38,18 @@ export const useGetUserModalFunctions = (options: UseGetUserModalFunctionsOption
 
       return allFunctions;
     },
-    select: (allFunctions) => {
-      allFunctions.forEach((fn) => {
-        queryClient.setQueryData(["modalFunctions", fn.id], fn);
-      });
-      return allFunctions;
-    },
     enabled: enabled && !!userUuid,
     staleTime: 5 * 60 * 1000, // Cache for 5 minutes
   });
+
+  // Cache modal functions when user functions are successfully fetched
+  React.useEffect(() => {
+    if (query.data) {
+      query.data.forEach((fn) => {
+        queryClient.setQueryData(["modalFunctions", fn.id], fn);
+      });
+    }
+  }, [query.data, queryClient]);
+
+  return query;
 };

--- a/garden/src/features/model-deployments/ModelDeployments.tsx
+++ b/garden/src/features/model-deployments/ModelDeployments.tsx
@@ -1,18 +1,21 @@
-import React from "react";
-import { ColumnDef } from "@tanstack/react-table";
-import { StatusHeader } from "@/features/model-deployments/StatusHeader";
-import { ModelDeploymentsTable } from "@/features/model-deployments/ModelDeploymentsTable";
+import React, { useState } from "react";
 import { Button } from "@/components/shadcn/button";
 import { useNavigate } from "react-router-dom";
 import { Plus } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/tooltip";
 import { useGetModelDeployments } from "./api/useGetModelDeployments";
 import { LoadingOverlay } from "@/components/LoadingOverlay";
+import { Input } from "@/components/shadcn/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/shadcn/select";
+import { StatusHeader } from "./StatusHeader";
 
 export interface ModelDeployment {
+    id: number,
     name: string,
     status: "deployed" | "undeployed" | "error",
     type: "Modal App" | "GCMU",
+    modal_function_ids?: number[],
+    updated_at?: string,
     originalData: any, // Will be either ModalAppMetadataResponse or future GCMU type
 }
 
@@ -22,55 +25,68 @@ const statusColors = {
     error: 'bg-red-100 text-red-800',
 };
 
-export const columns: ColumnDef<ModelDeployment>[] = [
-    {
-        accessorKey: 'status',
-        header: () => {
-            return (<StatusHeader
-                colors={statusColors}
-            />);
-        },
-        cell: ({ row }) => {
-            const status = row.getValue('status') as ModelDeployment['status'];
-            const colorClass = statusColors[status];
-            return (
-                <span className={`px-2 py-1 rounded-full text-xs font-medium ${colorClass}`}>
-                    {status.charAt(0).toUpperCase() + status.slice(1)}
-                </span>
-            );
-        },
-    },
-    {
-        accessorKey: "name",
-        header: "Name",
-    },
-    {
-        accessorKey: "type",
-        header: "Type",
-    },
-];
-
 export const ModelDeployments = () => {
     const navigate = useNavigate();
     const { data: modelDeployments, isLoading } = useGetModelDeployments();
 
+    const [searchTerm, setSearchTerm] = useState("");
+    const [statusFilter, setStatusFilter] = useState<"all" | "deployed" | "undeployed" | "error">("all");
+
     const handleCreateDeployment = () => {
         navigate("/modal-app/create");
     };
+
+    const handleOpenDeployment = (deployment: ModelDeployment) => {
+        const modalAppId = deployment.originalData?.id;
+        navigate(`/model-deployments/${modalAppId}`);
+    };
+
+    const filteredDeployments = modelDeployments?.filter((deployment) => {
+        const queryWords = searchTerm.toLowerCase().split(/\s+/).filter(Boolean);
+        const haystack = `${deployment.name ?? ''} ${deployment.type ?? ''}`.toLowerCase();
+        const matchesSearch = queryWords.every((word) => haystack.includes(word));
+        const matchesStatus = statusFilter === "all" || deployment.status === statusFilter;
+        return matchesSearch && matchesStatus;
+    });
 
     if (isLoading) {
         return <LoadingOverlay />;
     }
 
     return (
-        <div>
-            <div className="flex justify-end">
+        <div className="space-y-6">
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+                <div className="flex flex-1 gap-3 flex-wrap sm:flex-nowrap items-stretch">
+                    <Input
+                        placeholder="Search deployments..."
+                        value={searchTerm}
+                        onChange={(e) => setSearchTerm(e.target.value)}
+                        className="flex-grow"
+                    />
+                    <div className="w-full sm:w-auto">
+                        <Select value={statusFilter} onValueChange={(val) => setStatusFilter(val as typeof statusFilter)}>
+                            <SelectTrigger className="h-10">
+                                <SelectValue placeholder="Filter by status" />
+                            </SelectTrigger>
+                            <SelectContent>
+                                <SelectItem value="all">All</SelectItem>
+                                <SelectItem value="deployed">Deployed</SelectItem>
+                                <SelectItem value="undeployed">Undeployed</SelectItem>
+                                <SelectItem value ="error">Error</SelectItem>
+                            </SelectContent>
+                        </Select>
+                    </div>
+                </div>
+
                 <TooltipProvider>
                     <Tooltip delayDuration={100}>
                         <TooltipTrigger asChild>
-                            <Button onClick={handleCreateDeployment} size={"sm"} variant={"outline"} aria-description="Create a new model deployment">
-                                <Plus></Plus>
-                            </Button>
+                            <div className="h-10">
+                                <Button onClick={handleCreateDeployment} size={"sm"} variant={"outline"} className="h-full" aria-description="Create a new model deployment">
+                                    <Plus className="mr-1 h-4 w-4"/>
+                                    New Deployment
+                                </Button>
+                            </div>
                         </TooltipTrigger>
                         <TooltipContent>
                             <p>Create a new Deployment</p>
@@ -78,7 +94,57 @@ export const ModelDeployments = () => {
                     </Tooltip>
                 </TooltipProvider>
             </div>
-            <ModelDeploymentsTable columns={columns} data={modelDeployments || []} />
+
+            <div className="text-muted-foreground text-sm mt-1 ml-1">
+                <StatusHeader colors={statusColors} />
+            </div>
+
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+                {filteredDeployments?.map((deployment) => {
+                    const functionCount = deployment.originalData?.modal_function_ids?.length ?? 0;
+                    const status = deployment.status;
+                    const statusClass = statusColors[status];
+
+                    return (
+                        <div 
+                            key={deployment.id}
+                            onClick={() => handleOpenDeployment(deployment)}
+                            className="w-full cursor-pointer rounded-xl border border-[#d6e9dd] bg-white hover:shadow-lg hover:ring-2 hover:ring-[#a5d6b1] transition px-5 py-4 flex flex-col gap-4 sm:flex-row sm:items-center justify-between"
+                        >
+                            <div className="flex flex-col gap-1 w-full">
+                                <div className="flex items-center gap-3 flex-wrap">
+                                    <h3 className="text-base font-semibold text-[#1f3d2d]">{deployment.name}</h3>
+                                    <span className={`px-2 py-1 rounded-full text-xs font-medium ${statusClass}`}>
+                                        {status.charAt(0).toUpperCase() + status.slice(1)}
+                                    </span>
+                                </div>
+                                <div className="flex flex-wrap text-sm mt-2 gap-x-4 gap-y-1 text-muted-foreground">
+                                    <span className="bg-gray-100 px-2 py-0.5 rounded-full">{deployment.type}</span>
+                                    <span className="bg-gray-100 px-2 py-0.5 rounded-full">{functionCount} function{functionCount != 1 ? "s" : ""}</span>
+                                </div>
+                            </div>
+                            
+                            <Button
+                                size="sm"
+                                variant="secondary"
+                                className="hover:bg-primary hover:text-white transition"
+                                onClick={(e) => {
+                                    e.stopPropagation();
+                                    handleOpenDeployment(deployment);
+                                }}
+                            >
+                                Manage
+                            </Button>
+                        </div>
+                    );
+                })}
+                {filteredDeployments?.length === 0 && (
+                    <div className="col-span-full text-center text-sm text-gray-500 pt-8">
+                        No deployments match your search.
+                    </div>
+                )}
+            </div>
         </div>
     )
 }

--- a/garden/src/features/model-deployments/api/useGetModelDeployments.ts
+++ b/garden/src/features/model-deployments/api/useGetModelDeployments.ts
@@ -11,6 +11,7 @@ const getModelDeployments = async (): Promise<ModelDeployment[]> => {
     // TODO get GCMU deployments once they exist, combine them with modal apps
     return modalAppsResponse.data.map((ma: ModalAppResponse) => {
         return {
+            id: ma.id ?? -1,
             name: ma.original_app_name || ma.app_name,
             status: ma.deploy_status === "done" ? "deployed" :
                 ma.deploy_status === "error" ? "error" :

--- a/garden/src/features/search/api/useSearchGardens.ts
+++ b/garden/src/features/search/api/useSearchGardens.ts
@@ -1,3 +1,4 @@
+import React from "react";
 import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Garden, GardenSearchFilter, GardenSearchRequest, GardenSearchResponse } from "@/types";
 import axios from "@/lib/axios";
@@ -13,7 +14,7 @@ const searchGardens = async (searchOptions: GardenSearchRequest): Promise<Garden
 
 export const useSearchGardens = (searchOptions: GardenSearchRequest) => {
   const queryClient = useQueryClient();
-  return useQuery<GardenSearchResponse, Error>({
+  const query = useQuery<GardenSearchResponse, Error>({
     queryKey: [
       "gardens",
       "search",
@@ -25,18 +26,21 @@ export const useSearchGardens = (searchOptions: GardenSearchRequest) => {
     ],
     queryFn: async () => searchGardens(searchOptions),
     placeholderData: keepPreviousData,
-    select: (searchResults) => {
-      searchResults.garden_meta.forEach((garden) => {
+  });
+
+  // Cache gardens and modal functions when search results are successfully fetched
+  React.useEffect(() => {
+    if (query.data?.garden_meta) {
+      query.data.garden_meta.forEach((garden) => {
         queryClient.setQueryData(["gardens", garden.doi], garden);
-      });
-      searchResults.garden_meta.forEach((garden) => {
         garden.modal_functions?.forEach((fn) => {
           queryClient.setQueryData(["modalFunctions", fn.id], fn);
         });
       });
-      return searchResults;
-    },
-  });
+    }
+  }, [query.data, queryClient]);
+
+  return query;
 };
 
 export const transformSearchResultToGardens = (searchResult?: GardenSearchResponse): Garden[] => {

--- a/garden/src/features/users/components/UserProfilePage.tsx
+++ b/garden/src/features/users/components/UserProfilePage.tsx
@@ -26,7 +26,7 @@ const UserProfilePage = () => {
   return (
     <div className="mt-16 flex h-full min-h-[80vh] w-full flex-row justify-center gap-10 p-10">
       <UserProfileCard />
-      <UserProfileTabs defaultTab={tab || undefined} />
+      <UserProfileTabs defaultTab="profile" />
     </div>
   );
 };

--- a/garden/src/features/users/components/UserProfileTabs.tsx
+++ b/garden/src/features/users/components/UserProfileTabs.tsx
@@ -9,22 +9,40 @@ import { ModelDeployments } from "@/features/model-deployments/ModelDeployments"
 const TABS = ["profile", "my-gardens", "saved-gardens", "model-deployments"] as const;
 type TabKey = (typeof TABS)[number];
 
-const UserProfileTabs = () => {
+type UserProfileTabsProps = {
+  defaultTab?: TabKey;
+};
+
+const UserProfileTabs = ({ defaultTab }: UserProfileTabsProps) => {
   const location = useLocation();
   const navigate = useNavigate();
-
   const params = new URLSearchParams(location.search);
   const queryTab = params.get("tab");
 
-  const activeTab: TabKey = TABS.includes(queryTab as TabKey) ? (queryTab as TabKey) : "profile";
+  const resolveTab = (): TabKey => {
+    if (queryTab && TABS.includes(queryTab as TabKey)) return queryTab as TabKey;
+    if (defaultTab && TABS.includes(defaultTab)) return defaultTab;
+    return "profile";
+  };
+
+  const [currentTab, setCurrentTab] = React.useState<TabKey>(resolveTab)
+
+  React.useEffect(() => {
+    const urlTab = params.get("tab");
+    if (urlTab && TABS.includes(urlTab as TabKey) && urlTab !== currentTab) {
+      setCurrentTab(urlTab as TabKey);
+    }
+  }, [location.search]);
 
   const handleTabChange = (newTab: string) => {
-    params.set("tab", newTab);
+    const newTabKey = newTab as TabKey;
+    setCurrentTab(newTabKey);
+    params.set("tab", newTabKey);
     navigate({ search: params.toString() }, { replace: true });
   };
 
   return (
-    <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full font-display">
+    <Tabs value={currentTab} onValueChange={handleTabChange} className="w-full font-display">
       <TabsList className="h-12 w-full bg-transparent">
         <TabsTrigger
           value="profile"
@@ -51,6 +69,7 @@ const UserProfileTabs = () => {
           Model Deployments
         </TabsTrigger>
       </TabsList>
+
       <div className="min-h-[60vh] flex-grow overflow-auto pt-4 sm:pt-8">
         <TabsContent value="profile">
           <div className="flex w-full justify-center">

--- a/garden/src/features/users/components/UserProfileTabs.tsx
+++ b/garden/src/features/users/components/UserProfileTabs.tsx
@@ -1,17 +1,30 @@
 import React from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/shadcn/tabs";
 import UserProfileInfo from "./UserProfileInfo";
 import MyGardens from "./MyGardens";
 import SavedGardens from "./SavedGardens";
 import { ModelDeployments } from "@/features/model-deployments/ModelDeployments";
 
-interface UserProfileTabsProps {
-  defaultTab?: "profile" | "my-gardens" | "saved-gardens" | "model-deployments";
-}
+const TABS = ["profile", "my-gardens", "saved-gardens", "model-deployments"] as const;
+type TabKey = (typeof TABS)[number];
 
-const UserProfileTabs = ({ defaultTab = "profile" }: UserProfileTabsProps) => {
+const UserProfileTabs = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const params = new URLSearchParams(location.search);
+  const queryTab = params.get("tab");
+
+  const activeTab: TabKey = TABS.includes(queryTab as TabKey) ? (queryTab as TabKey) : "profile";
+
+  const handleTabChange = (newTab: string) => {
+    params.set("tab", newTab);
+    navigate({ search: params.toString() }, { replace: true });
+  };
+
   return (
-    <Tabs defaultValue={defaultTab} className="w-full font-display">
+    <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full font-display">
       <TabsList className="h-12 w-full bg-transparent">
         <TabsTrigger
           value="profile"

--- a/garden/src/utils/utils.ts
+++ b/garden/src/utils/utils.ts
@@ -2,5 +2,5 @@ export const SUPER_USERS: string[] = [
     "c8741264-d274-11e5-bee7-f30dff9f1ea8", // Ben
     "6c9e223f-c215-4c26-9abb-262dbce0001c", // Will
     "76024960-c68b-4fec-8cb8-b65b096f18da", // Owen
-    "e9a17e09-657b-4087-a719-241ab72b1d9b", // Hayden
+    "1edf904a-6f76-4a14-8851-d3c55ee0f037", // Hayden
 ];


### PR DESCRIPTION
## Redeployment Flow Update
### Resolves #348 
---
- Edited `ModalFunctionManager.tsx` to conditionally render a "Manage Deployments" button within the function view of a garden page that displays a dialog box to connect the user to each valid deployment and navigates the user directly to the model's deployment page or their Model Deployments tab within their profile.
- Edited `UserProfileTabs.tsx` to implement updated profile tab logic to allow the user to navigate directly to their Model Deployments tab.
- Edited `UserProfilePage.tsx` to pass the updated tab logic.
- Edited `ModelDeployments.tsx` to remove the table view of current deployments, to implement an interactive card view for deployments, to add a search bar with search functionality, to add a filtering selection based on deployment status,  and to add text to the "New Deployment" button.
- Edited `useGetModelDeployments.ts` to add an `id` to each returned deployment object to align with the `ModelDeployment` type and resolve a type error in `ModelDeployments.tsx`.
---
### Originally, the process for a user to redeploy a Modal app was buried and not accessible in a natural way. There was no direction from within the garden page, as the deployment could only be accessed through the user's profile page, and under the Model Deployments tab.
![image](https://github.com/user-attachments/assets/99caf80a-f499-4d57-b350-9cf46a47520d)
### From there, the table view did not appear to be interactive and clickable, which would then finally lead the user to the model deployment page.
![image](https://github.com/user-attachments/assets/1024dce0-7d53-4deb-9a37-c3b0af768d7b)
---
### Added a "Manage Deployments" button within the garden's function view to help the user easily navigate directly to the model's deployment page or to their Model Deployments tab within their profile.
![image](https://github.com/user-attachments/assets/137663cc-0d27-42bc-af8f-2932635d5eec)
### The "Manage Deployments" dialog box lists every deployment within the garden that is owned by the user, as well as a "View All Deployments" button that navigates the user directly to their Model Deployments tab on their profile.
![image](https://github.com/user-attachments/assets/18307e90-3983-44a9-9829-5033a45618ad)
### Implemented an interactive card view that displays the model type and function count, as well as a "Manage" button to convey that the deployment cards are clickable. 
### Added a search bar with search functionality, regardless of typed order or spaces, to help the user find specific deployments.
### Added text to the "New Deployment" button for improved clarity.
![image](https://github.com/user-attachments/assets/cdfccfa2-e2e7-40d5-a182-1c71f8ca10d0)
### Added a filtered selection list of deployments based on their current status.
![image](https://github.com/user-attachments/assets/9c840ed0-1a25-4697-88ed-4c973d17d2d2)
### Arranged the "Status" tooltip to be present and clarify the meaning of each status.
![image](https://github.com/user-attachments/assets/b3709825-f827-4a54-9178-0efb5c92b906)
### Implemented a no-results message based on filtered and searched user input.
![image](https://github.com/user-attachments/assets/089c62e2-8040-4876-ab2e-e4d28544289b)
---
## Known Gaps & Future Work
- While I believe an additional tag for each deployment card that displayed when it was last updated would be informative and helpful for additional sorting, there is not currently a field within the backend that tracks these dates. Upon updating, we can look into easily adding the data within the cards and include a sorting option that allows users to show recently updated deployments!