### PR TITLE
fix: caching issues

### DIFF
--- a/garden/src/features/gardens/api/useCreateGarden.ts
+++ b/garden/src/features/gardens/api/useCreateGarden.ts
@@ -23,6 +23,7 @@ export const useCreateGarden = () => {
     mutationFn: createGarden,
     onSuccess: (garden) => {
       queryClient.setQueryData(["gardens", garden.doi], garden);
+      queryClient.invalidateQueries({ queryKey: ["gardens"] });
     },
   });
 };

--- a/garden/src/features/gardens/api/useDeleteGarden.ts
+++ b/garden/src/features/gardens/api/useDeleteGarden.ts
@@ -1,6 +1,6 @@
 import { GardenCreateResponse } from "@/types";
 import axios from "@/lib/axios";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { AxiosResponse } from "axios";
 
 const deleteGarden = async (doi: string) => {

--- a/garden/src/features/gardens/api/useDeleteGarden.ts
+++ b/garden/src/features/gardens/api/useDeleteGarden.ts
@@ -1,6 +1,6 @@
 import { GardenCreateResponse } from "@/types";
 import axios from "@/lib/axios";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { AxiosResponse } from "axios";
 
 const deleteGarden = async (doi: string) => {

--- a/garden/src/features/gardens/components/GardenDropdownOptions.tsx
+++ b/garden/src/features/gardens/components/GardenDropdownOptions.tsx
@@ -225,10 +225,10 @@ const DeleteGardenModal = ({
       onSuccess: () => {
         setIsOpen(false);
         setInput("");
-        navigate("/");
-        toast.success("Garden deleted successfully!");
-        queryClient.invalidateQueries({ queryKey: ["gardens", "search"] });
+        queryClient.invalidateQueries({ queryKey: ["gardens"] });
         queryClient.removeQueries({ queryKey: ["gardens", doi] });
+        toast.success("Garden deleted successfully!");
+        navigate("/");
       },
     });
   };

--- a/garden/src/features/model-deployments/ModelDeploymentDetails.tsx
+++ b/garden/src/features/model-deployments/ModelDeploymentDetails.tsx
@@ -96,6 +96,9 @@ export const ModelDeploymentDetails = ({ entity }: ModelDeploymentDetailsProps) 
         try {
             await instance.delete(`/modal-apps/${entity.id}`);
             queryClient.invalidateQueries({ queryKey: ['modelDeployments'] });
+            entity.modal_function_ids.forEach((id) => {
+                queryClient.invalidateQueries({ queryKey: ["modalFunctions", id] });
+            });
             navigate("/user?tab=model-deployments");
             toast(`Deployment Deleted: ${entity.original_app_name || entity.app_name}`);
         } catch (error: any) {


### PR DESCRIPTION
Resolves: #405
Resolves: #404 

This PR fixes a few caching issues:

- modal function cache is now invalidated correctly when deleting a model deployment
- garden cache is invalidated when creating or deleting a garden which solves the issue of deleted gardens showing on the profile page.
- While testing this I noticed new gardens weren't showing up on the profile page until a refresh either. This also fixes that issue.