### PR TITLE
Make it easier to copy garden URLs

### DIFF
--- a/garden/src/features/gardens/components/GardenDropdownOptions.tsx
+++ b/garden/src/features/gardens/components/GardenDropdownOptions.tsx
@@ -57,8 +57,8 @@ const GardenDropdownMenu = ({
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="ghost">
-            <EllipsisVertical className="h-6 w-6" />
+          <Button variant="ghost" size={"icon"} className="hover:text-green">
+            <EllipsisVertical />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent className="w-56" align="end">

--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -84,9 +84,7 @@ const GardenContent = ({ garden, ownsThisGarden, isNewlyCreated }: GardenContent
               />
               <div className="flex items-center">
                 <SaveGardenButton garden={garden} />
-                <div className="m-2">
-                  <ShareGardenButton garden={garden} />
-                </div>
+                <ShareGardenButton garden={garden} />
                 <GardenDropdownOptions
                   garden={garden}
                   setIsPublishGardenModalOpen={setIsPublishGardenModalOpen}

--- a/garden/src/features/gardens/components/GardenPage.tsx
+++ b/garden/src/features/gardens/components/GardenPage.tsx
@@ -27,6 +27,7 @@ import { GardenMetadataSidebar } from "./GardenMetadataSidebar";
 import { EditableTitle } from "@/components/shared/metadata";
 
 import { SUPER_USERS } from "@/utils/utils";
+import { ShareGardenButton } from "./ShareGardenButton";
 
 interface GardenContentProps {
   garden: Garden;
@@ -81,8 +82,11 @@ const GardenContent = ({ garden, ownsThisGarden, isNewlyCreated }: GardenContent
                   });
                 }}
               />
-              <div className="flex">
+              <div className="flex items-center">
                 <SaveGardenButton garden={garden} />
+                <div className="m-2">
+                  <ShareGardenButton garden={garden} />
+                </div>
                 <GardenDropdownOptions
                   garden={garden}
                   setIsPublishGardenModalOpen={setIsPublishGardenModalOpen}

--- a/garden/src/features/gardens/components/SaveGardenButton.tsx
+++ b/garden/src/features/gardens/components/SaveGardenButton.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Loader2, Bookmark } from "lucide-react";
 import { Garden } from "@/types";
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from "@/components/shadcn/tooltip";
+import { Button } from "@/components/shadcn/button";
 import { cn } from "@/utils/form.utils";
 import { useGetUserInfo } from "@/features/users/api/useGetUserInfo";
 import { useSaveGarden } from "../api/useSaveGarden";
@@ -42,10 +43,11 @@ const SaveGardenButton = ({ garden }: { garden: Garden }) => {
           onMouseLeave={() => setHover(false)}
           className="px-1"
         >
-          <div
+          <Button
             onClick={handleClick}
+            size={"icon"}
+            variant={"ghost"}
             className={cn(
-              "relative flex h-8 w-8 cursor-pointer items-center justify-center rounded-full bg-transparent transition-colors duration-200 ease-in-out",
               hover ? (isSaved ? "bg-red-100" : "bg-primary/40") : "bg-transparent",
             )}
           >
@@ -57,7 +59,7 @@ const SaveGardenButton = ({ garden }: { garden: Garden }) => {
                 fill={isSaved ? "currentColor" : "none"}
               />
             )}
-          </div>
+          </Button>
         </TooltipTrigger>
         <TooltipContent>
           {user?.saved_garden_dois?.includes(garden.doi)

--- a/garden/src/features/gardens/components/ShareGardenButton.tsx
+++ b/garden/src/features/gardens/components/ShareGardenButton.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { CopyIcon } from "lucide-react";
+import { Clipboard } from "lucide-react";
 import { toast } from "sonner";
 import { Garden } from "@/types";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/tooltip";
@@ -15,7 +15,7 @@ export const ShareGardenButton = ({ garden }: { garden: Garden }) => {
             <Tooltip delayDuration={200}>
                 <TooltipTrigger asChild>
                     <div className="h-5 w-5 flex items-center justify-center hover:bg-green-400">
-                        <CopyIcon className="hover:text-green" onClick={handleClick} />
+                        <Clipboard className="hover:text-green" onClick={handleClick} />
                     </div>
                 </TooltipTrigger>
                 <TooltipContent>

--- a/garden/src/features/gardens/components/ShareGardenButton.tsx
+++ b/garden/src/features/gardens/components/ShareGardenButton.tsx
@@ -3,6 +3,7 @@ import { Clipboard } from "lucide-react";
 import { toast } from "sonner";
 import { Garden } from "@/types";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/tooltip";
+import { Button } from "@/components/shadcn/button";
 
 export const ShareGardenButton = ({ garden }: { garden: Garden }) => {
 
@@ -14,9 +15,9 @@ export const ShareGardenButton = ({ garden }: { garden: Garden }) => {
         <TooltipProvider>
             <Tooltip delayDuration={200}>
                 <TooltipTrigger asChild>
-                    <div className="h-5 w-5 flex items-center justify-center hover:bg-green-400">
-                        <Clipboard className="hover:text-green" onClick={handleClick} />
-                    </div>
+                    <Button variant="ghost" size={"icon"} className="hover:text-green" onClick={handleClick}>
+                        <Clipboard />
+                    </Button>
                 </TooltipTrigger>
                 <TooltipContent>
                     <p>Copy Garden URL</p>

--- a/garden/src/features/gardens/components/ShareGardenButton.tsx
+++ b/garden/src/features/gardens/components/ShareGardenButton.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { CopyIcon } from "lucide-react";
+import { toast } from "sonner";
+import { Garden } from "@/types";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/tooltip";
+
+export const ShareGardenButton = ({ garden }: { garden: Garden }) => {
+
+    const handleClick = () => {
+        navigator.clipboard.writeText(`${window.location.origin}/#/garden/${encodeURIComponent(garden.doi)}`)
+        toast.info("Garden URL copied to clipboard!")
+    }
+    return (
+        <TooltipProvider>
+            <Tooltip delayDuration={200}>
+                <TooltipTrigger asChild>
+                    <div className="h-5 w-5 flex items-center justify-center hover:bg-green-400">
+                        <CopyIcon className="hover:text-green" onClick={handleClick} />
+                    </div>
+                </TooltipTrigger>
+                <TooltipContent>
+                    <p>Copy Garden URL</p>
+                </TooltipContent>
+            </Tooltip>
+        </TooltipProvider>
+    );
+}

--- a/garden/src/features/search/components/SearchResult.tsx
+++ b/garden/src/features/search/components/SearchResult.tsx
@@ -20,12 +20,13 @@ import { BookOpenIcon, CalendarIcon, TagIcon } from "lucide-react";
 import { PersonIcon } from "@radix-ui/react-icons";
 
 import SaveGardenButton from "../../gardens/components/SaveGardenButton";
+import { ShareGardenButton } from "../../gardens/components/ShareGardenButton";
 import { Button } from "@/components/shadcn/button";
 
-export const SearchResult = ({ garden, verbose, showPublishedBanner = true, 
-  }: { garden: Garden; verbose: boolean; showPublishedBanner?:boolean; }) => {
-    const functions = [...(garden.entrypoints ?? []), ...(garden.modal_functions ?? [])];
-    const [showMore, setShowMore] = useState(false);
+export const SearchResult = ({ garden, verbose, showPublishedBanner = true,
+}: { garden: Garden; verbose: boolean; showPublishedBanner?: boolean; }) => {
+  const functions = [...(garden.entrypoints ?? []), ...(garden.modal_functions ?? [])];
+  const [showMore, setShowMore] = useState(false);
 
   const handleShowMore = () => {
     setShowMore(!showMore);
@@ -33,30 +34,31 @@ export const SearchResult = ({ garden, verbose, showPublishedBanner = true,
   return (
     <Card className={`relative transition-colors hover:shadow-lg ${garden.is_archived ? "bg-gray-100" : "hover:bg-gray-50"}`}>
       <CardHeader className={`${(showPublishedBanner || garden.is_archived || garden.doi_is_draft) ? "pt-8" : ""}`}>
-         {showPublishedBanner && (
-          <div style={{backgroundColor: "#C2E6CA", color: "#11451F"}}
+        {showPublishedBanner && (
+          <div style={{ backgroundColor: "#C2E6CA", color: "#11451F" }}
             className="absolute top-0 left-0 w-full rounded-t-md px-4 py-1 text-center text-sm font-semibold shadow-sm">
-              Published
-            </div>
-         )}
+            Published
+          </div>
+        )}
         <div className="flex items-start justify-between space-x-3">
           {garden.is_archived && (
-          <div style={{backgroundColor: "#D2D1F7", color: "#3C2F67"}}
-            className="absolute top-0 left-0 w-full rounded-t-md px-4 py-1 text-center text-sm font-semibold shadow-sm">
+            <div style={{ backgroundColor: "#D2D1F7", color: "#3C2F67" }}
+              className="absolute top-0 left-0 w-full rounded-t-md px-4 py-1 text-center text-sm font-semibold shadow-sm">
               Archived
-          </div>
-         )}
-         {garden.doi_is_draft && (
-          <div style={{backgroundColor: "#DBE9FF", color: "#28487B"}}
-            className="absolute top-0 left-0 w-full rounded-t-md px-4 py-1 text-center text-sm font-semibold shadow-sm">
+            </div>
+          )}
+          {garden.doi_is_draft && (
+            <div style={{ backgroundColor: "#DBE9FF", color: "#28487B" }}
+              className="absolute top-0 left-0 w-full rounded-t-md px-4 py-1 text-center text-sm font-semibold shadow-sm">
               Draft
             </div>
-         )}
+          )}
           <CardTitle className="line-clamp-2 text-xl font-bold transition-colors duration-300 hover:text-primary">
             <Link to={`/garden/${encodeURIComponent(garden.doi)}`}>{garden.title}</Link>
           </CardTitle>
           <div className="flex items-center space-x-1  text-gray-600">
             <SaveGardenButton garden={garden} />
+            <ShareGardenButton garden={garden} />
           </div>
         </div>
 
@@ -65,10 +67,10 @@ export const SearchResult = ({ garden, verbose, showPublishedBanner = true,
           to={`/garden/${encodeURIComponent(garden.doi)}`}
         >
           DOI: {garden.doi}
-          {garden.marked_for_deletion && garden.doi_is_draft &&(
-            <div style={{backgroundColor: "#F0C2BD", color: "#411528"}}
+          {garden.marked_for_deletion && garden.doi_is_draft && (
+            <div style={{ backgroundColor: "#F0C2BD", color: "#411528" }}
               className="ml-2 inline-block rounded px-2 py-0.5 text-xs font-medium">
-                Marked for Deletion
+              Marked for Deletion
             </div>
           )}
         </Link>
@@ -83,20 +85,20 @@ export const SearchResult = ({ garden, verbose, showPublishedBanner = true,
           </span>
         </CardDescription>
       </CardHeader>
-      
+
       <div className="p-1">
-        <MarkdownCardContent 
+        <MarkdownCardContent
           className={`m-2 p-2 text-balanced ${(showMore) ? "" : "line-clamp-3"}`}
           content={garden.description || "*No description available*"}
         />
-        <Button 
+        <Button
           onClick={handleShowMore}
           className="text-black text-xs bg-inherit hover:text-blue-400 hover:bg-inherit hover:underline"
         >
           {(showMore) ? "Show Less" : "Show More"}
         </Button>
       </div>
-      
+
       {verbose && functions?.length > 0 && (
         <CardContent>
           <div>


### PR DESCRIPTION
Resolves: #422 

This PR makes it easier to share a garden by adding a button to the top of the garden pages and garden cards that copies the URL to the garden's detail page to the users clipboard. To provide some visual feedback, a toast pops up confirming the URL was indeed copied to the clipboard.


https://github.com/user-attachments/assets/96d5fad9-1f6b-4bcb-a3d1-2bf982ae3f32

I also tweaked the `SaveGardenButton` and `GardenDropdownOptions` styles so that we have a more consistent look and feel for these icons/buttons.