### PR TITLE
Auto-fill Paper modal from doi.org URL and raw DOIs

### DIFF
--- a/garden/src/features/materials/components/modals/PaperModal.tsx
+++ b/garden/src/features/materials/components/modals/PaperModal.tsx
@@ -1,6 +1,7 @@
+import React from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Book, CheckCheck, FileText, Hash, Link, Loader2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { useState, useEffect } from "react";
 import { toast } from "sonner";
 
@@ -24,11 +25,11 @@ import {
   FormDescription,
 } from "@/components/shadcn/form";
 import { Input } from "@/components/shadcn/input";
-import { Textarea } from "@/components/shadcn/textarea";
 import MultipleSelector from "@/components/shadcn/multiple-select";
-import { Garden, ModalFunction, Paper } from "@/types";
-import { paperSchema, PaperSchema} from "../../types/material.types";
+import { Paper } from "@/types";
+import { paperSchema, PaperSchema } from "../../types/material.types";
 import { extractArxivId, fetchArxivMetadata } from "../../utils/arxiv";
+import { extractDoiFromUrl, validateDoi, fetchDoiMetadata } from "../../utils/doi";
 import { Checkbox } from "@/components/shadcn/checkbox";
 import { usePatchGarden } from "@/features/gardens/api/usePatchGarden";
 import { usePatchModalFunction } from "@/features/modal/api/usePatchModalFunction";
@@ -46,9 +47,10 @@ const PaperModal = ({ edit, onSave, initialData, trigger, context }: PaperModalP
   const [isOpen, setIsOpen] = useState(false);
   const [isLoadingMetadata, setIsLoadingMetadata] = useState(false);
   const [previousUrl, setPreviousUrl] = useState("");
+  const [previousDoi, setPreviousDoi] = useState("");
   const [addAuthorsToEntity, setAddAuthorsToEntity] = useState(false);
-  const { mutate: patchGarden} = usePatchGarden();
-  const { mutate: patchModalFunction} = usePatchModalFunction();
+  const { mutate: patchGarden } = usePatchGarden();
+  const { mutate: patchModalFunction } = usePatchModalFunction();
 
   const form = useForm<PaperSchema>({
     resolver: zodResolver(paperSchema),
@@ -66,6 +68,7 @@ const PaperModal = ({ edit, onSave, initialData, trigger, context }: PaperModalP
   });
 
   const url = form.watch("url");
+  const doi = form.watch("doi");
 
   // Reset form when modal is opened or closed
   useEffect(() => {
@@ -94,51 +97,60 @@ const PaperModal = ({ edit, onSave, initialData, trigger, context }: PaperModalP
         });
       }
       setPreviousUrl("");
+      setPreviousDoi("");
     }
   }, [isOpen, edit, initialData, form]);
 
   useEffect(() => {
+    const autoFillMetadata = async (metadata: Partial<Paper>, source: string) => {
+      let fieldsUpdated = false;
+
+      // Only auto-fill empty fields
+      if (metadata.title && !form.getValues("title")) {
+        form.setValue("title", metadata.title);
+        fieldsUpdated = true;
+      }
+
+      if (metadata.doi && !form.getValues("doi")) {
+        form.setValue("doi", metadata.doi);
+        fieldsUpdated = true;
+      }
+
+      if (metadata.url && !form.getValues("url")) {
+        form.setValue("url", metadata.url);
+        fieldsUpdated = true;
+      }
+
+      if (metadata.citation && !form.getValues("citation")) {
+        form.setValue("citation", metadata.citation);
+        fieldsUpdated = true;
+      }
+
+      // Check if authors field is empty
+      const currentAuthors = form.getValues("authors");
+      const isAuthorsEmpty = !currentAuthors || currentAuthors.length === 0;
+
+      if (metadata.authors && metadata.authors.length > 0 && isAuthorsEmpty) {
+        form.setValue(
+          "authors",
+          metadata.authors.map((author) => ({
+            value: author,
+            label: author,
+          }))
+        );
+        fieldsUpdated = true;
+      }
+
+      if (fieldsUpdated) {
+        toast.success(`Paper metadata auto-filled from ${source}`);
+      }
+    };
+
     const fetchArxivData = async (arxivId: string) => {
       setIsLoadingMetadata(true);
       try {
         const metadata = await fetchArxivMetadata(arxivId);
-        
-        let fieldsUpdated = false;
-        
-        // Only auto-fill empty fields
-        if (metadata.title && !form.getValues("title")) {
-          form.setValue("title", metadata.title);
-          fieldsUpdated = true;
-        }
-        
-        if (metadata.doi && !form.getValues("doi")) {
-          form.setValue("doi", metadata.doi);
-          fieldsUpdated = true;
-        }
-        
-        if (metadata.citation && !form.getValues("citation")) {
-          form.setValue("citation", metadata.citation);
-          fieldsUpdated = true;
-        }
-        
-        // Check if authors field is empty
-        const currentAuthors = form.getValues("authors");
-        const isAuthorsEmpty = !currentAuthors || currentAuthors.length === 0;
-        
-        if (metadata.authors && metadata.authors.length > 0 && isAuthorsEmpty) {
-          form.setValue(
-            "authors",
-            metadata.authors.map((author) => ({
-              value: author,
-              label: author,
-            }))
-          );
-          fieldsUpdated = true;
-        }
-        
-        if (fieldsUpdated) {
-          toast.success("Paper metadata auto-filled from arXiv");
-        }
+        await autoFillMetadata(metadata, "arXiv");
       } catch (error) {
         console.error("Error fetching arXiv metadata:", error);
         toast.error("Failed to fetch paper metadata from arXiv");
@@ -147,15 +159,50 @@ const PaperModal = ({ edit, onSave, initialData, trigger, context }: PaperModalP
       }
     };
 
-    // Check if URL is an arXiv link and different from the previous one
+    const fetchDoiData = async (doi: string) => {
+      setIsLoadingMetadata(true);
+      try {
+        const metadata = await fetchDoiMetadata(doi);
+        await autoFillMetadata(metadata, "DOI");
+      } catch (error) {
+        console.error("Error fetching DOI metadata:", error);
+        toast.error("Failed to fetch paper metadata from DOI");
+      } finally {
+        setIsLoadingMetadata(false);
+      }
+    };
+
+    // Check if URL changed and process it
     if (url && url !== previousUrl) {
       setPreviousUrl(url);
+
+      // Try arxiv
       const arxivId = extractArxivId(url);
       if (arxivId) {
         fetchArxivData(arxivId);
+        return;
+      }
+
+      // Try DOI URL if not arXiv
+      const doiFromUrl = extractDoiFromUrl(url);
+      if (doiFromUrl) {
+        fetchDoiData(doiFromUrl);
+        return;
       }
     }
-  }, [url, form, previousUrl]);
+
+    // Check if DOI field changed and process it
+    if (doi && doi !== previousDoi) {
+      setPreviousDoi(doi);
+
+      // Validate and fetch DOI metadata
+      const validDoi = validateDoi(doi);
+      if (validDoi) {
+        fetchDoiData(validDoi);
+        return;
+      }
+    }
+  }, [url, doi, form, previousUrl, previousDoi]);
 
   const handleSave = (data: PaperSchema) => {
     if (addAuthorsToEntity) {
@@ -163,7 +210,7 @@ const PaperModal = ({ edit, onSave, initialData, trigger, context }: PaperModalP
         // Get unique authors by comparing string values rather than object references
         const existingGardenAuthors = context.garden.authors || [];
         const newAuthors = data.authors?.map(a => a.value) || [];
-        
+
         // Create a properly deduplicated list by using a Set with string values
         const uniqueGardenAuthors = Array.from(new Set([...existingGardenAuthors, ...newAuthors]));
 
@@ -177,7 +224,7 @@ const PaperModal = ({ edit, onSave, initialData, trigger, context }: PaperModalP
       if (context.modalFunction) {
         const existingModalAuthors = context.modalFunction.authors || [];
         const newAuthors = data.authors?.map(a => a.value) || [];
-        
+
         // Create a properly deduplicated list by using a Set with string values
         const uniqueModalAuthors = Array.from(new Set([...existingModalAuthors, ...newAuthors]));
 
@@ -216,9 +263,9 @@ const PaperModal = ({ edit, onSave, initialData, trigger, context }: PaperModalP
                   <FormLabel>Paper URL</FormLabel>
                   <FormControl>
                     <div className="relative">
-                      <Input 
-                        {...field} 
-                        placeholder="https://arxiv.org/abs/2101.12345 or https://arxiv.org/pdf/2101.12345.pdf" 
+                      <Input
+                        {...field}
+                        placeholder="https://doi.org/10.1038/nature12373 or https://arxiv.org/abs/2101.12345"
                         className={isLoadingMetadata ? "pr-10" : ""}
                       />
                       {isLoadingMetadata && (
@@ -229,7 +276,24 @@ const PaperModal = ({ edit, onSave, initialData, trigger, context }: PaperModalP
                     </div>
                   </FormControl>
                   <FormDescription>
-                    Paste an arXiv link to auto-fill paper details
+                    Paste a doi.org or arXiv URL to auto-fill paper details
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="doi"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Paper DOI</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder="10.1038/nature12373" value={field.value || ""} />
+                  </FormControl>
+                  <FormDescription>
+                    Paste a DOI to auto-fill paper details
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -250,19 +314,6 @@ const PaperModal = ({ edit, onSave, initialData, trigger, context }: PaperModalP
               )}
             />
 
-            <FormField
-              control={form.control}
-              name="doi"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Paper DOI</FormLabel>
-                  <FormControl>
-                    <Input {...field} className="rounded-l-none" placeholder="Paper DOI" value={field.value || ""} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
 
             <FormField
               control={form.control}

--- a/garden/src/features/materials/utils/doi.ts
+++ b/garden/src/features/materials/utils/doi.ts
@@ -1,0 +1,144 @@
+import { Paper } from "@/types";
+
+/**
+ * Extracts DOI from a URL
+ * @param url The URL to check
+ * @returns The DOI if found, otherwise null
+ */
+export const extractDoiFromUrl = (url: string): string | null => {
+  if (!url) return null;
+
+  if (url.includes("doi.org/")) {
+    const doiIndex = url.indexOf("doi.org/");
+    const doi = url.substring(doiIndex + 8);
+    return doi;
+  }
+
+  return null;
+};
+
+/**
+ * Validates and cleans a bare DOI string
+ * @param input The potential DOI string
+ * @returns The cleaned DOI if valid, otherwise null
+ */
+export const validateDoi = (input: string): string | null => {
+  if (!input) return null;
+
+  // Clean up whitespace
+  const cleaned = input.trim();
+
+  // Check if it matches DOI format (starts with 10.)
+  const doiMatch = cleaned.match(/^(10\.\d+\/[^\s]+)/);
+  if (doiMatch) {
+    return doiMatch[1];
+  }
+
+  return null;
+};
+
+/**
+ * Parse BibTeX string to extract paper metadata
+ * @param bibtex The BibTeX string
+ * @returns Parsed metadata
+ */
+export const parseBibtex = (bibtex: string): Partial<Paper> => {
+  const metadata: Partial<Paper> = {};
+
+  // Extract title
+  const titleMatch = bibtex.match(/title\s*=\s*{([^}]+)}/i);
+  if (titleMatch) {
+    metadata.title = titleMatch[1].trim();
+  }
+
+  // Extract DOI
+  const doiMatch = bibtex.match(/doi\s*=\s*{([^}]+)}/i);
+  if (doiMatch) {
+    metadata.doi = doiMatch[1].trim();
+  }
+
+  // Extract authors
+  const authorMatch = bibtex.match(/author\s*=\s*{([^}]+)}/i);
+  if (authorMatch) {
+    const authorString = authorMatch[1];
+    // Split by "and" and clean up names
+    const authors = authorString
+      .split(/\s+and\s+/i)
+      .map(author => {
+        // Handle "Last, First" format and convert to "First Last"
+        if (author.includes(',')) {
+          const parts = author.split(',').map(p => p.trim());
+          if (parts.length >= 2) {
+            return `${parts[1]} ${parts[0]}`;
+          }
+        }
+        return author.trim();
+      })
+      .filter(author => author.length > 0);
+
+    metadata.authors = authors;
+  }
+
+  // Extract year
+  const yearMatch = bibtex.match(/year\s*=\s*{?(\d{4})}?/i);
+  const year = yearMatch ? yearMatch[1] : '';
+
+  // Extract journal
+  const journalMatch = bibtex.match(/journal\s*=\s*{([^}]+)}/i);
+  const journal = journalMatch ? journalMatch[1].trim() : '';
+
+  // Create citation from available data
+  if (metadata.authors && metadata.title && year) {
+    const authorText = metadata.authors.length > 3
+      ? `${metadata.authors[0]} et al.`
+      : metadata.authors.join(", ");
+
+    let citation = `${authorText} (${year}). ${metadata.title}`;
+    if (journal) {
+      citation += `. ${journal}`;
+    }
+    if (metadata.doi) {
+      citation += `. https://doi.org/${metadata.doi}`;
+    }
+
+    metadata.citation = citation;
+  }
+
+  return metadata;
+};
+
+/**
+ * Fetches paper metadata from DOI.org using content negotiation
+ * @param doi The DOI to fetch metadata for
+ * @returns Paper metadata
+ */
+export const fetchDoiMetadata = async (doi: string): Promise<Partial<Paper>> => {
+  try {
+    // Use the canonical DOI URL
+    const url = `https://doi.org/${doi}`;
+
+    const response = await fetch(url, {
+      headers: {
+        'Accept': 'application/x-bibtex',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch DOI metadata: ${response.status} ${response.statusText}`);
+    }
+
+    const bibtex = await response.text();
+
+    // Parse the BibTeX response
+    const metadata = parseBibtex(bibtex);
+
+    // Ensure we have the DOI and canonical URL
+    metadata.doi = doi;
+    metadata.url = `https://doi.org/${doi}`;
+
+    return metadata;
+  } catch (error) {
+    console.error("Error fetching DOI metadata:", error);
+    return {};
+  }
+};

--- a/garden/tests/features/materials/utils/doi.test.ts
+++ b/garden/tests/features/materials/utils/doi.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+
+import { extractDoiFromUrl, validateDoi, parseBibtex } from "@/features/materials/utils/doi";
+
+describe("when given a url, extractDoiFromUrl", () => {
+    const doi = "10.26311%2F65ez-ew73";
+    it("returns the parsed DOI", () => {
+        const url = `https://doi.org/${doi}`;
+        const extracted = extractDoiFromUrl(url);
+        expect(extracted).toBe(doi);
+    });
+
+    it("returns null if not a doi.org url", () => {
+        const url = `https://example.com/${doi}`;
+        const extraced = extractDoiFromUrl(url);
+        expect(extraced).toBe(null);
+    });
+});
+
+
+describe("when given a DOI, validateDoi", () => {
+    const doi = "10.263112/F65ez-ew73";
+    it("trims whitespace", () => {
+        const doiWithSpace = " " + doi + " ";
+        const validated = validateDoi(doiWithSpace);
+        expect(validated).toBe(doi);
+    })
+
+    it("returns null if bad DOI", () => {
+        const badDoi = "this-insnt-a-doi";
+        const validated = validateDoi(badDoi);
+        expect(validated).toBe(null);
+    });
+});
+
+describe("when given BibTeX, parseBibtex", () => {
+    it("extracts title correctly", () => {
+        const bibtex = `@article{key,
+            title={A Sample Research Paper},
+            author={John Doe and Jane Smith},
+            year={2023}
+        }`;
+        const result = parseBibtex(bibtex);
+        expect(result.title).toBe("A Sample Research Paper");
+    });
+
+    it("extracts DOI correctly", () => {
+        const bibtex = `@article{key,
+            title={Sample Paper},
+            doi={10.1234/example.doi},
+            year={2023}
+        }`;
+        const result = parseBibtex(bibtex);
+        expect(result.doi).toBe("10.1234/example.doi");
+    });
+
+    it("extracts and formats authors correctly", () => {
+        const bibtex = `@article{key,
+            title={Sample Paper},
+            author={Doe, John and Smith, Jane and Brown, Alice},
+            year={2023}
+        }`;
+        const result = parseBibtex(bibtex);
+        expect(result.authors).toEqual(["John Doe", "Jane Smith", "Alice Brown"]);
+    });
+
+    it("handles authors without comma format", () => {
+        const bibtex = `@article{key,
+            title={Sample Paper},
+            author={John Doe and Jane Smith},
+            year={2023}
+        }`;
+        const result = parseBibtex(bibtex);
+        expect(result.authors).toEqual(["John Doe", "Jane Smith"]);
+    });
+
+    it("creates proper citation with all fields", () => {
+        const bibtex = `@article{key,
+            title={Machine Learning in Practice},
+            author={Smith, John and Doe, Jane},
+            year={2023},
+            journal={Journal of AI Research},
+            doi={10.1234/example.doi}
+        }`;
+        const result = parseBibtex(bibtex);
+        expect(result.citation).toBe("John Smith, Jane Doe (2023). Machine Learning in Practice. Journal of AI Research. https://doi.org/10.1234/example.doi");
+    });
+
+    it("creates citation without journal", () => {
+        const bibtex = `@article{key,
+            title={Sample Paper},
+            author={Smith, John},
+            year={2023},
+            doi={10.1234/example.doi}
+        }`;
+        const result = parseBibtex(bibtex);
+        expect(result.citation).toBe("John Smith (2023). Sample Paper. https://doi.org/10.1234/example.doi");
+    });
+
+    it("creates citation without DOI", () => {
+        const bibtex = `@article{key,
+            title={Sample Paper},
+            author={Smith, John},
+            year={2023},
+            journal={Sample Journal}
+        }`;
+        const result = parseBibtex(bibtex);
+        expect(result.citation).toBe("John Smith (2023). Sample Paper. Sample Journal");
+    });
+
+    it("uses 'et al.' for more than 3 authors", () => {
+        const bibtex = `@article{key,
+            title={Collaborative Research},
+            author={Smith, John and Doe, Jane and Brown, Alice and Wilson, Bob},
+            year={2023}
+        }`;
+        const result = parseBibtex(bibtex);
+        expect(result.citation).toBe("John Smith et al. (2023). Collaborative Research");
+    });
+
+    it("returns empty object for empty bibtex", () => {
+        const result = parseBibtex("");
+        expect(result).toEqual({});
+    });
+
+    it("handles missing required fields gracefully", () => {
+        const bibtex = `@article{key,
+            journal={Some Journal}
+        }`;
+        const result = parseBibtex(bibtex);
+        expect(result.citation).toBeUndefined();
+        expect(result.title).toBeUndefined();
+        expect(result.authors).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Resolves: #421 

This PR adds auto-filling for metadata in the "Add Paper" form similar to what we have for arxiv URLs, but for doi.org urls as well as raw DOIs.

When a user inputs a DOI or a doi.org URL, we fetch the bibtex from doi.org and parse the info and insert it into the form automatically.

*Using a `doi.org` url*

https://github.com/user-attachments/assets/8fe086d9-168e-4a89-91c1-6536f967a78d


*Using a raw DOI*

https://github.com/user-attachments/assets/e99a2e5d-c3cf-4770-a697-33a64ef3382b



## Testing
Some new unit tests of the DOI and bibtex parsing. Manual testing of the Paper Modal.