### PR TITLE
More MLIP copy and layout

### DIFF
--- a/garden/src/features/mlip-page/MLIPPage.tsx
+++ b/garden/src/features/mlip-page/MLIPPage.tsx
@@ -5,7 +5,7 @@ import { SectionBenchmark } from "./components/Section-Benchmark";
 
 export default function MLIPPage() {
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-white overflow-x-hidden">
       <main>
         <SectionOverview />
         <SectionAvailableMLIPs />

--- a/garden/src/features/mlip-page/components/MLIPTaskCard.tsx
+++ b/garden/src/features/mlip-page/components/MLIPTaskCard.tsx
@@ -11,7 +11,7 @@ export const MLIPTaskCard = ({ title, description, imageSrc, theme }: Props) => 
       <img
         src={imageSrc}
         alt={title}
-        className="w-70 h-60 object-contain mx-auto mb-8 rounded-xl shadow-md"
+        className="w-80 h-60 object-contain mx-auto mb-8 rounded-xl shadow-md"
       />
       <h3 className="text-2xl font-bold text-slate-800 mb-4 font-serif text-center">
         {title}
@@ -20,7 +20,7 @@ export const MLIPTaskCard = ({ title, description, imageSrc, theme }: Props) => 
         {description}
       </p>
       <div className="flex gap-3 justify-center">
-        <button className="px-6 py-3 bg-gradient-to-r from-blue-600 to-indigo-600 text-white rounded-full font-semibold shadow hover:scale-105 transition">
+        <button className="px-6 py-3 bg-gradient-to-r from-blue-600 to-indigo-600 text-white rounded-full font-semibold shadow-md hover:scale-105 hover:shadow-lg transition">
           On-demand
         </button>
         <button className="px-6 py-3 bg-white text-slate-700 border border-slate-200 rounded-full hover:bg-slate-50 transition">

--- a/garden/src/features/mlip-page/components/Section-AvailableMLIPs.tsx
+++ b/garden/src/features/mlip-page/components/Section-AvailableMLIPs.tsx
@@ -5,7 +5,7 @@ export const SectionAvailableMLIPs = () => {
   return (
     <section
       id="available-mlips"
-      className="relative px-6 py-14 md:py-16 bg-gradient-to-br from-white via-slate-50/30 to-blue-50/50 text-slate-800 overflow-visible"
+      className="relative px-6 py-16 md:py-20 bg-gradient-to-br from-white via-slate-50/30 to-blue-50/50 text-slate-800 overflow-visible"
     >
       {/* Background visual */}
       <div className="absolute inset-0 z-0">
@@ -24,7 +24,7 @@ export const SectionAvailableMLIPs = () => {
       </div>
 
       {/* Content */}
-      <div className="relative z-10 max-w-6xl mx-auto md:grid md:grid-cols-[1fr_auto] md:gap-10 items-start">
+      <div className="relative z-10 max-w-7xl mx-auto md:grid md:grid-cols-[1fr_auto] md:gap-10 items-start">
         {/* Table on the left (orders first) */}
         <div className="md:order-1">
           <MLIPTable data={mockMLIPs} />
@@ -35,13 +35,13 @@ export const SectionAvailableMLIPs = () => {
           <h2 className="mb-4 text-4xl font-serif font-bold tracking-tight text-slate-800">
             Available MLIPs
           </h2>
-          <div className="hidden md:block w-20 h-1 bg-gradient-to-r from-blue-500 to-indigo-500 mb-4 rounded-full ml-auto" />
+          <div className="hidden md:block w-20 h-1 bg-gradient-to-r from-blue-500 to-indigo-500 mb-8 rounded-full ml-auto" />
 
           <p className="text-lg md:text-xl text-slate-600 font-light max-w-lg md:max-w-xs md:ml-auto mb-6 leading-relaxed">
             These models have been configured for high throughput batch relaxation with{" "}
             <a
               href="https://radical-ai.github.io/torch-sim/"
-              className="text-blue-600 hover:text-blue-700"
+              className="text-indigo-600 underline underline-offset-4 hover:text-indigo-700"
             >
               TorchSim
             </a>

--- a/garden/src/features/mlip-page/components/Section-Benchmark.tsx
+++ b/garden/src/features/mlip-page/components/Section-Benchmark.tsx
@@ -3,7 +3,7 @@ export const SectionBenchmark = () => {
   return (
     <section
       id="benchmarking"
-      className="relative overflow-hidden w-full px-6 py-24 bg-gradient-to-br from-white via-slate-50/60 to-blue-50/40 text-slate-800"
+      className="relative overflow-hidden w-full px-6 py-16 md:py-20 bg-gradient-to-br from-white via-slate-50/60 to-blue-50/40 text-slate-800"
     >
       <div className="absolute inset-0 z-0">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,_#e2e8f0_1px,_transparent_1px)] [background-size:80px_80px] opacity-20 pointer-events-none" />
@@ -12,20 +12,20 @@ export const SectionBenchmark = () => {
       </div>
 
       <div className="relative z-10 max-w-7xl mx-auto">
-        <h2 className="mb-8 text-4xl font-serif font-bold tracking-tight text-slate-800">
+        <h2 className="mb-4 text-4xl font-serif font-bold tracking-tight text-slate-800">
           Cost Benchmarking
         </h2>
-        <div className="w-20 h-1 bg-gradient-to-r from-blue-500 to-indigo-500 mb-10 rounded-full" />
+        <div className="w-20 h-1 bg-gradient-to-r from-blue-500 to-indigo-500 mb-8 rounded-full" />
 
         <p className="text-lg md:text-xl text-slate-600 font-light mb-4 leading-relaxed">
           Know the accuracy <em>and</em> the price tag. 
         </p>
         <p className="text-md text-slate-500 leading-relaxed mb-6">
-        We pair task performance scores from <a href="https://matbench-discovery.materialsproject.org/" className="text-blue-600 underline" target="_blank" rel="noopener noreferrer">MatBench Discovery</a> with Garden’s own throughput and cost benchmarks, run on the exact hardware and configuration your jobs will use. 
+        We pair task performance scores from <a href="https://matbench-discovery.materialsproject.org/" className="text-indigo-600 underline underline-offset-4 hover:text-indigo-700" target="_blank" rel="noopener noreferrer">MatBench Discovery</a> with Garden’s own throughput and cost benchmarks, run on the exact hardware and configuration your jobs will use. 
         That way, you get both an accuracy metric and a realistic cost baseline for planning production budgets, whether you’re using an HPC allocation or cloud credits.
         </p>
         <p className="text-md text-slate-500 leading-relaxed mb-6">
-        We test each MLIP on <a href="https://matbench-discovery.materialsproject.org/data#--links-to-wbm-files" className="text-blue-600 underline" target="_blank" rel="noopener noreferrer">the WBM dataset</a> (median 22 atoms per structure) and report cost per 1,000 relaxations. 
+        We test each MLIP on <a href="https://matbench-discovery.materialsproject.org/data#--links-to-wbm-files" className="text-indigo-600 underline underline-offset-4 hover:text-indigo-700" target="_blank" rel="noopener noreferrer">the WBM dataset</a> (median 22 atoms per structure) and report cost per 1,000 relaxations. 
         If your workloads involve larger systems, expect lower throughput and higher costs.
         </p>
       </div>

--- a/garden/src/features/mlip-page/components/Section-Benchmark.tsx
+++ b/garden/src/features/mlip-page/components/Section-Benchmark.tsx
@@ -1,26 +1,4 @@
 export const SectionBenchmark = () => {
-  const benchmarkMetrics = [
-    {
-      label: "Energy Accuracy",
-      value: "< 1 meV/atom",
-      description: "Mean absolute error across test sets",
-    },
-    {
-      label: "Force Prediction",
-      value: "< 0.1 eV/Å",
-      description: "Root mean square error for atomic forces",
-    },
-    {
-      label: "Training Efficiency",
-      value: "10³ – 10⁶×",
-      description: "Speed improvement over DFT calculations",
-    },
-    {
-      label: "Transferability",
-      value: "95%+",
-      description: "Accuracy maintained across material systems",
-    },
-  ];
 
   return (
     <section
@@ -35,40 +13,21 @@ export const SectionBenchmark = () => {
 
       <div className="relative z-10 max-w-7xl mx-auto">
         <h2 className="mb-8 text-4xl font-serif font-bold tracking-tight text-slate-800">
-          Benchmarking Results
+          Cost Benchmarking
         </h2>
         <div className="w-20 h-1 bg-gradient-to-r from-blue-500 to-indigo-500 mb-10 rounded-full" />
 
-        <p className="text-lg md:text-xl text-slate-600 max-w-4xl leading-relaxed mb-12">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat
+        <p className="text-lg md:text-xl text-slate-600 font-light mb-4 leading-relaxed">
+          Know the accuracy <em>and</em> the price tag. 
         </p>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-16">
-          {benchmarkMetrics.map((metric, index) => (
-            <div
-              key={index}
-              className="p-6 rounded-xl bg-white/80 border border-slate-200/60 backdrop-blur-sm shadow-md hover:shadow-lg transition"
-            >
-              <div className="text-2xl font-bold text-slate-700 mb-1">
-                {metric.value}
-              </div>
-              <div className="font-semibold text-slate-800">{metric.label}</div>
-              <div className="text-sm text-slate-600 mt-1">{metric.description}</div>
-            </div>
-          ))}
-        </div>
-
-        <div className="bg-white/70 backdrop-blur-sm border border-slate-200/50 shadow-md rounded-xl p-6 md:p-8">
-          <h3 className="text-xl md:text-2xl font-serif font-semibold text-slate-800 mb-4">
-            Testing Framework
-          </h3>
-          <p className="text-md md:text-lg text-slate-600 leading-relaxed mb-4">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
-          </p>
-          <p className="text-md md:text-base text-slate-500 leading-relaxed">
-            Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-          </p>
-        </div>
+        <p className="text-md text-slate-500 leading-relaxed mb-6">
+        We pair task performance scores from <a href="https://matbench-discovery.materialsproject.org/" className="text-blue-600 underline" target="_blank" rel="noopener noreferrer">MatBench Discovery</a> with Garden’s own throughput and cost benchmarks, run on the exact hardware and configuration your jobs will use. 
+        That way, you get both an accuracy metric and a realistic cost baseline for planning production budgets, whether you’re using an HPC allocation or cloud credits.
+        </p>
+        <p className="text-md text-slate-500 leading-relaxed mb-6">
+        We test each MLIP on <a href="https://matbench-discovery.materialsproject.org/data#--links-to-wbm-files" className="text-blue-600 underline" target="_blank" rel="noopener noreferrer">the WBM dataset</a> (median 22 atoms per structure) and report cost per 1,000 relaxations. 
+        If your workloads involve larger systems, expect lower throughput and higher costs.
+        </p>
       </div>
     </section>
   );

--- a/garden/src/features/mlip-page/components/Section-MLIPTasks.tsx
+++ b/garden/src/features/mlip-page/components/Section-MLIPTasks.tsx
@@ -4,7 +4,7 @@ export const SectionMLIPTasks = () => {
   return (
     <section
       id="mlip-tasks"
-      className="relative overflow-hidden bg-gradient-to-br from-white via-slate-50/30 to-blue-50/50 text-slate-800 py-20 px-6"
+      className="relative overflow-hidden bg-gradient-to-br from-white via-slate-50/30 to-blue-50/50 text-slate-800 py-16 md:py-20 px-6"
     >
       <div className="absolute inset-0 z-0">
         <div className="absolute w-[40vw] h-[40vw] top-[-10%] left-[-5%] rounded-full bg-indigo-100 opacity-20 blur-3xl" />
@@ -16,13 +16,13 @@ export const SectionMLIPTasks = () => {
           <h2 className="text-4xl font-serif font-bold tracking-tight mb-4 text-slate-800">
             Molecular Structure Relaxation
           </h2>
-          <div className="w-20 h-1 bg-gradient-to-r from-blue-500 to-indigo-500 mb-6 rounded-full"></div>
+          <div className="w-20 h-1 bg-gradient-to-r from-blue-500 to-indigo-500 mb-8 rounded-full"></div>
           <p className="text-lg md:text-xl text-slate-600 font-light mb-4 leading-relaxed">
             Finding a material's lowest-energy state (relaxation) is essential for stability screening.
           </p>
           <p className="text-md text-slate-500 leading-relaxed mb-6">
             Machine-learned interatomic potentials (MLIPs) act as fast surrogates for expensive DFT calculations, predicting the forces on every atom.
-            Garden uses <a href="https://radical-ai.github.io/torch-sim/" className="text-blue-600 underline" target="_blank" rel="noopener noreferrer">TorchSim</a> as a simulation wrapper to take advantage of GPU parallelization and find the lowest-energy state of many materials at once.
+            Garden uses <a href="https://radical-ai.github.io/torch-sim/" className="text-indigo-600 underline underline-offset-4 hover:text-indigo-700" target="_blank" rel="noopener noreferrer">TorchSim</a> as a simulation wrapper to take advantage of GPU parallelization and find the lowest-energy state of many materials at once.
           </p>
         </div>
 

--- a/garden/src/features/mlip-page/components/Section-MLIPTasks.tsx
+++ b/garden/src/features/mlip-page/components/Section-MLIPTasks.tsx
@@ -14,21 +14,16 @@ export const SectionMLIPTasks = () => {
       <div className="relative z-10 max-w-7xl mx-auto flex flex-col md:flex-row items-center gap-12">
         <div className="w-full md:w-1/2">
           <h2 className="text-4xl font-serif font-bold tracking-tight mb-4 text-slate-800">
-            Structure Relaxation
+            Molecular Structure Relaxation
           </h2>
           <div className="w-20 h-1 bg-gradient-to-r from-blue-500 to-indigo-500 mb-6 rounded-full"></div>
           <p className="text-lg md:text-xl text-slate-600 font-light mb-4 leading-relaxed">
-            Relaxation is the process of finding the most stable atomic configuration of a material.
+            Finding a material's lowest-energy state (relaxation) is essential for stability screening.
           </p>
-          <p className="text-md text-slate-500 leading-relaxed mb-6 max-w-md">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+          <p className="text-md text-slate-500 leading-relaxed mb-6">
+            Machine-learned interatomic potentials (MLIPs) act as fast surrogates for expensive DFT calculations, predicting the forces on every atom.
+            Garden uses <a href="https://radical-ai.github.io/torch-sim/" className="text-blue-600 underline" target="_blank" rel="noopener noreferrer">TorchSim</a> as a simulation wrapper to take advantage of GPU parallelization and find the lowest-energy state of many materials at once.
           </p>
-          <a
-            // href=""
-            className="inline-block px-6 py-3 bg-gradient-to-r from-blue-600 to-indigo-600 text-white rounded-full font-semibold shadow-md hover:scale-105 hover:shadow-lg transition"
-          >
-            See Available MLIPs
-          </a>
         </div>
 
         <div className="w-full md:w-1/2 flex justify-center">

--- a/garden/src/features/mlip-page/components/Section-Overview.tsx
+++ b/garden/src/features/mlip-page/components/Section-Overview.tsx
@@ -35,10 +35,11 @@ export const SectionOverview = () => {
           </span>
         </h1>
         <p className="text-lg text-black font-light leading-relaxed mb-4">
-          Use Garden to run MLIP-driven atomistic simulation tasks like relaxation and structure prediction. We have the libraries and GPUs pre-configured; you just need an .xyz file and a few lines of Python.
+          Use Garden to run MLIP-driven atomistic simulation tasks like relaxation and structure prediction. 
+          We have the libraries and GPUs pre-configured. You just need an .xyz file and a few lines of Python.
         </p>
         <p className="text-sm text-slate-500 leading-relaxed mb-6 max-w-md">
-          Run workloads on the cloud or on participating research computing facilities like Argonne Leadership Computing Facility (ALCF) or Purdue's Rosen Center for Advanced Computing.
+          Run workloads on participating research computing facilities like Argonne Leadership Computing Facility (ALCF) with <a href="http://globus-compute.readthedocs.io/en/stable/" className="text-blue-600 underline" target="_blank" rel="noopener noreferrer">Globus Compute</a> or on the cloud with <a href="https://modal.com/" className="text-blue-600 underline" target="_blank" rel="noopener noreferrer">Modal</a>.
         </p>
         <div className="flex flex-wrap gap-4">
           <Link

--- a/garden/src/features/mlip-page/components/Section-Overview.tsx
+++ b/garden/src/features/mlip-page/components/Section-Overview.tsx
@@ -3,11 +3,11 @@ import { Link } from "react-router-dom";
 
 export const SectionOverview = () => {
   return (
-    <section className="relative min-h-[50vh] flex flex-col md:flex-row items-center justify-between bg-gradient-to-br from-blue-50 via-white to-indigo-50 text-slate-800 overflow-hidden px-6 md:px-12 py-20 md:py-28">
-      
+    <section className="relative min-h-[50vh] bg-gradient-to-br from-blue-50 via-white to-indigo-50 text-slate-800 overflow-hidden px-6 md:px-12 py-16 md:py-20">
+
       <div className="absolute inset-0 z-0">
-        <div className="absolute w-[60vw] h-[60vw] top-[-20%] left-[-10%] rounded-full bg-indigo-100 opacity-50 blur-3xl animate-pulse-slow" />
-        <div className="absolute w-[40vw] h-[40vw] bottom-[-20%] right-[-10%] rounded-full bg-blue-100 opacity-20 blur-2xl animate-pulse-slower" />
+        <div className="absolute w-[60vw] h-[60vw] top-[-20%] left-[-10%] rounded-full bg-indigo-100 opacity-50 blur-3xl animate-pulse" />
+        <div className="absolute w-[40vw] h-[40vw] bottom-[-20%] right-[-10%] rounded-full bg-blue-100 opacity-20 blur-2xl animate-pulse" />
         {[...Array(10)].map((_, i) => (
           <div
             key={i}
@@ -23,42 +23,45 @@ export const SectionOverview = () => {
         <div className="absolute inset-0 bg-gradient-to-r from-transparent via-indigo-100 to-transparent opacity-30 pointer-events-none rotate-[25deg]" />
       </div>
 
-      <div className="hidden md:flex flex-col items-center justify-center pl-6 pr-4">
-        <div className="w-1 h-64 bg-gradient-to-b from-blue-500 via-indigo-500 to-purple-500 rounded-full"></div>
-      </div>
-
-      <div className="relative z-10 w-full md:w-1/2 max-w-2xl">
-        <h1 className="text-5xl md:text-6xl font-serif font-bold text-slate-800 leading-tight mb-6">
-          <div>Machine Learned</div>
-          <span className="whitespace-nowrap bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 bg-clip-text text-transparent">
-            Interatomic Potentials
-          </span>
-        </h1>
-        <p className="text-lg text-black font-light leading-relaxed mb-4">
-          Use Garden to run MLIP-driven atomistic simulation tasks like relaxation and structure prediction. 
-          We have the libraries and GPUs pre-configured. You just need an .xyz file and a few lines of Python.
-        </p>
-        <p className="text-sm text-slate-500 leading-relaxed mb-6 max-w-md">
-          Run workloads on participating research computing facilities like Argonne Leadership Computing Facility (ALCF) with <a href="http://globus-compute.readthedocs.io/en/stable/" className="text-blue-600 underline" target="_blank" rel="noopener noreferrer">Globus Compute</a> or on the cloud with <a href="https://modal.com/" className="text-blue-600 underline" target="_blank" rel="noopener noreferrer">Modal</a>.
-        </p>
-        <div className="flex flex-wrap gap-4">
-          <Link
-            to="/garden/10.26311%2Fcexg-2349"
-            className="inline-block px-6 py-3 bg-gradient-to-r from-blue-600 to-indigo-600 text-white rounded-full font-semibold shadow-md hover:scale-105 hover:shadow-lg transition"
-          >
-            Run on the cloud
-          </Link>
-          <Link
-            to="/garden/mlip-garden"
-            className="inline-block px-6 py-3 bg-gradient-to-r from-blue-600 to-indigo-600 text-white rounded-full font-semibold shadow-md hover:scale-105 hover:shadow-lg transition"
-          >
-            Run on HPC
-          </Link>
+      {/* Centered content container so backgrounds remain full-width while content aligns */}
+      <div className="relative z-10 max-w-7xl mx-auto flex flex-col md:flex-row items-center justify-between">
+        <div className="hidden md:flex flex-col items-center justify-center pl-6 pr-4">
+          <div className="w-1 h-64 bg-gradient-to-b from-blue-500 via-indigo-500 to-purple-500 rounded-full"></div>
         </div>
-      </div>
 
-      <div className="relative z-10 w-full md:w-1/2 mt-12 md:mt-0 flex justify-center">
-        <MLIPCodeSnippet />
+        <div className="w-full md:w-1/2 max-w-2xl">
+          <h1 className="text-5xl md:text-6xl font-serif font-bold text-slate-800 leading-tight mb-6">
+            <div>Machine Learned</div>
+            <span className="whitespace-nowrap bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 bg-clip-text text-transparent">
+              Interatomic Potentials
+            </span>
+          </h1>
+          <p className="text-lg md:text-xl text-slate-700 font-light leading-relaxed mb-3">
+            Use Garden to run MLIP-driven atomistic simulation tasks like relaxation and structure prediction.
+            We have the libraries and GPUs pre-configured. You just need an .xyz file and a few lines of Python.
+          </p>
+          <p className="text-sm text-slate-500 leading-relaxed mb-6 max-w-md">
+            Run workloads on participating research computing facilities like Argonne Leadership Computing Facility (ALCF) with <a href="http://globus-compute.readthedocs.io/en/stable/" className="text-indigo-600 underline underline-offset-4 hover:text-indigo-700" target="_blank" rel="noopener noreferrer">Globus Compute</a> or on the cloud with <a href="https://modal.com/" className="text-indigo-600 underline underline-offset-4 hover:text-indigo-700" target="_blank" rel="noopener noreferrer">Modal</a>.
+          </p>
+          <div className="flex flex-wrap gap-4">
+            <Link
+              to="/garden/10.26311%2Fcexg-2349"
+              className="inline-block px-6 py-3 bg-gradient-to-r from-blue-600 to-indigo-600 text-white rounded-full font-semibold shadow-md hover:scale-105 hover:shadow-lg transition"
+            >
+              Run on the cloud
+            </Link>
+            <Link
+              to="/garden/mlip-garden"
+              className="inline-block px-6 py-3 bg-gradient-to-r from-blue-600 to-indigo-600 text-white rounded-full font-semibold shadow-md hover:scale-105 hover:shadow-lg transition"
+            >
+              Run on HPC
+            </Link>
+          </div>
+        </div>
+
+        <div className="w-full md:w-1/2 mt-8 md:mt-0 flex justify-center">
+          <MLIPCodeSnippet />
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
This PR:
- Replaces remaining lorem ipsum text with (hopefully) good enough copy for the tasks and benchmarking sections.
- Tweaks typography for consistency across sections
- Makes little layout tweaks to prevent horizontal overflow and make the MLIP comparison table peek above the fold on a laptop display

<img width="795" height="386" alt="Screenshot 2025-08-07 at 5 49 26 PM" src="https://github.com/user-attachments/assets/3767967f-83a5-4488-a5cb-afcfd1387ec9" />
<img width="813" height="475" alt="Screenshot 2025-08-07 at 5 49 20 PM" src="https://github.com/user-attachments/assets/f89ca06c-e2f3-4c23-a05e-d84b7bcedae1" />
