### PR TITLE
fix: garden page error when navigating directly to a garden page

### DIFF
--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -126,6 +126,10 @@ const GardenPage = () => {
   const auth = useGlobusAuth();
   const { data: garden, isLoading, isError, refetch } = useGetGarden(doi || '');
 
+  const memoizedRefetch = React.useCallback(async () => {
+    await refetch();
+  }, [refetch]);
+
   if (isLoading) {
     return <LoadingOverlay />;
   }
@@ -139,10 +143,6 @@ const GardenPage = () => {
 
   const isSuperUser = SUPER_USERS.includes(auth?.authorization?.user?.sub)
   const ownsThisGarden = auth?.isAuthenticated && (garden.owner_identity_id === auth?.authorization?.user?.sub || isSuperUser);
-
-  const memoizedRefetch = React.useCallback(async () => {
-    await refetch();
-  }, [refetch]);
 
   return (
     <MaterialsProvider garden={garden} refetchGarden={memoizedRefetch}>


### PR DESCRIPTION
Resolves: #399 

This PR fixes the issue Ben found that arises when navigating directly to a garden page.

The issue was a hook being called after some conditional statements that can cause the component to render loading or not found pages. This violated a rule of react: Hooks must be called in the same order on each render.

The fix: move all hook calls to above the conditional rendering logic.