### PR TITLE
Description rendering and editing enhancements

### DIFF
--- a/garden/index.html
+++ b/garden/index.html
@@ -51,6 +51,11 @@
       rel="stylesheet"
     />
 
+    <!-- Monospace font -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Mono:wght@100..900&display=swap" rel="stylesheet">
+
     <title>Garden</title>
   </head>
 

--- a/garden/package-lock.json
+++ b/garden/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@codemirror/commands": "^6.8.0",
+        "@codemirror/lang-markdown": "^6.3.4",
         "@codemirror/lang-python": "^6.1.7",
         "@codemirror/language": "^6.11.0",
         "@codemirror/language-data": "^6.5.1",
@@ -647,9 +648,9 @@
       }
     },
     "node_modules/@codemirror/lang-markdown": {
-      "version": "6.3.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.3.3.tgz",
-      "integrity": "sha512-1fn1hQAPWlSSMCvnF810AkhWpNLkJpl66CRfIy3vVl20Sl4NwChkorCHqpMtNbXr1EuMJsrDnhEpjZxKZ2UX3A==",
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.3.4.tgz",
+      "integrity": "sha512-fBm0BO03azXnTAsxhONDYHi/qWSI+uSEIpzKM7h/bkIc9fHnFp9y7KTMXKON0teNT97pFhc1a9DQTtWBYEZ7ug==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.7.1",

--- a/garden/package.json
+++ b/garden/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "dependencies": {
     "@codemirror/commands": "^6.8.0",
+    "@codemirror/lang-markdown": "^6.3.4",
     "@codemirror/lang-python": "^6.1.7",
     "@codemirror/language": "^6.11.0",
     "@codemirror/language-data": "^6.5.1",

--- a/garden/src/components/EditableCodeField.tsx
+++ b/garden/src/components/EditableCodeField.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 import { EditorState } from '@codemirror/state';
 import { EditorView, keymap } from '@codemirror/view';
 import { python } from '@codemirror/lang-python';
+import { markdown } from "@codemirror/lang-markdown";
 import { defaultKeymap, indentWithTab } from '@codemirror/commands';
 import { syntaxHighlighting, defaultHighlightStyle } from '@codemirror/language';
 import { Button } from './shadcn/button';
@@ -42,8 +43,11 @@ interface EditableCodeFieldProps {
   value: string;
   fieldName: string;
   onSave: (value: string) => Promise<void>;
-  ownsThisFunction: boolean;
+  onEdit?: (value: string) => void;
+  ownsThisEntity: boolean;
   language?: string;
+  editing: boolean;
+  showSaveButton: boolean;
 }
 
 export const EditableCodeField = ({
@@ -51,10 +55,13 @@ export const EditableCodeField = ({
   value,
   fieldName,
   onSave,
-  ownsThisFunction,
+  onEdit = () => { },
+  ownsThisEntity: ownsThisFunction,
   language = 'python',
+  editing = false,
+  showSaveButton = true,
 }: EditableCodeFieldProps) => {
-  const [isEditing, setIsEditing] = useState(false);
+  const [isEditing, setIsEditing] = useState(editing);
   const [isSaving, setIsSaving] = useState(false);
   const [editValue, setEditValue] = useState(value || '');
   const editorRef = useRef<HTMLDivElement>(null);
@@ -65,12 +72,13 @@ export const EditableCodeField = ({
       const startState = EditorState.create({
         doc: value || '',
         extensions: [
-          python(),
+          (language === "python") ? python() : markdown(),
           ...basicSetup,
           EditorView.updateListener.of(update => {
             if (update.docChanged) {
               const newValue = update.state.doc.toString();
               setEditValue(newValue);
+              onEdit(newValue);
             }
           })
         ]
@@ -152,37 +160,38 @@ export const EditableCodeField = ({
   return (
     <div className="group border border-transparent bg-white rounded-md py-1.5 px-2.5 shadow-sm">
       <p className="text-sm text-gray-500 font-medium mb-1">{label}</p>
-      <div 
+      <div
         ref={editorRef}
         className="w-full min-h-[200px] font-mono text-sm rounded-md overflow-hidden border border-gray-200 resize-vertical"
         style={{ resize: 'vertical' }}
       />
-      <div className="flex justify-end gap-2 mt-2">
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={handleCancel}
-          className="h-7 px-2"
-          disabled={isSaving}
-        >
-          <XIcon className="h-4 w-4 mr-1" />
-          Cancel
-        </Button>
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={handleSave}
-          className="h-7 px-2"
-          disabled={isSaving}
-        >
-          {isSaving ? (
-            <Loader2Icon className="h-4 w-4 mr-1 animate-spin" />
-          ) : (
-            <CheckIcon className="h-4 w-4 mr-1" />
-          )}
-          {isSaving ? 'Saving...' : 'Save'}
-        </Button>
-      </div>
+      {(showSaveButton) ?
+        <div className="flex justify-end gap-2 mt-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleCancel}
+            className="h-7 px-2"
+            disabled={isSaving}
+          >
+            <XIcon className="h-4 w-4 mr-1" />
+            Cancel
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleSave}
+            className="h-7 px-2"
+            disabled={isSaving}
+          >
+            {isSaving ? (
+              <Loader2Icon className="h-4 w-4 mr-1 animate-spin" />
+            ) : (
+              <CheckIcon className="h-4 w-4 mr-1" />
+            )}
+            {isSaving ? 'Saving...' : 'Save'}
+          </Button>
+        </div> : <></>}
     </div>
   );
 }; 

--- a/garden/src/components/EditableCodeField.tsx
+++ b/garden/src/components/EditableCodeField.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import { useEffect, useRef, useState } from 'react';
 import { EditorState } from '@codemirror/state';
-import { EditorView, keymap } from '@codemirror/view';
+import { EditorView, keymap, lineNumbers } from '@codemirror/view';
 import { python } from '@codemirror/lang-python';
 import { markdown } from "@codemirror/lang-markdown";
-import { defaultKeymap, indentWithTab } from '@codemirror/commands';
-import { syntaxHighlighting, defaultHighlightStyle } from '@codemirror/language';
+import { defaultKeymap, indentWithTab, history, historyKeymap } from '@codemirror/commands';
+import { syntaxHighlighting, defaultHighlightStyle, indentOnInput, bracketMatching } from '@codemirror/language';
+import { autocompletion, completionKeymap, closeBrackets, closeBracketsKeymap } from '@codemirror/autocomplete';
 import { Button } from './shadcn/button';
 import { XIcon, CheckIcon, Loader2Icon, EditIcon } from 'lucide-react';
 import CopyButton from './CopyButton';
@@ -29,7 +30,7 @@ const basicSetup = [
       height: '100%'
     },
     '.cm-content': {
-      fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+      fontFamily: 'Noto Sans Mono, monospace',
       padding: '8px'
     },
     '.cm-scroller': {
@@ -72,7 +73,7 @@ export const EditableCodeField = ({
       const startState = EditorState.create({
         doc: value || '',
         extensions: [
-          (language === "python") ? python() : markdown(),
+          (language === "python") ? python() : markdown({ defaultCodeLanguage: python() }),
           ...basicSetup,
           EditorView.updateListener.of(update => {
             if (update.docChanged) {
@@ -80,7 +81,18 @@ export const EditableCodeField = ({
               setEditValue(newValue);
               onEdit(newValue);
             }
-          })
+          }),
+          lineNumbers(),
+          indentOnInput(),
+          bracketMatching(),
+          closeBrackets(),
+          autocompletion(),
+          history(),
+          keymap.of([
+            ...closeBracketsKeymap,
+            ...completionKeymap,
+            ...historyKeymap,
+          ]),
         ]
       });
 

--- a/garden/src/components/shared/metadata/EditableMetadataField.tsx
+++ b/garden/src/components/shared/metadata/EditableMetadataField.tsx
@@ -3,11 +3,11 @@ import { useState, useEffect } from "react";
 import { EditIcon, SaveIcon, XIcon, InfoIcon } from "lucide-react";
 import { Button } from "@/components/shadcn/button";
 import { Input } from "@/components/shadcn/input";
-import { Textarea } from "@/components/shadcn/textarea";
 import MultipleSelector from "@/components/shadcn/multiple-select";
 import { Garden, ModalFunction } from "@/types";
 import { toast } from "sonner";
 import Markdown from "@/components/Markdown";
+import { EditableCodeField } from "@/components/EditableCodeField";
 import {
   Tooltip,
   TooltipContent,
@@ -129,11 +129,16 @@ const EditableMetadataField = ({
             />
           )
         ) : fieldName === 'description' ? (
-          <Textarea
-            value={inputValue as string}
-            onChange={(e) => setInputValue(e.target.value)}
-            placeholder={placeholder}
-            className="w-full min-h-[80px]"
+          <EditableCodeField
+            label="Markdown"
+            language="markdown"
+            fieldName="description"
+            onSave={async (value) => { }}
+            onEdit={(newValue) => { setInputValue(newValue) }}
+            value={entity.description || ""}
+            ownsThisEntity={ownsThisEntity}
+            editing={true}
+            showSaveButton={false}
           />
         ) : (
           <Input

--- a/garden/src/components/shared/metadata/EditableMetadataField.tsx
+++ b/garden/src/components/shared/metadata/EditableMetadataField.tsx
@@ -6,8 +6,8 @@ import { Input } from "@/components/shadcn/input";
 import MultipleSelector from "@/components/shadcn/multiple-select";
 import { Garden, ModalFunction } from "@/types";
 import { toast } from "sonner";
-import Markdown from "@/components/Markdown";
 import { EditableCodeField } from "@/components/EditableCodeField";
+import TruncatedDescription from "@/components/shared/metadata/TruncatedDescription";
 import {
   Tooltip,
   TooltipContent,
@@ -234,9 +234,7 @@ const EditableMetadataField = ({
             )}
           </div>
         ) : fieldName === 'description' ? (
-          <div className="prose prose-sm max-w-none prose-p:text-gray-700 prose-headings:text-gray-800">
-            <Markdown content={value as string || ""} />
-          </div>
+          <TruncatedDescription content={value as string || ""} />
         ) : (
           // Display single value
           <p className="font-medium text-gray-800">

--- a/garden/src/components/shared/metadata/TruncatedDescription.tsx
+++ b/garden/src/components/shared/metadata/TruncatedDescription.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { useState } from "react";
+import Markdown from "@/components/Markdown";
+
+interface TruncatedDescriptionProps {
+  content: string;
+  maxLength?: number;
+}
+
+const TruncatedDescription = ({ content, maxLength = 500 }: TruncatedDescriptionProps) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  if (!content) return null;
+
+  const shouldTruncate = content.length > maxLength;
+  const displayContent = shouldTruncate && !isExpanded
+    ? content.slice(0, maxLength) + '...'
+    : content;
+
+  return (
+    <div className="prose prose-sm max-w-none prose-p:text-gray-700 prose-headings:text-gray-800">
+      <Markdown content={displayContent} />
+      {shouldTruncate && (
+        <div className="flex justify-end">
+          <button
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="text-blue-600 hover:text-blue-800 text-sm font-medium mt-2"
+          >
+            {isExpanded ? 'Show Less' : 'Show More'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TruncatedDescription;

--- a/garden/src/features/gardens/components/garden-page/GardenDescription.tsx
+++ b/garden/src/features/gardens/components/garden-page/GardenDescription.tsx
@@ -9,7 +9,7 @@ interface GardenDescriptionProps {
 }
 
 const GardenDescription = ({ garden, ownsThisGarden }: GardenDescriptionProps) => {
-  const { mutateAsync: updateGarden} = usePatchGarden();
+  const { mutateAsync: updateGarden } = usePatchGarden();
 
   return (
     <div className="space-y-3 py-2">

--- a/garden/src/features/materials/components/ModalAssociatedMaterials.tsx
+++ b/garden/src/features/materials/components/ModalAssociatedMaterials.tsx
@@ -50,14 +50,14 @@ const AssociatedMaterials = ({ resource, ownsThisFunction }: AssociatedMaterials
     try {
       const currentMaterials = resource[type] || [];
       const updatedMaterials = [...currentMaterials, material];
-      
+
       await patchModalFunction({
         id: resource.id,
         modalFunction: {
           [type]: updatedMaterials
         }
       });
-      
+
       toast.success(`${type.slice(0, -1)} added successfully`);
     } catch (error) {
       toast.error(`Failed to add ${type.slice(0, -1)}`);
@@ -70,14 +70,14 @@ const AssociatedMaterials = ({ resource, ownsThisFunction }: AssociatedMaterials
       const currentMaterials = resource[type] || [];
       const updatedMaterials = [...currentMaterials];
       updatedMaterials[index] = material;
-      
+
       await patchModalFunction({
         id: resource.id,
         modalFunction: {
           [type]: updatedMaterials
         }
       });
-      
+
       toast.success(`${type.slice(0, -1)} updated successfully`);
     } catch (error) {
       toast.error(`Failed to update ${type.slice(0, -1)}`);
@@ -89,14 +89,14 @@ const AssociatedMaterials = ({ resource, ownsThisFunction }: AssociatedMaterials
     try {
       const currentMaterials = resource[type] || [];
       const updatedMaterials = currentMaterials.filter((_, i) => i !== index);
-      
+
       await patchModalFunction({
         id: resource.id,
         modalFunction: {
           [type]: updatedMaterials
         }
       });
-      
+
       toast.success(`${type.slice(0, -1)} removed successfully`);
     } catch (error) {
       toast.error(`Failed to remove ${type.slice(0, -1)}`);
@@ -106,8 +106,8 @@ const AssociatedMaterials = ({ resource, ownsThisFunction }: AssociatedMaterials
 
   return (
     <div className="mt-6">
-      <Tabs 
-        defaultValue="function" 
+      <Tabs
+        defaultValue="function"
         className="w-full min-h-[400px]"
       >
         <TabsList className="mb-2 bg-gray-200 p-0.5 grid grid-cols-6">
@@ -154,17 +154,13 @@ const AssociatedMaterials = ({ resource, ownsThisFunction }: AssociatedMaterials
               <CardTitle className="text-xl font-bold text-gray-800">
                 {resource.function_name}
               </CardTitle>
-              <MarkdownCardContent 
-                className="mt-1 text-gray-600"
-                content={resource.description || ""}
-              />
             </CardHeader>
             <CardContent className="px-6 py-4">
               <SyntaxHighlighter>{resource.function_text}</SyntaxHighlighter>
             </CardContent>
           </Card>
         </TabsContent>
-        
+
         {/* App Text Tab */}
         <TabsContent value="apptext" className="mt-0 relative p-4">
           {!resource.file_contents ? (
@@ -201,7 +197,7 @@ const AssociatedMaterials = ({ resource, ownsThisFunction }: AssociatedMaterials
             </Card>
           )}
         </TabsContent>
-        
+
         {/* Datasets Tab */}
         <TabsContent value="datasets" className="mt-0 relative">
           <Card className="border-0 shadow-none bg-transparent">
@@ -225,12 +221,12 @@ const AssociatedMaterials = ({ resource, ownsThisFunction }: AssociatedMaterials
                     />
                   )}
                 </div>
-                
+
                 {datasets.length > 0 ? (
                   <div className="grid grid-cols-1 gap-8 py-2">
                     {datasets.map((dataset, index) => (
-                      <DatasetCard 
-                        key={dataset.doi || index} 
+                      <DatasetCard
+                        key={dataset.doi || index}
                         dataset={dataset}
                         isOwner={ownsThisFunction}
                         context={{
@@ -249,7 +245,7 @@ const AssociatedMaterials = ({ resource, ownsThisFunction }: AssociatedMaterials
             </CardContent>
           </Card>
         </TabsContent>
-        
+
         {/* Papers Tab */}
         <TabsContent value="papers" className="mt-0 relative">
           <Card className="border-0 shadow-none bg-transparent">
@@ -262,7 +258,7 @@ const AssociatedMaterials = ({ resource, ownsThisFunction }: AssociatedMaterials
                   </h3>
                   {ownsThisFunction && (
                     <PaperModal
-                      context={{modalFunction: resource}}
+                      context={{ modalFunction: resource }}
                       onSave={(data) => handleAddMaterial('papers', data)}
                       trigger={
                         <Button type="button" variant="outline">
@@ -273,12 +269,12 @@ const AssociatedMaterials = ({ resource, ownsThisFunction }: AssociatedMaterials
                     />
                   )}
                 </div>
-                
+
                 {papers.length > 0 ? (
                   <div className="grid grid-cols-1 gap-8 py-2">
                     {papers.map((paper, index) => (
-                      <PaperCard 
-                        key={paper.doi || paper.title || index} 
+                      <PaperCard
+                        key={paper.doi || paper.title || index}
                         paper={paper}
                         isOwner={ownsThisFunction}
                         context={{
@@ -321,12 +317,12 @@ const AssociatedMaterials = ({ resource, ownsThisFunction }: AssociatedMaterials
                     />
                   )}
                 </div>
-                
+
                 {repositories.length > 0 ? (
                   <div className="grid grid-cols-1 gap-8 py-2">
                     {repositories.map((repo, index) => (
-                      <RepositoryCard 
-                        key={repo.url || index} 
+                      <RepositoryCard
+                        key={repo.url || index}
                         repository={repo}
                         isOwner={ownsThisFunction}
                         context={{
@@ -369,12 +365,12 @@ const AssociatedMaterials = ({ resource, ownsThisFunction }: AssociatedMaterials
                     />
                   )}
                 </div>
-                
+
                 {notebooks.length > 0 ? (
                   <div className="grid grid-cols-1 gap-8 py-2">
                     {notebooks.map((notebook, index) => (
-                      <NotebookCard 
-                        key={notebook.url || index} 
+                      <NotebookCard
+                        key={notebook.url || index}
                         notebook={notebook}
                         isOwner={ownsThisFunction}
                         context={{

--- a/garden/src/features/modal/components/ModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/ModalFunctionPage.tsx
@@ -171,7 +171,7 @@ return my_garden.${modalFunction.function_name}(input)`;
       value={modalFunction.example_usage || defaultExample}
       fieldName="example_usage"
       onSave={handleSave}
-      ownsThisFunction={ownsThisFunction}
+      ownsThisEntity={ownsThisFunction}
       language="python"
     />
   );

--- a/garden/src/features/modal/components/ModalFunctionPage.tsx
+++ b/garden/src/features/modal/components/ModalFunctionPage.tsx
@@ -173,6 +173,8 @@ return my_garden.${modalFunction.function_name}(input)`;
       onSave={handleSave}
       ownsThisEntity={ownsThisFunction}
       language="python"
+      editing={false}
+      showSaveButton={true}
     />
   );
 };


### PR DESCRIPTION
Resolves: #418 
Resolves: #420

This PR adds a 'Show More' toggle for long descriptions on both Garden and Function pages. It also adds some enhancements to the editing experience for descriptions (and the example usage editing on function pages).

## Show More toggle

*Before* - super long description pushes everything way down the page

https://github.com/user-attachments/assets/4823a37e-e562-4497-8ea5-c07179fad476

*After* -- a nice 'Show More' toggle

https://github.com/user-attachments/assets/40dbe8ed-c34d-41e9-ac46-6f0726261f66

## Editing enhancements

*Before* - basic text box input that was really tiny and not obvious that you could expand it

https://github.com/user-attachments/assets/9d933845-8ea1-4b6d-82dd-e96249b984a4

*After* - a nice text editing experience with clear indication that it supports markdown

https://github.com/user-attachments/assets/42e7618b-3f9e-4053-8309-ae00d6ea15f0

*Bonus* -  editing python code has some basic autocomplete and automatic bracket closing

https://github.com/user-attachments/assets/126d6c7b-8294-436d-ab61-beba54ae9d1d


