### PR TITLE
copy doi.org URL if published, otherwise fallback to garden URL

### DIFF
--- a/garden/src/features/gardens/components/ShareGardenButton.tsx
+++ b/garden/src/features/gardens/components/ShareGardenButton.tsx
@@ -7,9 +7,14 @@ import { Button } from "@/components/shadcn/button";
 
 export const ShareGardenButton = ({ garden }: { garden: Garden }) => {
 
+    const useDoi = !garden.doi_is_draft;
+    const copyText = (useDoi) ? garden.doi
+        : `${window.location.origin}/#/garden/${encodeURIComponent(garden.doi)}`;
+    const toastText = (useDoi) ? "DOI" : "URL";
+
     const handleClick = () => {
-        navigator.clipboard.writeText(`${window.location.origin}/#/garden/${encodeURIComponent(garden.doi)}`)
-        toast.info("Garden URL copied to clipboard!")
+        navigator.clipboard.writeText(copyText)
+        toast.info(`Garden ${toastText} copied to clipboard!`)
     }
     return (
         <TooltipProvider>
@@ -20,7 +25,7 @@ export const ShareGardenButton = ({ garden }: { garden: Garden }) => {
                     </Button>
                 </TooltipTrigger>
                 <TooltipContent>
-                    <p>Copy Garden URL</p>
+                    <p>Copy Garden {toastText}</p>
                 </TooltipContent>
             </Tooltip>
         </TooltipProvider>

--- a/garden/src/features/gardens/components/ShareGardenButton.tsx
+++ b/garden/src/features/gardens/components/ShareGardenButton.tsx
@@ -8,9 +8,9 @@ import { Button } from "@/components/shadcn/button";
 export const ShareGardenButton = ({ garden }: { garden: Garden }) => {
 
     const useDoi = !garden.doi_is_draft;
-    const copyText = (useDoi) ? garden.doi
-        : `${window.location.origin}/#/garden/${encodeURIComponent(garden.doi)}`;
-    const toastText = (useDoi) ? "DOI" : "URL";
+    const copyText = (useDoi) ? `https://doi.org/${garden.doi}`
+        : `${window.location.origin}/#/garden / ${encodeURIComponent(garden.doi)} `;
+    const toastText = (useDoi) ? "doi.org URL" : "URL";
 
     const handleClick = () => {
         navigator.clipboard.writeText(copyText)


### PR DESCRIPTION
This is a small tweak to the `ShareGardenButton` that makes it use the DOI if the garden is published, otherwise falls back to the URL.


https://github.com/user-attachments/assets/62985dd8-29a3-4162-a21e-b2311305b930

