### PR TITLE
Function Selection Component Update - Issues #337, #385, #395

### DIFF
--- a/garden/src/features/gardens/components/create/CreateGardenFormFields.tsx
+++ b/garden/src/features/gardens/components/create/CreateGardenFormFields.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useMemo, useCallback } from "react";
 import { UseFormReturn, useFormContext } from "react-hook-form";
 
 import { ChevronDown, ChevronUp } from "lucide-react";
@@ -21,10 +21,12 @@ import {
   CollapsibleTrigger
 } from "@/components/shadcn/collapsible";
 
-import { SelectModalFunctionsTable } from "../SelectModalFunctionsTable";
 import { GardenCreateFormData } from "../../types/garden.types";
 import { tagOptions } from "../../utils/garden.utils";
-import { useState } from "react";
+import FunctionSelectionTable from "@/features/modal/components/FunctionSelectionTable";
+import { useGetAllModalFunctions } from "@/features/modal/api/useGetAllModalFunctions";
+import { Controller } from "react-hook-form";
+import { toast } from "sonner";
 
 export const CreateGardenFormFields = () => {
   const form = useFormContext() as UseFormReturn<GardenCreateFormData>;
@@ -41,6 +43,20 @@ export const CreateGardenFormFields = () => {
   const isPublished = form.watch("doi_is_draft") === false && form.watch("is_archived") === false;
 
   const [funcitonTableExpanded, setFunctiontableExpanded] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const handleSearchChange = useCallback(
+    (value:string) => setSearchQuery(value),
+    []
+  );
+  
+  const { data: modalFunctions, isLoading, isFetching } = useGetAllModalFunctions();
+
+  const filteredFunctions= useMemo(() => {
+    if (!modalFunctions || !Array.isArray(modalFunctions)) return [];
+    if (!modalAppFunctionIds || modalAppFunctionIds.length === 0) return modalFunctions;
+    return modalFunctions.filter((f) => !modalAppFunctionIds.includes(f.id));
+  }, [modalFunctions, modalAppFunctionIds]);
 
   return (
     <div className="space-y-12">
@@ -158,7 +174,7 @@ export const CreateGardenFormFields = () => {
       <div className="space-y-8">
         <Collapsible className="w-full space-y-4">
           <CollapsibleTrigger asChild>
-            <Button variant="ghost" className="p-1 w-full h-16" onClick={() => { setFunctiontableExpanded(!funcitonTableExpanded) }}>
+            <Button variant="ghost" className="p-1 w-full h-16" onClick={() => setFunctiontableExpanded((prev) => !prev)}>
               <div className="flex items-center justify-between w-full">
                 <div className="m-4">
                   <div className="flex flex-col items-start">
@@ -174,10 +190,54 @@ export const CreateGardenFormFields = () => {
             </Button>
           </CollapsibleTrigger>
           <CollapsibleContent className="mt-4">
-            <SelectModalFunctionsTable
-              currentFunctionIds={modalAppFunctionIds}
-              published={isPublished}
-            />
+          <Controller
+            control={form.control}
+            name="modal_function_ids"
+            render={({ field }) => (
+              <FunctionSelectionTable
+                functions={filteredFunctions}
+                selectedFunctionIds={field.value ?? []}
+                onSelectionChange={field.onChange}
+                isLoading={isLoading}
+                isFetching={isFetching}
+                searchQuery={searchQuery}
+                onSearchChange={handleSearchChange}
+                showSelectedChips={true}
+                showClearAllButton={true}
+                showSearch={true}
+                maxHeight="420px"
+                className="mt-2"
+                onFunctionAdded={(functionId, authorIds) => {
+                  if (!authorIds || authorIds.length === 0) {
+                    toast.warning("This function has no authors defined");
+                    return;
+                  }
+
+                  const current = form.getValues("authors") || [];
+                  const updated = Array.from(new Set([...current, ...authorIds]));
+                  form.setValue("authors", updated);
+                }}
+                onFunctionRemoved={(functionId) => {
+                  const currentAuthors = form.getValues("authors") || [];
+
+                  const removedFunc = filteredFunctions.find(f => f.id === functionId);
+                  const removedAuthorIds = removedFunc?.authors ?? [];
+
+                  const stillSelectedFunctions = filteredFunctions.filter(f =>
+                    f.id !== functionId && field.value.includes(f.id)
+                  );
+
+                  const remainingAuthorIds = new Set<string>();
+                  stillSelectedFunctions.forEach(f => {
+                    (f.authors ?? []).forEach(id => remainingAuthorIds.add(id));
+                  });
+
+                  const updatedAuthors = currentAuthors.filter(id => remainingAuthorIds.has(id));
+                  form.setValue("authors", updatedAuthors);
+                }}
+              />
+            )}
+          />
           </CollapsibleContent>
         </Collapsible>
       </div>

--- a/garden/src/features/gardens/components/garden-page/ModalFunctionManager.tsx
+++ b/garden/src/features/gardens/components/garden-page/ModalFunctionManager.tsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { PlusCircle, ExternalLink, X } from 'lucide-react';
 import { Button } from '@/components/shadcn/button';
 import { Garden } from '@/types';
-import { Checkbox } from '@/components/shadcn/checkbox';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/shadcn/dialog';
 import {
   Table,
@@ -13,12 +12,14 @@ import {
   TableCell,
 } from "@/components/shadcn/table";
 import { toast } from 'sonner';
-import { useGetUserModalFunctions } from '@/features/modal/api/useGetUserModalFunctions';
+// import { useGetUserModalFunctions } from '@/features/modal/api/useGetUserModalFunctions';
+import { useGetAllModalFunctions } from '@/features/modal/api/useGetAllModalFunctions';
 import { usePatchGarden } from '@/features/gardens/api/usePatchGarden';
 import { Link, useNavigate } from 'react-router-dom';
-import LoadingSpinner from '@/components/LoadingSpinner';
+// import LoadingSpinner from '@/components/LoadingSpinner';
 import { useGetModelDeployments } from '@/features/model-deployments/api/useGetModelDeployments';
 import { useGetUserInfo } from '@/features/users/api/useGetUserInfo';
+import FunctionSelectionTable from '@/features/modal/components/FunctionSelectionTable';
 
 interface ModalFunctionManagerProps {
   garden: Garden;
@@ -38,38 +39,81 @@ const ModalFunctionManager: React.FC<ModalFunctionManagerProps> = ({
 
   // State for selected function IDs
   const [selectedFunctionIds, setSelectedFunctionIds] = useState<number[]>(currentFunctionIds);
-  const [showFullDescriptionIds, setShowFullDescriptionIds] = useState<number[]>([]);
+  const [selectedAuthorIds, setSelectedAuthorIds] = useState<Set<string>>(new Set());
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isDeploymentDialogOpen, setIsDeploymentDialogOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
-  const [isConfirmClearOpen, setIsConfirmClearOpen] = useState(false);
 
-  // Sync selected functions
-  useEffect(() => {
-    if (isDialogOpen) {
-      setSelectedFunctionIds(garden.modal_functions?.map(f => f.id) || []);
-    }
-  }, [isDialogOpen, garden.modal_functions]);
-
-  // Get user's modal functions - only fetch when dialog is opened
+  // Get modal functions - only fetch when dialog is opened
   const {
     data: functions,
     refetch,
     isFetching,
     isLoading
-  } = useGetUserModalFunctions();
+  } = useGetAllModalFunctions();
+
+  // Sync selected functions
+  useEffect(() => {
+    if (isDialogOpen && functions && functions.length > 0) {
+      const syncedIds = garden.modal_functions
+        ?.map(f => f.id)
+        .filter(id => functions.some(func => func.id === id)) || [];
+      setSelectedFunctionIds(syncedIds);
+    }
+  }, [isDialogOpen, garden.modal_functions, functions]);
+
+  // Sync model authors
+  useEffect(() => {
+    if (isDialogOpen) {
+      setSelectedFunctionIds(garden.modal_functions?.map(f => f.id) || []);
+
+      const initialAuthorIds = new Set<string>();
+      garden.modal_functions?.forEach(fn => {
+        fn.authors?.forEach(identity_id => {
+          if (identity_id) {
+            initialAuthorIds.add(identity_id);
+          }
+        });
+      });
+
+      setSelectedAuthorIds(initialAuthorIds);
+    }
+  }, [isDialogOpen, garden.modal_functions]);
 
   const { mutateAsync: patchGarden } = usePatchGarden();
 
   const { data: modelDeployments } = useGetModelDeployments();
 
-  // Handle checkbox change
-  const handleFunctionToggle = (functionId: number) => {
-    setSelectedFunctionIds(prev =>
-      prev.includes(functionId)
-        ? prev.filter(id => id !== functionId)
-        : [...prev, functionId]
-    );
+  const handleFunctionAdded = (functionId: number, authorIds: string[]) => {
+    setSelectedAuthorIds(prev => {
+      const newSet = new Set(prev);
+      authorIds.forEach(id => {
+        if (id) {
+          newSet.add(id);
+        }
+      });
+      return newSet;
+    });
+  };
+
+  const handleFunctionRemoved = (functionId: number) => {
+    const removedFunction = garden.modal_functions?.find(f => f.id === functionId);
+    const removedAuthorIds = removedFunction?.authors || [];
+
+    setSelectedAuthorIds(prev => {
+      const updated = new Set(prev);
+      removedAuthorIds.forEach(id => {
+        const stillUsed = garden.modal_functions?.some(f =>
+          f.id!== functionId &&
+          selectedFunctionIds.includes(f.id) &&
+          f.authors?.includes(id)
+        );
+        if (!stillUsed) {
+          updated.delete(id);
+        }
+      });
+      return updated;
+    });
   };
 
   // Handle saving functions to the garden
@@ -91,7 +135,8 @@ const ModalFunctionManager: React.FC<ModalFunctionManagerProps> = ({
       await patchGarden({
         doi: garden.doi,
         garden: {
-          modal_function_ids: selectedFunctionIds
+          modal_function_ids: selectedFunctionIds,
+          authors: Array.from(selectedAuthorIds),
         },
         successMessage
       });
@@ -105,12 +150,6 @@ const ModalFunctionManager: React.FC<ModalFunctionManagerProps> = ({
       console.error('Error updating garden functions:', error);
     }
   };
-
-  const filteredFunctions = functions?.filter((func) => {
-    const queryWords = searchQuery.toLowerCase().split(/\s+/).filter(Boolean);
-    const haystack = `${func.title ?? ''} ${func.function_name ?? ''} ${func.description ?? ''}`.toLowerCase();
-    return queryWords.every((word) => haystack.includes(word));
-  });
 
   const deploymentIdsUsedInGarden = new Set(
       garden.modal_functions?.map(f => f.modal_app_id).filter(Boolean)
@@ -214,157 +253,34 @@ const ModalFunctionManager: React.FC<ModalFunctionManagerProps> = ({
               </div>
             </div>
           )}
-
         </DialogContent>
       </Dialog>
 
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-        <DialogContent className="max-w-3xl">
+        <DialogContent className="max-w-5xl">
           <DialogHeader>
             <DialogTitle>Manage Garden Functions</DialogTitle>
           </DialogHeader>
 
-          <div className="mb-2 flex items-center justify-between">
+          <div className="mb-2"> {/* flex items-center justify-between */}
             <p className="text-sm text-gray-500">
               Select functions to include in this garden:
             </p>
           </div>
 
-          {selectedFunctionIds.length > 0 && (
-            <div className="flex flex-wrap gap-2 mt-1">
-              {selectedFunctionIds.map((id) => {
-                const func = functions?.find(f => f.id == id);
-                if (!func) return null;
-
-                return (
-                  <div
-                    key={id}
-                    className="flex items-center rounded-full bg-[#e0f3e7] text-sm px-3 py-1 border border-[#b3dbc3]"
-                  >
-                    {func.title || func.function_name}
-                    <button
-                      onClick={() => handleFunctionToggle(id)}
-                      className="ml-2 text-[#2f5d41] hover:text-red-500"
-                    >
-                      <X className="h-4 w-4" />
-                    </button>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-
-          {selectedFunctionIds.length > 0 && (
-            <div className="mt-2 mb-4">
-              <button onClick={() => setIsConfirmClearOpen(true)}
-                className="text-sm text-[#2f5d41] bg-white hover:bg-[#f0f5f3] border border-[#b3dbc3] px-3 py-1 rounded-md shadow-sm transition flex items-center gap-1">
-                Clear all selected
-              </button>
-            </div>
-          )}
-
-          <input
-            type="text"
-            placeholder="Search functions..."
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full sm:w-1/2 px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#5cae4f]"
+          <FunctionSelectionTable
+            functions={functions}
+            selectedFunctionIds={selectedFunctionIds}
+            onSelectionChange={setSelectedFunctionIds}
+            isLoading={isLoading}
+            isFetching={isFetching}
+            searchQuery={searchQuery}
+            onSearchChange={setSearchQuery}
+            showSelectedChips
+            showClearAllButton
+            onFunctionAdded={handleFunctionAdded}
+            onFunctionRemoved={handleFunctionRemoved}
           />
-
-          <div className="relative mb-4 rounded-md border bg-white">
-            <div className="max-h-[420px] overflow-y-auto">
-              <Table>
-                <TableHeader className="sticky top-0 bg-white z-10">
-                  <TableRow>
-                    <TableHead className="w-1/12"></TableHead>
-                    <TableHead className="w-1/4">Name</TableHead>
-                    <TableHead className="w-1/2">Description</TableHead>
-                    <TableHead className="w-1/6 text-center"></TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {isLoading ? (
-                    <TableRow>
-                      <TableCell colSpan={4} className="text-center">
-                        <div className="flex h-24 items-center justify-center">
-                          <LoadingSpinner />
-                        </div>
-                      </TableCell>
-                    </TableRow>
-                  ) : functions?.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={4} className="text-center text-gray-500">
-                        No modal functions available
-                      </TableCell>
-                    </TableRow>
-                  ) : filteredFunctions?.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={4} className="text-center text-gray-500">
-                        No functions match your search.
-                      </TableCell>
-                    </TableRow>
-                  ) : (
-                    (filteredFunctions ?? []).map((func) => (
-                      <TableRow
-                        key={func.id}
-                        onClick={() => handleFunctionToggle(func.id)}
-                        className={`
-                            group cursor-pointer transition-all duration-200 ease-in-out rounded-md
-                            ${selectedFunctionIds.includes(func.id)
-                            ? "bg-[#e0f3e7] border-y border-[#5cae4f] shadow-sm"
-                            : "hover:bg-[#eef5f1]"}  
-                          `}
-                      >
-                        <TableCell className="w-1/12 text-center">
-                          <Checkbox
-                            checked={selectedFunctionIds.includes(func.id)}
-                            onCheckedChange={() => handleFunctionToggle(func.id)}
-                            onClick={(e) => e.stopPropagation()}
-                            value={func.id}
-                          />
-                        </TableCell>
-                        <TableCell className="w-1/4 truncate whitespace-normal break-words">
-                          {func.title || func.function_name}
-                        </TableCell>
-                        <TableCell className="w-1/2 whitespace-normal break-words text-sm text-gray-700">
-                          <div>
-                            <p className={showFullDescriptionIds.includes(func.id) ? '' : 'line-clamp-2'}>
-                              {func.description || "No description available"}
-                            </p>
-                            {func.description && func.description.length > 120 && (
-                              <button
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  setShowFullDescriptionIds((prev) =>
-                                    prev.includes(func.id) ? prev.filter((id) => id !== func.id) : [...prev, func.id]
-                                  );
-                                }}
-                                className="mt-1 text-xs text-green hover:underline"
-                              >
-                                {showFullDescriptionIds.includes(func.id) ? "Show less" : "Show more"}
-                              </button>
-                            )}
-                          </div>
-                        </TableCell>
-                        <TableCell className="w-1/6 text-center">
-                          <Link
-                            to={`/modal-functions/${func.id}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            <Button variant="outline" size="sm" type="button">
-                              View
-                              <ExternalLink size={14} className="mb-0.5 ml-1" />
-                            </Button>
-                          </Link>
-                        </TableCell>
-                      </TableRow>
-                    ))
-                  )}
-                </TableBody>
-              </Table>
-            </div>
-          </div>
 
           <div className="flex justify-end space-x-2 mt-4">
             <Button variant="outline" onClick={() => setIsDialogOpen(false)}>
@@ -374,28 +290,6 @@ const ModalFunctionManager: React.FC<ModalFunctionManagerProps> = ({
               Update Garden
             </Button>
           </div>
-
-          <Dialog open={isConfirmClearOpen} onOpenChange={setIsConfirmClearOpen}>
-            <DialogContent className="max-w-md">
-              <DialogHeader>
-                <DialogTitle>Remove all selected functions?</DialogTitle>
-              </DialogHeader>
-              <div className="text-sm text-gray-600">
-                Your current selections will be cleared. This won't affect the garden until changes are confirmed.
-              </div>
-              <div className="flex justify-end gap-2 mt-4">
-                <Button variant="outline" onClick={() => setIsConfirmClearOpen(false)}>
-                  Cancel
-                </Button>
-                <Button variant="destructive" onClick={() => {
-                  setSelectedFunctionIds([]);
-                  setIsConfirmClearOpen(false);
-                }}>
-                  Clear All
-                </Button>
-              </div>
-            </DialogContent>
-          </Dialog>
 
         </DialogContent>
       </Dialog>

--- a/garden/src/features/modal/api/useGetAllModalFunctions.ts
+++ b/garden/src/features/modal/api/useGetAllModalFunctions.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "@/lib/axios";
+import { ModalFunction } from "@/types";
+
+export const useGetAllModalFunctions = () => {
+  return useQuery({
+    queryKey: ["allModalFunctions"],
+    queryFn: async (): Promise<ModalFunction[]> => {
+      const response = await axios.get("/modal-functions");
+      return response.data;
+    },
+  });
+};

--- a/garden/src/features/modal/components/FunctionSelectionTable.tsx
+++ b/garden/src/features/modal/components/FunctionSelectionTable.tsx
@@ -1,0 +1,265 @@
+import React, { useState, useCallback } from 'react';
+import { ExternalLink, X } from 'lucide-react';
+import { Button } from '@/components/shadcn/button';
+import { Checkbox } from '@/components/shadcn/checkbox';
+import {
+  Table,
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+} from "@/components/shadcn/table";
+import { Link } from 'react-router-dom';
+import LoadingSpinner from '@/components/LoadingSpinner';
+import { ModalFunction } from '@/types';
+import { toast } from 'sonner';
+
+interface FunctionSelectionTableProps {
+  functions: ModalFunction[] | undefined;
+  selectedFunctionIds?: number[];
+  onSelectionChange: (selectedIds: number[]) => void;
+  isLoading?: boolean;
+  isFetching?: boolean;
+  searchQuery?: string;
+  onSearchChange?: (query: string) => void;
+  showSelectedChips?: boolean;
+  showClearAllButton?: boolean;
+  showSearch?: boolean;
+  maxHeight?: string;
+  onFunctionAdded?: (functionId: number, authorIds: string[]) => void;
+  onFunctionRemoved?: (functionId: number) => void;
+  className?: string;
+  tableClassName?: string;
+}
+
+const FunctionSelectionTable: React.FC<FunctionSelectionTableProps> = ({
+  functions,
+  selectedFunctionIds = [],
+  onSelectionChange,
+  isLoading = false,
+  isFetching = false,
+  searchQuery = "",
+  onSearchChange,
+  showSelectedChips = true,
+  showClearAllButton = true,
+  showSearch = true,
+  maxHeight = "420px",
+  onFunctionAdded,
+  onFunctionRemoved,
+  className = "",
+  tableClassName = ""
+}) => {
+  const [showFullDescriptionIds, setShowFullDescriptionIds] = useState<number[]>([]);
+  const [isConfirmClearOpen, setIsConfirmClearOpen] = useState(false);
+
+  const filteredFunctions = (functions ?? []).filter((func) => {
+    const queryWords = searchQuery.toLowerCase().split(/\s+/).filter(Boolean);
+    const haystack = `${func.title ?? ''} ${func.function_name ?? ''} ${func.description ?? ''}`.toLowerCase();
+    return queryWords.every((word) => haystack.includes(word));
+  });
+
+  const handleFunctionToggle = useCallback(
+    (functionId: number) => {
+      const isCurrentlySelected = selectedFunctionIds.includes(functionId);
+      const newSelectedIds = isCurrentlySelected
+        ? selectedFunctionIds.filter(id => id !== functionId)
+        : [...selectedFunctionIds, functionId];
+
+      onSelectionChange(newSelectedIds);
+
+      if (!isCurrentlySelected && onFunctionAdded) {
+        const func = functions?.find(f => f.id === functionId);
+        if (func) {
+          const authorIds = func.authors ?? [];
+          if (authorIds.length === 0) {
+            toast.warning(`Function "${func.title || func.function_name}" has no authors defined`);
+          }
+          onFunctionAdded(functionId, authorIds);
+        }
+      } else if (isCurrentlySelected && onFunctionRemoved) {
+        onFunctionRemoved(functionId);
+      }
+    },
+    [selectedFunctionIds, onSelectionChange, onFunctionAdded, onFunctionRemoved, functions]
+  );
+
+  const handleClearAll = () => {
+    onSelectionChange([]);
+    setIsConfirmClearOpen(false);
+  };
+
+  const toggleDescription = (functionId: number) => {
+    setShowFullDescriptionIds((prev) =>
+      prev.includes(functionId)
+        ? prev.filter((id) => id !== functionId)
+        : [...prev, functionId]
+    );
+  };
+
+  
+  return (
+    <div className={className}>
+      {showSelectedChips && selectedFunctionIds.length > 0 && (
+        <div className="flex flex-wrap gap-2 mb-4">
+          {selectedFunctionIds.map((id) => {
+            const func = functions?.find(f => f.id === id);
+            if (!func) return null;
+
+            return (
+              <div
+                key={id}
+                className="flex items-center rounded-full bg-[#e0f3e7] text-sm px-3 py-1 border border-[#b3dbc3]"
+              >
+                {func.title || func.function_name}
+                <button
+                  onClick={() => handleFunctionToggle(id)}
+                  className="ml-2 text-[#2f5d41] hover:text-red-500"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {showClearAllButton && selectedFunctionIds.length > 0 && (
+        <div className="mb-4">
+          <button
+            onClick={() => setIsConfirmClearOpen(true)}
+            className="text-sm text-[#2f5d41] bg-white hover:bg-[#f0f5f3] border border-[#b3dbc3] px-3 py-1 rounded-md shadow-sm transition flex items-center gap-1"
+          >
+            Clear all selected
+          </button>
+        </div>
+      )}
+
+      {showSearch && onSearchChange && (
+        <input
+          type="text"
+          placeholder="Search functions..."
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+          className="w-full sm:w-1/2 px-3 py-2 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-[#5cae4f] mb-4"
+        />
+      )}
+
+      <div className={`relative rounded-md border bg-white ${tableClassName}`}>
+        <div className="overflow-y-auto" style={{ maxHeight }}>
+          <Table>
+            <TableHeader className="sticky top-0 bg-white z-10">
+              <TableRow>
+                <TableHead className="w-1/12"></TableHead>
+                <TableHead className="w-1/4">Name</TableHead>
+                <TableHead className="w-1/2">Description</TableHead>
+                <TableHead className="w-1/6 text-center">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isLoading ? (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-center">
+                    <div className="flex h-24 items-center justify-center">
+                      <LoadingSpinner />
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ) : functions?.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-center text-gray-500">
+                    No modal functions available
+                  </TableCell>
+                </TableRow>
+              ) : filteredFunctions?.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={4} className="text-center text-gray-500">
+                    No functions match your search.
+                  </TableCell>
+                </TableRow>
+              ) : (
+                filteredFunctions.map((func) => (
+                  <TableRow
+                    key={func.id}
+                    onClick={(e) => {
+                      const tag = (e.target as HTMLElement).tagName.toLowerCase();
+                      if (['input', 'button', 'svg', 'path'].includes(tag)) return;
+                      handleFunctionToggle(func.id);
+                    }}
+                    className={`group cursor-pointer transition-all duration-200 ease-in-out rounded-md
+                      ${selectedFunctionIds.includes(func.id)
+                        ? "bg-[#e0f3e7] border-y border-[#5cae4f] shadow-sm"
+                        : "hover:bg-[#eef5f1]"}`}
+                  >
+                    <TableCell className="w-1/12 text-center">
+                      <Checkbox
+                        checked={selectedFunctionIds.includes(func.id)}
+                        onCheckedChange={() => handleFunctionToggle(func.id)}
+                        onPointerDown={(e) => e.stopPropagation()}
+                        value={func.id}
+                      />
+                    </TableCell>
+                    <TableCell className="w-1/4 truncate whitespace-normal break-words">
+                      {func.title || func.function_name}
+                    </TableCell>
+                    <TableCell className="w-1/2 whitespace-normal break-words text-sm text-gray-700">
+                      <div>
+                        <p className={showFullDescriptionIds.includes(func.id) ? '' : 'line-clamp-2'}>
+                          {func.description || "No description available"}
+                        </p>
+                        {func.description && func.description.length > 120 && (
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              toggleDescription(func.id);
+                            }}
+                            className="mt-1 text-xs text-green hover:underline"
+                          >
+                            {showFullDescriptionIds.includes(func.id) ? "Show less" : "Show more"}
+                          </button>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell className="w-1/6 text-center">
+                      <Link
+                        to={`/modal-functions/${func.id}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <Button variant="outline" size="sm" type="button">
+                          View
+                          <ExternalLink size={14} className="mb-0.5 ml-1" />
+                        </Button>
+                      </Link>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </div>
+
+      {isConfirmClearOpen && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white p-6 rounded-lg max-w-md w-full mx-4">
+            <h3 className="text-lg font-semibold mb-2">Remove all selected functions?</h3>
+            <p className="text-sm text-gray-600 mb-4">
+              Your current selections will be cleared. This won't affect the garden until changes are confirmed.
+            </p>
+            <div className="flex justify-end gap-2">
+              <Button variant="outline" onClick={() => setIsConfirmClearOpen(false)}>
+                Cancel
+              </Button>
+              <Button variant="destructive" onClick={handleClearAll}>
+                Clear All
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FunctionSelectionTable;


### PR DESCRIPTION
## Function Selection Component Update
### Resolves #337 + #385 + #395 
---
- Created `FunctionSelectionTable.tsx` to update the function selection table to be a reusable component for selecting modal functions.
- Created `useGetAllModalFunctions.ts` to add a new query hook to fetch all published modal functions from `/modal-functions`.
- Edited `CreateGardenFormFields.tsx` to replace old function table UI with `FunctionSelectionTable`, to add model authors to `authors` when functions are added, and to remove authors if no longer used by selected functions.
- Edited `ModalFunctionManager.tsx` to replace old function table UI with `FunctionSelectionTable`, to load all published functions using `useGetAllModalFunctions`, to implement author syncing when added/removed, and to display a warning when a function without an author is selected.
---
### Originally, the 'Create Garden' form displayed an older version of the function selection table. Additionally, the new function selection UI only included functions owned by the user. Authors would also not be automatically added when their function was selected and included within a Garden.
<img width="1730" height="914" alt="image" src="https://github.com/user-attachments/assets/f7d0f798-4d93-4eeb-bb0f-1dd43f8f8434" />

---
### Implemented the new reusable function selection table component within the 'Create Garden' form. Updated the function table to display all published functions as an option for the user to select and add to their garden.
<img width="1704" height="905" alt="image" src="https://github.com/user-attachments/assets/e560c2b7-5ad4-4415-9634-296e4d190449" />

### Included logic to automatically populate the 'Contributors' section with additional authors based on the currently selected functions within the table.
<img width="1594" height="321" alt="image" src="https://github.com/user-attachments/assets/21f7c6d6-e307-4bfc-9d32-a658c296ed81" />

### Updated the dialog logic to automatically sync model authors in the garden’s metadata when functions are added or removed. Ensures authors are only removed if none of their functions remain in the garden, avoiding duplicate entries and preserving authorship across shared contributions.
<img width="596" height="663" alt="image" src="https://github.com/user-attachments/assets/5a49a146-a071-4a92-b172-c1559f7fca0c" />

### Added a warning message when a function without an author is selected to be added to the garden.
<img width="567" height="120" alt="image" src="https://github.com/user-attachments/assets/fd5568ab-f2a5-4b5a-ad5e-b35565e92a91" />
