### PR TITLE
fix: function page loading error

### DIFF
--- a/garden/src/features/gardens/api/useGetGarden.ts
+++ b/garden/src/features/gardens/api/useGetGarden.ts
@@ -1,3 +1,4 @@
+import React from "react";
 import { Garden } from "@/types";
 import axios from "@/lib/axios";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -6,21 +7,26 @@ const getGarden = async (doi: string): Promise<Garden> => {
   try {
     const response = await axios.get(`/gardens/${doi}`);
     return response.data;
-  } catch (error) {
+  } catch {
     throw new Error("Error fetching garden by DOI");
   }
 };
 
 export const useGetGarden = (doi: string) => {
   const queryClient = useQueryClient();
-  return useQuery<Garden, Error>({
+  const query = useQuery<Garden, Error>({
     queryKey: ["gardens", doi],
     queryFn: () => getGarden(doi),
-    select: (garden) => {
-      garden.modal_functions?.forEach((fn) => {
+  });
+
+  // Cache modal functions when garden data is successfully fetched
+  React.useEffect(() => {
+    if (query.data?.modal_functions) {
+      query.data.modal_functions.forEach((fn) => {
         queryClient.setQueryData(["modalFunctions", fn.id], fn);
       });
-      return garden;
-    },
-  });
+    }
+  }, [query.data, queryClient]);
+
+  return query;
 };

--- a/garden/src/features/gardens/api/useGetGardens.ts
+++ b/garden/src/features/gardens/api/useGetGardens.ts
@@ -1,3 +1,4 @@
+import React from "react";
 import { Garden } from "@/types";
 import axios from "@/lib/axios";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -24,22 +25,25 @@ const getGardens = async (params: GetGardensParams): Promise<Garden[]> => {
 
 export const useGetGardens = (params: GetGardensParams) => {
   const queryClient = useQueryClient();
-  return useQuery<Garden[], Error>({
+  const query = useQuery<Garden[], Error>({
     queryKey: ["gardens", params],
     queryFn: () => getGardens(params),
-    select: (gardens) => {
-      gardens.forEach((garden) => {
+  });
+
+  // Cache gardens and modal functions when gardens are successfully fetched
+  React.useEffect(() => {
+    if (query.data) {
+      query.data.forEach((garden) => {
         queryClient.setQueryData(["gardens", garden.doi], garden);
-      });
-      // gardens currently contain their associated function metadata,
-      // cache them so we can avoid sending requests for functions
-      // we have already seen.
-      gardens.forEach((garden) => {
+        // gardens currently contain their associated function metadata,
+        // cache them so we can avoid sending requests for functions
+        // we have already seen.
         garden.modal_functions?.forEach((fn) => {
           queryClient.setQueryData(["modalFunctions", fn.id], fn);
         });
       });
-      return gardens;
-    },
-  });
+    }
+  }, [query.data, queryClient]);
+
+  return query;
 };

--- a/garden/src/features/modal/api/useGetUserModalFunctions.tsx
+++ b/garden/src/features/modal/api/useGetUserModalFunctions.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "@/lib/axios";
 import { ModalFunction } from "@/types";
@@ -18,8 +19,9 @@ export const useGetUserModalFunctions = (options: UseGetUserModalFunctionsOption
   const auth = useGlobusAuth();
   const userUuid = auth?.authorization?.user?.sub;
   const queryClient = useQueryClient();
+
   // Fetch the user's modal apps and their functions
-  return useQuery<ModalFunction[]>({
+  const query = useQuery<ModalFunction[]>({
     queryKey: ["userModalFunctions", userUuid, excludeFunctionIds],
     queryFn: async () => {
       // Get all modal functions for the user
@@ -36,13 +38,18 @@ export const useGetUserModalFunctions = (options: UseGetUserModalFunctionsOption
 
       return allFunctions;
     },
-    select: (allFunctions) => {
-      allFunctions.forEach((fn) => {
-        queryClient.setQueryData(["modalFunctions", fn.id], fn);
-      });
-      return allFunctions;
-    },
     enabled: enabled && !!userUuid,
     staleTime: 5 * 60 * 1000, // Cache for 5 minutes
   });
+
+  // Cache modal functions when user functions are successfully fetched
+  React.useEffect(() => {
+    if (query.data) {
+      query.data.forEach((fn) => {
+        queryClient.setQueryData(["modalFunctions", fn.id], fn);
+      });
+    }
+  }, [query.data, queryClient]);
+
+  return query;
 };

--- a/garden/src/features/search/api/useSearchGardens.ts
+++ b/garden/src/features/search/api/useSearchGardens.ts
@@ -1,3 +1,4 @@
+import React from "react";
 import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Garden, GardenSearchFilter, GardenSearchRequest, GardenSearchResponse } from "@/types";
 import axios from "@/lib/axios";
@@ -13,7 +14,7 @@ const searchGardens = async (searchOptions: GardenSearchRequest): Promise<Garden
 
 export const useSearchGardens = (searchOptions: GardenSearchRequest) => {
   const queryClient = useQueryClient();
-  return useQuery<GardenSearchResponse, Error>({
+  const query = useQuery<GardenSearchResponse, Error>({
     queryKey: [
       "gardens",
       "search",
@@ -25,18 +26,21 @@ export const useSearchGardens = (searchOptions: GardenSearchRequest) => {
     ],
     queryFn: async () => searchGardens(searchOptions),
     placeholderData: keepPreviousData,
-    select: (searchResults) => {
-      searchResults.garden_meta.forEach((garden) => {
+  });
+
+  // Cache gardens and modal functions when search results are successfully fetched
+  React.useEffect(() => {
+    if (query.data?.garden_meta) {
+      query.data.garden_meta.forEach((garden) => {
         queryClient.setQueryData(["gardens", garden.doi], garden);
-      });
-      searchResults.garden_meta.forEach((garden) => {
         garden.modal_functions?.forEach((fn) => {
           queryClient.setQueryData(["modalFunctions", fn.id], fn);
         });
       });
-      return searchResults;
-    },
-  });
+    }
+  }, [query.data, queryClient]);
+
+  return query;
 };
 
 export const transformSearchResultToGardens = (searchResult?: GardenSearchResponse): Garden[] => {


### PR DESCRIPTION
Resolves: #388 

This PR finally fixes the infinite render bug on function pages!

**TLDR**: I was misusing a callback that triggers side-effects that would cause the page to re-render, which would call the callback again, triggering the side-effect again, repeat until react noticed. 

## Details
It was a subtle issue with the caching strategy used to populate the cache of modal functions when fetching a garden. In `useGetGardens` (and other related hooks) I was using the `select` callback to populate the cache with all of the modal functions in a garden:

```ts
export const useGetGardens = (params: GetGardensParams) => {
  const queryClient = useQueryClient();
  return useQuery<Garden[], Error>({
    queryKey: ["gardens", params],
    queryFn: () => getGardens(params),
    select: (gardens) => {
      gardens.forEach((garden) => {
        queryClient.setQueryData(["gardens", garden.doi], garden);
      });
      gardens.forEach((garden) => {
        garden.modal_functions?.forEach((fn) => {
          queryClient.setQueryData(["modalFunctions", fn.id], fn);
        });
      });
      return gardens;
    },
  });
}
```

Here is the flow that causes an error in this setup:
  - Step 1: The page component renders, useGetGarden hook runs
  - Step 2: React Query calls the select function with the garden data
  - Step 3: Inside select, queryClient.setQueryData() updates the cache for modal functions
  - Step 4: Cache updates trigger React Query to notify all components using those queries
  - Step 5: Components re-render because their query data changed
  - Step 6: Re-render causes useGetGarden to run again (back to Step 1)
  - Step 7: Process repeats indefinitely until React detects the loop and throws the error we see


**The Fix**
Move the cache updates out of the `select` callback into a `useEffect` callback which doesn't trigger the re-renders.

```ts
export const useGetGardens = (params: GetGardensParams) => {
  const queryClient = useQueryClient();
  const query = useQuery<Garden[], Error>({
    queryKey: ["gardens", params],
    queryFn: () => getGardens(params),
  });

  // Cache gardens and modal functions when gardens are successfully fetched
  React.useEffect(() => {
    if (query.data) {
      query.data.forEach((garden) => {
        queryClient.setQueryData(["gardens", garden.doi], garden);
        // gardens currently contain their associated function metadata,
        // cache them so we can avoid sending requests for functions
        // we have already seen.
        garden.modal_functions?.forEach((fn) => {
          queryClient.setQueryData(["modalFunctions", fn.id], fn);
        });
      });
    }
  }, [query.data, queryClient]);

  return query;
};
```

This was a subtle but critical misuse of the 'select' callback which I now know is meant to be a pure function and should not be used to alter the state of the application.

# Testing
Interestingly, the only way I could reliably get this error to show up in my local environment was running a production build and clicking around the site using Safari. For reasons I do not understand the error is much more rare in Firefox and Chrome. 

I was able to get the error to trigger consistently in Safari, after making these tweaks, no more errors! Let's hope this is the last time I declare this bug fixed!