### PR TITLE
fix errant spaces in garden url

### DIFF
--- a/garden/src/features/gardens/components/ShareGardenButton.tsx
+++ b/garden/src/features/gardens/components/ShareGardenButton.tsx
@@ -9,7 +9,7 @@ export const ShareGardenButton = ({ garden }: { garden: Garden }) => {
 
     const useDoi = !garden.doi_is_draft;
     const copyText = (useDoi) ? `https://doi.org/${garden.doi}`
-        : `${window.location.origin}/#/garden / ${encodeURIComponent(garden.doi)} `;
+        : `${window.location.origin}/#/garden/${encodeURIComponent(garden.doi)}`;
     const toastText = (useDoi) ? "doi.org URL" : "URL";
 
     const handleClick = () => {


### PR DESCRIPTION
Something went wrong (or I fat-fingered something in vim) that put spaces around the backslashes in the garden url in the `ShareGardenButton`. This is a quick fix.