### PR TITLE
Add 'Show All' toggle for long author/contributor lists

### DIFF
--- a/garden/src/components/shared/metadata/EditableMetadataField.tsx
+++ b/garden/src/components/shared/metadata/EditableMetadataField.tsx
@@ -8,7 +8,7 @@ import { Garden, ModalFunction } from "@/types";
 import { toast } from "sonner";
 import { EditableCodeField } from "@/components/EditableCodeField";
 import TruncatedDescription from "@/components/shared/metadata/TruncatedDescription";
-import TruncatedAuthorList from "@/components/shared/metadata/TruncatedAuthorList";
+import TruncatedList from "@/components/shared/metadata/TruncatedList";
 import {
   Tooltip,
   TooltipContent,
@@ -220,9 +220,9 @@ const EditableMetadataField = ({
       <div className="mt-0.5">
         {isArray ? (
           // Display array items with truncation for authors/contributors
-          fieldName === 'authors' || fieldName === 'contributors' ? (
-            <TruncatedAuthorList 
-              items={Array.isArray(value) ? value : []} 
+          fieldName === 'authors' || fieldName === 'contributors' || fieldName === 'tags' ? (
+            <TruncatedList
+              items={Array.isArray(value) ? value : []}
               label={label}
             />
           ) : (

--- a/garden/src/components/shared/metadata/EditableMetadataField.tsx
+++ b/garden/src/components/shared/metadata/EditableMetadataField.tsx
@@ -8,6 +8,7 @@ import { Garden, ModalFunction } from "@/types";
 import { toast } from "sonner";
 import { EditableCodeField } from "@/components/EditableCodeField";
 import TruncatedDescription from "@/components/shared/metadata/TruncatedDescription";
+import TruncatedAuthorList from "@/components/shared/metadata/TruncatedAuthorList";
 import {
   Tooltip,
   TooltipContent,
@@ -218,21 +219,29 @@ const EditableMetadataField = ({
 
       <div className="mt-0.5">
         {isArray ? (
-          // Display array items
-          <div className="flex flex-wrap gap-1 mt-1">
-            {value && Array.isArray(value) && value.length > 0 ? (
-              value.map((item, index) => (
-                <span
-                  key={index}
-                  className="inline-flex items-center bg-gray-100 text-gray-800 text-xs px-2 py-0.5 rounded"
-                >
-                  {item}
-                </span>
-              ))
-            ) : (
-              <p className="text-gray-400 italic text-sm">No {label.toLowerCase()} added</p>
-            )}
-          </div>
+          // Display array items with truncation for authors/contributors
+          fieldName === 'authors' || fieldName === 'contributors' ? (
+            <TruncatedAuthorList 
+              items={Array.isArray(value) ? value : []} 
+              label={label}
+            />
+          ) : (
+            // Display other arrays normally
+            <div className="flex flex-wrap gap-1 mt-1">
+              {value && Array.isArray(value) && value.length > 0 ? (
+                value.map((item, index) => (
+                  <span
+                    key={index}
+                    className="inline-flex items-center bg-gray-100 text-gray-800 text-xs px-2 py-0.5 rounded"
+                  >
+                    {item}
+                  </span>
+                ))
+              ) : (
+                <p className="text-gray-400 italic text-sm">No {label.toLowerCase()} added</p>
+              )}
+            </div>
+          )
         ) : fieldName === 'description' ? (
           <TruncatedDescription content={value as string || ""} />
         ) : (

--- a/garden/src/components/shared/metadata/TruncatedAuthorList.tsx
+++ b/garden/src/components/shared/metadata/TruncatedAuthorList.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+
+interface TruncatedAuthorListProps {
+  items: string[];
+  label: string;
+  maxVisible?: number;
+}
+
+const TruncatedAuthorList = ({ 
+  items, 
+  label, 
+  maxVisible = 5 
+}: TruncatedAuthorListProps) => {
+  const [showAll, setShowAll] = useState(false);
+  
+  if (!items || items.length === 0) {
+    return (
+      <p className="text-gray-400 italic text-sm">No {label.toLowerCase()} added</p>
+    );
+  }
+
+  const shouldTruncate = items.length > maxVisible;
+  const displayItems = shouldTruncate && !showAll ? items.slice(0, maxVisible) : items;
+  const hiddenCount = items.length - maxVisible;
+
+  return (
+    <div className="flex flex-wrap gap-1 mt-1">
+      {displayItems.map((item, index) => (
+        <span
+          key={index}
+          className="inline-flex items-center bg-gray-100 text-gray-800 text-xs px-2 py-0.5 rounded"
+        >
+          {item}
+        </span>
+      ))}
+      
+      {shouldTruncate && (
+        <button
+          onClick={() => setShowAll(!showAll)}
+          className="inline-flex items-center bg-blue-50 text-blue-700 hover:bg-blue-100 text-xs px-2 py-0.5 rounded transition-colors"
+        >
+          {showAll ? 'Show Less' : `Show All (${hiddenCount} more)`}
+        </button>
+      )}
+    </div>
+  );
+};
+
+export default TruncatedAuthorList;

--- a/garden/src/components/shared/metadata/TruncatedList.tsx
+++ b/garden/src/components/shared/metadata/TruncatedList.tsx
@@ -1,18 +1,18 @@
 import React, { useState } from 'react';
 
-interface TruncatedAuthorListProps {
+interface TruncatedListProps {
   items: string[];
   label: string;
   maxVisible?: number;
 }
 
-const TruncatedAuthorList = ({ 
-  items, 
-  label, 
-  maxVisible = 5 
-}: TruncatedAuthorListProps) => {
+const TruncatedList = ({
+  items,
+  label,
+  maxVisible = 5
+}: TruncatedListProps) => {
   const [showAll, setShowAll] = useState(false);
-  
+
   if (!items || items.length === 0) {
     return (
       <p className="text-gray-400 italic text-sm">No {label.toLowerCase()} added</p>
@@ -33,7 +33,7 @@ const TruncatedAuthorList = ({
           {item}
         </span>
       ))}
-      
+
       {shouldTruncate && (
         <button
           onClick={() => setShowAll(!showAll)}
@@ -46,4 +46,4 @@ const TruncatedAuthorList = ({
   );
 };
 
-export default TruncatedAuthorList;
+export default TruncatedList;


### PR DESCRIPTION
Resolves: #419 

This PR adds a component to truncate long author/gardener lists to keep the metadata sidebar from filling up with tons of authors. There is now a 'Show All' toggle when the list is too long.


https://github.com/user-attachments/assets/2243ebac-7e61-4197-9d25-541e246bbb6e

