### PR TITLE
Update with actual 7net time

### DIFF
--- a/garden/src/features/mlip-page/data/mockMLIPs.ts
+++ b/garden/src/features/mlip-page/data/mockMLIPs.ts
@@ -6,7 +6,7 @@ export const mockMLIPs: MLIPTableRow[] = [
     checkpoint: "SevenNet-MF-ompa",
     cps: 0.845,
     cloudCostPer10K: 2.21,
-    hpcNodeHoursPer10K: 1.23,
+    hpcNodeHoursPer10K: 1.54,
     modelLink: "/garden/10.26311%2Fcexg-2349/modal-functions/578",
     checkpointLink: "https://matbench-discovery.materialsproject.org/models/sevennet-mf-ompa",
   },


### PR DESCRIPTION
Official runtime from hayden is 1383.939608582994 seconds. That comes to 1.54 node hours per 10k materials