### PR TITLE
Include HPC functions in function selection table

### DIFF
--- a/garden/src/components/FunctionSelectionTable.tsx
+++ b/garden/src/components/FunctionSelectionTable.tsx
@@ -60,29 +60,32 @@ const FunctionSelectionTable: React.FC<FunctionSelectionTableProps> = ({
     return queryWords.every((word) => haystack.includes(word));
   });
 
+  // Helper to create composite key from function
+  const getFunctionCompositeKey = (func: Function): string => {
+    return `${func.functionType}-${func.id}`;
+  };
+
   const handleFunctionToggle = useCallback(
-    (functionId: string | number) => {
-      const isCurrentlySelected = selectedFunctionIds.includes(functionId);
+    (func: Function) => {
+      const compositeKey = getFunctionCompositeKey(func);
+      const isCurrentlySelected = selectedFunctionIds.includes(compositeKey);
       const newSelectedIds = isCurrentlySelected
-        ? selectedFunctionIds.filter(id => id !== functionId)
-        : [...selectedFunctionIds, functionId];
+        ? selectedFunctionIds.filter(id => id !== compositeKey)
+        : [...selectedFunctionIds, compositeKey];
 
       onSelectionChange(newSelectedIds);
 
       if (!isCurrentlySelected && onFunctionAdded) {
-        const func = functions?.find(f => f.id === functionId);
-        if (func) {
-          const authorIds = func.authors ?? [];
-          if (authorIds.length === 0) {
-            toast.warning(`Function "${func.title || func.function_name}" has no authors defined`);
-          }
-          onFunctionAdded(functionId, authorIds);
+        const authorIds = func.authors ?? [];
+        if (authorIds.length === 0) {
+          toast.warning(`Function "${func.title || func.function_name}" has no authors defined`);
         }
+        onFunctionAdded(compositeKey, authorIds);
       } else if (isCurrentlySelected && onFunctionRemoved) {
-        onFunctionRemoved(functionId);
+        onFunctionRemoved(compositeKey);
       }
     },
-    [selectedFunctionIds, onSelectionChange, onFunctionAdded, onFunctionRemoved, functions]
+    [selectedFunctionIds, onSelectionChange, onFunctionAdded, onFunctionRemoved]
   );
 
   const handleClearAll = () => {
@@ -103,18 +106,18 @@ const FunctionSelectionTable: React.FC<FunctionSelectionTableProps> = ({
     <div className={className}>
       {showSelectedChips && selectedFunctionIds.length > 0 && (
         <div className="flex flex-wrap gap-2 mb-4">
-          {selectedFunctionIds.map((id) => {
-            const func = functions?.find(f => f.id === id);
+          {selectedFunctionIds.map((compositeKey) => {
+            const func = functions?.find(f => getFunctionCompositeKey(f) === compositeKey);
             if (!func) return null;
 
             return (
               <div
-                key={id}
+                key={compositeKey}
                 className="flex items-center rounded-full bg-[#e0f3e7] text-sm px-3 py-1 border border-[#b3dbc3]"
               >
                 {func.title || func.function_name}
                 <button
-                  onClick={() => handleFunctionToggle(id)}
+                  onClick={() => handleFunctionToggle(func)}
                   className="ml-2 text-[#2f5d41] hover:text-red-500"
                 >
                   <X className="h-4 w-4" />
@@ -180,25 +183,27 @@ const FunctionSelectionTable: React.FC<FunctionSelectionTableProps> = ({
                   </TableCell>
                 </TableRow>
               ) : (
-                filteredFunctions.map((func) => (
+                filteredFunctions.map((func) => {
+                  const compositeKey = getFunctionCompositeKey(func);
+                  return (
                   <TableRow
-                    key={func.id}
+                    key={compositeKey}
                     onClick={(e) => {
                       const tag = (e.target as HTMLElement).tagName.toLowerCase();
                       if (['input', 'button', 'svg', 'path', 'a'].includes(tag)) return;
-                      handleFunctionToggle(func.id);
+                      handleFunctionToggle(func);
                     }}
                     className={`group cursor-pointer transition-all duration-200 ease-in-out rounded-md
-                      ${selectedFunctionIds.includes(func.id)
+                      ${selectedFunctionIds.includes(compositeKey)
                         ? "bg-[#e0f3e7] border-y border-[#5cae4f] shadow-sm"
                         : "hover:bg-[#eef5f1]"}`}
                   >
                     <TableCell className="w-1/12 text-center">
                       <Checkbox
-                        checked={selectedFunctionIds.includes(func.id)}
-                        onCheckedChange={() => handleFunctionToggle(func.id)}
+                        checked={selectedFunctionIds.includes(compositeKey)}
+                        onCheckedChange={() => handleFunctionToggle(func)}
                         onPointerDown={(e) => e.stopPropagation()}
-                        value={String(func.id)}
+                        value={compositeKey}
                       />
                     </TableCell>
                     <TableCell>
@@ -211,18 +216,18 @@ const FunctionSelectionTable: React.FC<FunctionSelectionTableProps> = ({
                     </TableCell>
                     <TableCell className="w-1/2 whitespace-normal break-words text-sm text-gray-700">
                       <div>
-                        <p className={showFullDescriptionIds.includes(func.id) ? '' : 'line-clamp-2'}>
+                        <p className={showFullDescriptionIds.includes(compositeKey) ? '' : 'line-clamp-2'}>
                           {func.description || "No description available"}
                         </p>
                         {func.description && func.description.length > 120 && (
                           <button
                             onClick={(e) => {
                               e.stopPropagation();
-                              toggleDescription(func.id);
+                              toggleDescription(compositeKey);
                             }}
                             className="mt-1 text-xs text-green hover:underline"
                           >
-                            {showFullDescriptionIds.includes(func.id) ? "Show less" : "Show more"}
+                            {showFullDescriptionIds.includes(compositeKey) ? "Show less" : "Show more"}
                           </button>
                         )}
                       </div>
@@ -243,7 +248,8 @@ const FunctionSelectionTable: React.FC<FunctionSelectionTableProps> = ({
                       )}
                     </TableCell>
                   </TableRow>
-                ))
+                  );
+                })
               )}
             </TableBody>
           </Table>

--- a/garden/src/components/FunctionSelectionTable.tsx
+++ b/garden/src/components/FunctionSelectionTable.tsx
@@ -12,13 +12,14 @@ import {
 } from "@/components/shadcn/table";
 import { Link } from 'react-router-dom';
 import LoadingSpinner from '@/components/LoadingSpinner';
-import { ModalFunction } from '@/types';
+import { Function, ModalFunction } from '@/types';
 import { toast } from 'sonner';
+import { Badge } from '@/components/shadcn/badge';
 
 interface FunctionSelectionTableProps {
-  functions: ModalFunction[] | undefined;
-  selectedFunctionIds?: number[];
-  onSelectionChange: (selectedIds: number[]) => void;
+  functions: Function[] | undefined;
+  selectedFunctionIds?: (string | number)[];
+  onSelectionChange: (selectedIds: (string | number)[]) => void;
   isLoading?: boolean;
   isFetching?: boolean;
   searchQuery?: string;
@@ -27,8 +28,8 @@ interface FunctionSelectionTableProps {
   showClearAllButton?: boolean;
   showSearch?: boolean;
   maxHeight?: string;
-  onFunctionAdded?: (functionId: number, authorIds: string[]) => void;
-  onFunctionRemoved?: (functionId: number) => void;
+  onFunctionAdded?: (functionId: string | number, authorIds: string[]) => void;
+  onFunctionRemoved?: (functionId: string | number) => void;
   className?: string;
   tableClassName?: string;
 }
@@ -50,7 +51,7 @@ const FunctionSelectionTable: React.FC<FunctionSelectionTableProps> = ({
   className = "",
   tableClassName = ""
 }) => {
-  const [showFullDescriptionIds, setShowFullDescriptionIds] = useState<number[]>([]);
+  const [showFullDescriptionIds, setShowFullDescriptionIds] = useState<(string | number)[]>([]);
   const [isConfirmClearOpen, setIsConfirmClearOpen] = useState(false);
 
   const filteredFunctions = (functions ?? []).filter((func) => {
@@ -60,7 +61,7 @@ const FunctionSelectionTable: React.FC<FunctionSelectionTableProps> = ({
   });
 
   const handleFunctionToggle = useCallback(
-    (functionId: number) => {
+    (functionId: string | number) => {
       const isCurrentlySelected = selectedFunctionIds.includes(functionId);
       const newSelectedIds = isCurrentlySelected
         ? selectedFunctionIds.filter(id => id !== functionId)
@@ -89,7 +90,7 @@ const FunctionSelectionTable: React.FC<FunctionSelectionTableProps> = ({
     setIsConfirmClearOpen(false);
   };
 
-  const toggleDescription = (functionId: number) => {
+  const toggleDescription = (functionId: string | number) => {
     setShowFullDescriptionIds((prev) =>
       prev.includes(functionId)
         ? prev.filter((id) => id !== functionId)
@@ -151,6 +152,7 @@ const FunctionSelectionTable: React.FC<FunctionSelectionTableProps> = ({
             <TableHeader className="sticky top-0 bg-white z-10">
               <TableRow>
                 <TableHead className="w-1/12"></TableHead>
+                <TableHead className="w-auto">Type</TableHead>
                 <TableHead className="w-1/4">Name</TableHead>
                 <TableHead className="w-1/2">Description</TableHead>
                 <TableHead className="w-1/6 text-center">Actions</TableHead>
@@ -159,7 +161,7 @@ const FunctionSelectionTable: React.FC<FunctionSelectionTableProps> = ({
             <TableBody>
               {isLoading ? (
                 <TableRow>
-                  <TableCell colSpan={4} className="text-center">
+                  <TableCell colSpan={5} className="text-center">
                     <div className="flex h-24 items-center justify-center">
                       <LoadingSpinner />
                     </div>
@@ -167,13 +169,13 @@ const FunctionSelectionTable: React.FC<FunctionSelectionTableProps> = ({
                 </TableRow>
               ) : functions?.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={4} className="text-center text-gray-500">
-                    No modal functions available
+                  <TableCell colSpan={5} className="text-center text-gray-500">
+                    No functions available
                   </TableCell>
                 </TableRow>
               ) : filteredFunctions?.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={4} className="text-center text-gray-500">
+                  <TableCell colSpan={5} className="text-center text-gray-500">
                     No functions match your search.
                   </TableCell>
                 </TableRow>
@@ -183,7 +185,7 @@ const FunctionSelectionTable: React.FC<FunctionSelectionTableProps> = ({
                     key={func.id}
                     onClick={(e) => {
                       const tag = (e.target as HTMLElement).tagName.toLowerCase();
-                      if (['input', 'button', 'svg', 'path'].includes(tag)) return;
+                      if (['input', 'button', 'svg', 'path', 'a'].includes(tag)) return;
                       handleFunctionToggle(func.id);
                     }}
                     className={`group cursor-pointer transition-all duration-200 ease-in-out rounded-md
@@ -196,8 +198,13 @@ const FunctionSelectionTable: React.FC<FunctionSelectionTableProps> = ({
                         checked={selectedFunctionIds.includes(func.id)}
                         onCheckedChange={() => handleFunctionToggle(func.id)}
                         onPointerDown={(e) => e.stopPropagation()}
-                        value={func.id}
+                        value={String(func.id)}
                       />
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={func.functionType === 'modal' ? 'default' : 'secondary'}>
+                        {func.functionType.toUpperCase()}
+                      </Badge>
                     </TableCell>
                     <TableCell className="w-1/4 truncate whitespace-normal break-words">
                       {func.title || func.function_name}
@@ -221,16 +228,19 @@ const FunctionSelectionTable: React.FC<FunctionSelectionTableProps> = ({
                       </div>
                     </TableCell>
                     <TableCell className="w-1/6 text-center">
-                      <Link
-                        to={`/modal-functions/${func.id}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        <Button variant="outline" size="sm" type="button">
-                          View
-                          <ExternalLink size={14} className="mb-0.5 ml-1" />
-                        </Button>
-                      </Link>
+                      {func.functionType === 'modal' && (
+                        <Link
+                          to={`/modal-functions/${func.id}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <Button variant="outline" size="sm" type="button">
+                            View
+                            <ExternalLink size={14} className="mb-0.5 ml-1" />
+                          </Button>
+                        </Link>
+                      )}
                     </TableCell>
                   </TableRow>
                 ))

--- a/garden/src/components/LoadingSpinner.tsx
+++ b/garden/src/components/LoadingSpinner.tsx
@@ -1,6 +1,6 @@
 const LoadingSpinner = () => {
   return (
-    <div className="flex  items-center justify-center">
+    <div className="flex  items-center justify-center" role="status">
       <svg
         className="mr-2 h-24 w-24 animate-spin fill-green text-gray-200"
         viewBox="0 0 100 101"

--- a/garden/src/features/gardens/components/GardenTabbedSection.tsx
+++ b/garden/src/features/gardens/components/GardenTabbedSection.tsx
@@ -8,7 +8,7 @@ import ModalFunctionBox from "./ModalFunctionBox";
 import { useDatasetManagement, usePaperManagement, useRepositoryManagement, useNotebookManagement } from '@/features/materials/hooks/useMaterialManagement';
 import { getUniqueItemCount } from "../utils/garden.utils";
 
-import ModalFunctionManager from "./garden-page/ModalFunctionManager";
+import FunctionManager from "./garden-page/FunctionManager";
 
 import {
     AddMaterialWithFunctionSelect,
@@ -117,7 +117,7 @@ export const GardenTabbedSection = ({ garden, ownsThisGarden }: { garden: Garden
                                 </h3>
 
                                 {ownsThisGarden && (
-                                    <ModalFunctionManager
+                                    <FunctionManager
                                         garden={garden}
                                         onSuccess={handleMaterialAdded}
                                     />

--- a/garden/src/features/gardens/components/create/CreateGardenFormFields.tsx
+++ b/garden/src/features/gardens/components/create/CreateGardenFormFields.tsx
@@ -23,7 +23,7 @@ import {
 
 import { GardenCreateFormData } from "../../types/garden.types";
 import { tagOptions } from "../../utils/garden.utils";
-import FunctionSelectionTable from "@/features/modal/components/FunctionSelectionTable";
+import FunctionSelectionTable from "@/components/FunctionSelectionTable";
 import { useGetAllModalFunctions } from "@/features/modal/api/useGetAllModalFunctions";
 import { Controller } from "react-hook-form";
 import { toast } from "sonner";

--- a/garden/src/features/gardens/components/create/CreateGardenFormFields.tsx
+++ b/garden/src/features/gardens/components/create/CreateGardenFormFields.tsx
@@ -54,8 +54,11 @@ export const CreateGardenFormFields = () => {
 
   const filteredFunctions= useMemo(() => {
     if (!modalFunctions || !Array.isArray(modalFunctions)) return [];
-    if (!modalAppFunctionIds || modalAppFunctionIds.length === 0) return modalFunctions;
-    return modalFunctions.filter((f) => !modalAppFunctionIds.includes(f.id));
+    const functions = !modalAppFunctionIds || modalAppFunctionIds.length === 0
+      ? modalFunctions
+      : modalFunctions.filter((f) => !modalAppFunctionIds.includes(f.id));
+    // Map to Function type with functionType discriminator
+    return functions.map(f => ({ ...f, functionType: 'modal' as const }));
   }, [modalFunctions, modalAppFunctionIds]);
 
   return (

--- a/garden/src/features/gardens/components/garden-page/FunctionManager.tsx
+++ b/garden/src/features/gardens/components/garden-page/FunctionManager.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { PlusCircle, ExternalLink, X } from 'lucide-react';
 import { Button } from '@/components/shadcn/button';
-import { Garden } from '@/types';
+import { Garden, Function, ModalFunction, HpcFunctionMetadataResponse } from '@/types';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/shadcn/dialog';
 import {
   Table,
@@ -12,138 +12,128 @@ import {
   TableCell,
 } from "@/components/shadcn/table";
 import { toast } from 'sonner';
-// import { useGetUserModalFunctions } from '@/features/modal/api/useGetUserModalFunctions';
 import { useGetAllModalFunctions } from '@/features/modal/api/useGetAllModalFunctions';
 import { usePatchGarden } from '@/features/gardens/api/usePatchGarden';
 import { Link, useNavigate } from 'react-router-dom';
-// import LoadingSpinner from '@/components/LoadingSpinner';
 import { useGetModelDeployments } from '@/features/model-deployments/api/useGetModelDeployments';
 import { useGetUserInfo } from '@/features/users/api/useGetUserInfo';
-import FunctionSelectionTable from '@/features/modal/components/FunctionSelectionTable';
+import FunctionSelectionTable from '@/components/FunctionSelectionTable';
+import { useHpcFunctions } from '@/features/hpc-admin/api/useHpcFunctions';
 
-interface ModalFunctionManagerProps {
+interface FunctionManagerProps {
   garden: Garden;
   onSuccess?: () => void;
 }
 
-const ModalFunctionManager: React.FC<ModalFunctionManagerProps> = ({
+const FunctionManager: React.FC<FunctionManagerProps> = ({
   garden,
   onSuccess
 }) => {
   const navigate = useNavigate();
   const { data: currentUser } = useGetUserInfo();
-  const modalAppId = garden.modal_functions?.[0]?.modal_app_id;
 
-  // Get current function IDs to exclude from the selection
-  const currentFunctionIds = garden.modal_functions?.map(f => f.id) || [];
-
-  // State for selected function IDs
-  const [selectedFunctionIds, setSelectedFunctionIds] = useState<number[]>(currentFunctionIds);
-  const [selectedAuthorIds, setSelectedAuthorIds] = useState<Set<string>>(new Set());
+  const [selectedModalIds, setSelectedModalIds] = useState<number[]>([]);
+  const [selectedHpcIds, setSelectedHpcIds] = useState<string[]>([]);
+  const [selectedAuthors, setSelectedAuthors] = useState<Set<string>>(new Set());
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isDeploymentDialogOpen, setIsDeploymentDialogOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
 
-  // Get modal functions - only fetch when dialog is opened
-  const {
-    data: functions,
-    refetch,
-    isFetching,
-    isLoading
-  } = useGetAllModalFunctions();
+  const { data: modalFunctions, isLoading: isLoadingModal, isError: isErrorModal } = useGetAllModalFunctions(isDialogOpen);
+  const { data: hpcFunctions, isLoading: isLoadingHpc, isError: isErrorHpc } = useHpcFunctions();
 
-  // Sync selected functions
   useEffect(() => {
-    if (isDialogOpen && functions && functions.length > 0) {
-      const syncedIds = garden.modal_functions
-        ?.map(f => f.id)
-        .filter(id => functions.some(func => func.id === id)) || [];
-      setSelectedFunctionIds(syncedIds);
+    if (isErrorModal) {
+      toast.error("Failed to load Modal functions.");
     }
-  }, [isDialogOpen, garden.modal_functions, functions]);
+    if (isErrorHpc) {
+      toast.error("Failed to load HPC functions.");
+    }
+  }, [isErrorModal, isErrorHpc]);
 
-  // Sync model authors
+  const allFunctions = useMemo<Function[]>(() => {
+    const modals: Function[] = (modalFunctions ?? []).map(f => ({ ...f, functionType: 'modal' }));
+    const hpcs: Function[] = (hpcFunctions ?? []).map(f => ({ ...f, functionType: 'hpc' }));
+    return [...modals, ...hpcs];
+  }, [modalFunctions, hpcFunctions]);
+
   useEffect(() => {
     if (isDialogOpen) {
-      setSelectedFunctionIds(garden.modal_functions?.map(f => f.id) || []);
+      const initialModalIds = garden.modal_functions?.map(f => f.id) || [];
+      const initialHpcIds = garden.hpc_functions?.map(f => f.id) || [];
+      setSelectedModalIds(initialModalIds);
+      setSelectedHpcIds(initialHpcIds);
 
       const initialAuthorIds = new Set<string>();
-      garden.modal_functions?.forEach(fn => {
-        fn.authors?.forEach(identity_id => {
-          if (identity_id) {
-            initialAuthorIds.add(identity_id);
-          }
-        });
-      });
-
-      setSelectedAuthorIds(initialAuthorIds);
+      garden.modal_functions?.forEach(fn => fn.authors?.forEach(authorName => initialAuthorIds.add(authorName)));
+      garden.hpc_functions?.forEach(fn => fn.authors?.forEach(authorName => initialAuthorIds.add(authorName)));
+      setSelectedAuthors(initialAuthorIds);
     }
-  }, [isDialogOpen, garden.modal_functions]);
+  }, [isDialogOpen, garden]);
 
   const { mutateAsync: patchGarden } = usePatchGarden();
 
   const { data: modelDeployments } = useGetModelDeployments();
 
-  const handleFunctionAdded = (functionId: number, authorIds: string[]) => {
-    setSelectedAuthorIds(prev => {
-      const newSet = new Set(prev);
-      authorIds.forEach(id => {
-        if (id) {
-          newSet.add(id);
+  const handleSelectionChange = (newSelectedIds: (string | number)[]) => {
+    const newModalIds: number[] = [];
+    const newHpcIds: string[] = [];
+    const newAuthors = new Set<string>();
+
+    newSelectedIds.forEach(id => {
+      const func = allFunctions.find(f => f.id === id);
+      if (func) {
+        if (func.functionType === 'modal') {
+          newModalIds.push(func.id as number);
+        } else {
+          newHpcIds.push(func.id as string);
         }
-      });
-      return newSet;
+        func.authors?.forEach(authorName => newAuthors.add(authorName));
+      }
     });
+
+    setSelectedModalIds(newModalIds);
+    setSelectedHpcIds(newHpcIds);
+    setSelectedAuthors(newAuthors);
   };
 
-  const handleFunctionRemoved = (functionId: number) => {
-    const removedFunction = garden.modal_functions?.find(f => f.id === functionId);
-    const removedAuthorIds = removedFunction?.authors || [];
-
-    setSelectedAuthorIds(prev => {
-      const updated = new Set(prev);
-      removedAuthorIds.forEach(id => {
-        const stillUsed = garden.modal_functions?.some(f =>
-          f.id!== functionId &&
-          selectedFunctionIds.includes(f.id) &&
-          f.authors?.includes(id)
-        );
-        if (!stillUsed) {
-          updated.delete(id);
-        }
-      });
-      return updated;
-    });
-  };
-
-  // Handle saving functions to the garden
   const handleSave = async () => {
     try {
-      const addedCount = selectedFunctionIds.filter(id => !currentFunctionIds.includes(id)).length;
-      const removedCount = currentFunctionIds.filter(id => !selectedFunctionIds.includes(id)).length;
+      const initialModalIds = garden.modal_functions?.map(f => f.id) || [];
+      const initialHpcIds = garden.hpc_functions?.map(f => f.id) || [];
 
-      let successMessage = "Garden functions updated successfully";
-      if (addedCount > 0 && removedCount > 0) {
-        successMessage = `Added ${addedCount} and removed ${removedCount} functions`;
-      } else if (addedCount > 0) {
-        successMessage = `Added ${addedCount} function${addedCount > 1 ? 's' : ''}`;
-      } else if (removedCount > 0) {
-        successMessage = `Removed ${removedCount} function${removedCount > 1 ? 's' : ''}`;
+      const modalChanged = JSON.stringify(initialModalIds.sort()) !== JSON.stringify(selectedModalIds.sort());
+      const hpcChanged = JSON.stringify(initialHpcIds.sort()) !== JSON.stringify(selectedHpcIds.sort());
+
+      if (!modalChanged && !hpcChanged) {
+        toast.info("No changes to save.");
+        setIsDialogOpen(false);
+        return;
       }
 
-      // Update the garden with the new set of functions
+      const addedModalCount = selectedModalIds.filter(id => !initialModalIds.includes(id)).length;
+      const removedModalCount = initialModalIds.filter(id => !selectedModalIds.includes(id)).length;
+      const addedHpcCount = selectedHpcIds.filter(id => !initialHpcIds.includes(id)).length;
+      const removedHpcCount = initialHpcIds.filter(id => !selectedHpcIds.includes(id)).length;
+
+      let parts: string[] = [];
+      if (addedModalCount > 0) parts.push(`Added ${addedModalCount} modal function(s)`);
+      if (removedModalCount > 0) parts.push(`Removed ${removedModalCount} modal function(s)`);
+      if (addedHpcCount > 0) parts.push(`Added ${addedHpcCount} HPC function(s)`);
+      if (removedHpcCount > 0) parts.push(`Removed ${removedHpcCount} HPC function(s)`);
+      const successMessage = parts.length > 0 ? parts.join(', ') : "Garden functions updated.";
+
       await patchGarden({
         doi: garden.doi,
         garden: {
-          modal_function_ids: selectedFunctionIds,
-          authors: Array.from(selectedAuthorIds),
+          ...(modalChanged && { modal_function_ids: selectedModalIds }),
+          ...(hpcChanged && { hpc_function_ids: selectedHpcIds }),
+          authors: Array.from(selectedAuthors),
         },
         successMessage
       });
 
       setIsDialogOpen(false);
-
-      // Call onSuccess callback if provided
       if (onSuccess) onSuccess();
     } catch (error) {
       toast.error("Failed to update garden functions");
@@ -262,24 +252,21 @@ const ModalFunctionManager: React.FC<ModalFunctionManagerProps> = ({
             <DialogTitle>Manage Garden Functions</DialogTitle>
           </DialogHeader>
 
-          <div className="mb-2"> {/* flex items-center justify-between */}
+          <div className="mb-2"> 
             <p className="text-sm text-gray-500">
               Select functions to include in this garden:
             </p>
           </div>
 
           <FunctionSelectionTable
-            functions={functions}
-            selectedFunctionIds={selectedFunctionIds}
-            onSelectionChange={setSelectedFunctionIds}
-            isLoading={isLoading}
-            isFetching={isFetching}
+            functions={allFunctions}
+            selectedFunctionIds={[...selectedModalIds, ...selectedHpcIds]}
+            onSelectionChange={handleSelectionChange}
+            isLoading={isLoadingModal || isLoadingHpc}
             searchQuery={searchQuery}
             onSearchChange={setSearchQuery}
             showSelectedChips
             showClearAllButton
-            onFunctionAdded={handleFunctionAdded}
-            onFunctionRemoved={handleFunctionRemoved}
           />
 
           <div className="flex justify-end space-x-2 mt-4">
@@ -297,4 +284,4 @@ const ModalFunctionManager: React.FC<ModalFunctionManagerProps> = ({
   );
 };
 
-export default ModalFunctionManager; 
+export default FunctionManager;

--- a/garden/src/features/gardens/components/garden-page/FunctionManager.tsx
+++ b/garden/src/features/gardens/components/garden-page/FunctionManager.tsx
@@ -33,13 +33,13 @@ const FunctionManager: React.FC<FunctionManagerProps> = ({
   const { data: currentUser } = useGetUserInfo();
 
   const [selectedModalIds, setSelectedModalIds] = useState<number[]>([]);
-  const [selectedHpcIds, setSelectedHpcIds] = useState<string[]>([]);
+  const [selectedHpcIds, setSelectedHpcIds] = useState<number[]>([]);
   const [selectedAuthors, setSelectedAuthors] = useState<Set<string>>(new Set());
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const [isDeploymentDialogOpen, setIsDeploymentDialogOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
 
-  const { data: modalFunctions, isLoading: isLoadingModal, isError: isErrorModal } = useGetAllModalFunctions(isDialogOpen);
+  const { data: modalFunctions, isLoading: isLoadingModal, isError: isErrorModal } = useGetAllModalFunctions();
   const { data: hpcFunctions, isLoading: isLoadingHpc, isError: isErrorHpc } = useHpcFunctions();
 
   useEffect(() => {
@@ -77,7 +77,7 @@ const FunctionManager: React.FC<FunctionManagerProps> = ({
 
   const handleSelectionChange = (newSelectedIds: (string | number)[]) => {
     const newModalIds: number[] = [];
-    const newHpcIds: string[] = [];
+    const newHpcIds: number[] = [];
     const newAuthors = new Set<string>();
 
     newSelectedIds.forEach(id => {
@@ -86,7 +86,7 @@ const FunctionManager: React.FC<FunctionManagerProps> = ({
         if (func.functionType === 'modal') {
           newModalIds.push(func.id as number);
         } else {
-          newHpcIds.push(func.id as string);
+          newHpcIds.push(func.id as number);
         }
         func.authors?.forEach(authorName => newAuthors.add(authorName));
       }

--- a/garden/src/features/gardens/components/garden-page/FunctionManager.tsx
+++ b/garden/src/features/gardens/components/garden-page/FunctionManager.tsx
@@ -57,6 +57,14 @@ const FunctionManager: React.FC<FunctionManagerProps> = ({
     return [...modals, ...hpcs];
   }, [modalFunctions, hpcFunctions]);
 
+  // Helper to create composite keys for selection
+  const toCompositeKey = (type: 'modal' | 'hpc', id: number): string => `${type}-${id}`;
+  const fromCompositeKey = (key: string): { type: 'modal' | 'hpc', id: number } | null => {
+    const match = key.match(/^(modal|hpc)-(\d+)$/);
+    if (!match) return null;
+    return { type: match[1] as 'modal' | 'hpc', id: parseInt(match[2], 10) };
+  };
+
   useEffect(() => {
     if (isDialogOpen) {
       const initialModalIds = garden.modal_functions?.map(f => f.id) || [];
@@ -81,14 +89,18 @@ const FunctionManager: React.FC<FunctionManagerProps> = ({
     const newAuthors = new Set<string>();
 
     newSelectedIds.forEach(id => {
-      const func = allFunctions.find(f => f.id === id);
-      if (func) {
-        if (func.functionType === 'modal') {
-          newModalIds.push(func.id as number);
-        } else {
-          newHpcIds.push(func.id as number);
+      const compositeKey = typeof id === 'string' ? id : String(id);
+      const parsed = fromCompositeKey(compositeKey);
+      if (parsed) {
+        const func = allFunctions.find(f => f.functionType === parsed.type && f.id === parsed.id);
+        if (func) {
+          if (func.functionType === 'modal') {
+            newModalIds.push(func.id as number);
+          } else {
+            newHpcIds.push(func.id as number);
+          }
+          func.authors?.forEach(authorName => newAuthors.add(authorName));
         }
-        func.authors?.forEach(authorName => newAuthors.add(authorName));
       }
     });
 
@@ -260,7 +272,10 @@ const FunctionManager: React.FC<FunctionManagerProps> = ({
 
           <FunctionSelectionTable
             functions={allFunctions}
-            selectedFunctionIds={[...selectedModalIds, ...selectedHpcIds]}
+            selectedFunctionIds={[
+              ...selectedModalIds.map(id => toCompositeKey('modal', id)),
+              ...selectedHpcIds.map(id => toCompositeKey('hpc', id))
+            ]}
             onSelectionChange={handleSelectionChange}
             isLoading={isLoadingModal || isLoadingHpc}
             searchQuery={searchQuery}

--- a/garden/src/features/gardens/components/garden-page/index.ts
+++ b/garden/src/features/gardens/components/garden-page/index.ts
@@ -1,4 +1,4 @@
-export { default as ModalFunctionManager } from "./ModalFunctionManager";
+export { default as FunctionManager } from "./FunctionManager";
 export { default as GardenDescription } from "./GardenDescription";
 export { default as VisibilityWarning } from "./VisibilityWarning";
 export { default as ReviewNotice } from "./ReviewNotice";

--- a/garden/src/types/index.ts
+++ b/garden/src/types/index.ts
@@ -75,7 +75,15 @@ type HpcFunctionPatchRequest = components["schemas"]["HpcFunctionPatchRequest"];
 type HpcInvocationCreateRequest = components["schemas"]["HpcInvocationCreateRequest"];
 type HpcInvocationResponse = components["schemas"]["HpcInvocationResponse"];
 
+// Discriminated union for Modal and HPC functions
+type FunctionType = 'modal' | 'hpc';
+type Function =
+  | (ModalFunction & { functionType: 'modal' })
+  | (HpcFunctionMetadataResponse & { functionType: 'hpc' });
+
 export type {
+  FunctionType,
+  Function,
   Garden,
   GardenMetadataResponse,
   GardenCreateRequest,

--- a/garden/tests/features/gardens/components/garden-page/FunctionManager.test.tsx
+++ b/garden/tests/features/gardens/components/garden-page/FunctionManager.test.tsx
@@ -1,0 +1,365 @@
+import { vi, describe, it, expect, beforeEach } from "vitest";
+import "@testing-library/jest-dom/vitest";
+import { screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import FunctionManager from "@/features/gardens/components/garden-page/FunctionManager";
+import {
+  Garden,
+  ModalFunction,
+  HpcFunctionMetadataResponse,
+  User,
+} from "@/types";
+
+// Mock API hooks and libraries
+vi.mock("@/features/users/api/useGetUserInfo");
+vi.mock("@/features/modal/api/useGetAllModalFunctions");
+vi.mock("@/features/hpc-admin/api/useHpcFunctions");
+vi.mock("@/features/gardens/api/usePatchGarden");
+vi.mock("@/features/model-deployments/api/useGetModelDeployments");
+vi.mock("sonner");
+
+// Import mocked hooks for type-safe mocking
+import { useGetUserInfo } from "@/features/users/api/useGetUserInfo";
+import { useGetAllModalFunctions } from "@/features/modal/api/useGetAllModalFunctions";
+import { useHpcFunctions } from "@/features/hpc-admin/api/useHpcFunctions";
+import { usePatchGarden } from "@/features/gardens/api/usePatchGarden";
+import { useGetModelDeployments } from "@/features/model-deployments/api/useGetModelDeployments";
+
+// --- Mock Data ---
+
+const mockOwner: User = {
+  identity_id: "owner-uuid",
+  username: "owner",
+  name: "Owner User",
+  email: "owner@garden.ai",
+  globus_identity: "owner-uuid",
+};
+
+const mockNonOwner: User = {
+  identity_id: "non-owner-uuid",
+  username: "nonowner",
+  name: "Non-Owner User",
+  email: "nonowner@garden.ai",
+  globus_identity: "non-owner-uuid",
+};
+
+const mockModalFunctions: ModalFunction[] = [
+  {
+    id: 1,
+    title: "Modal Func 1",
+    authors: ["Author One"],
+    container_uuid: "uuid1",
+    created_at: "date",
+    updated_at: "date",
+    doi: "doi1",
+    description: "desc 1",
+    short_name: "mf1",
+    public: true,
+  },
+  {
+    id: 2,
+    title: "Modal Func 2",
+    function_name: "modal_func_2",
+    authors: ["Author Two"],
+    container_uuid: "uuid2",
+    created_at: "date",
+    updated_at: "date",
+    doi: "doi2",
+    description: "desc 2",
+    short_name: "mf2",
+    public: true,
+  },
+];
+
+const mockHpcFunctions: HpcFunctionMetadataResponse[] = [
+  {
+    id: "hpc-func-1-uuid",
+    title: "HPC Func 1",
+    function_name: "hpc_func_1",
+    authors: ["Author Three"],
+    created_at: "date",
+    updated_at: "date",
+    doi: "doi3",
+    description: "desc 3",
+    short_name: "hpc1",
+    public: true,
+  },
+  {
+    id: "hpc-func-2-uuid",
+    title: "HPC Func 2",
+    function_name: "hpc_func_2",
+    authors: ["Author One"],
+    created_at: "date",
+    updated_at: "date",
+    doi: "doi4",
+    description: "desc 4",
+    short_name: "hpc2",
+    public: true,
+  },
+];
+
+const mockGarden: Garden = {
+  doi: "10.23677/test-garden",
+  title: "Test Garden",
+  authors: ["Owner User"],
+  owner_identity_id: "owner-uuid",
+  modal_functions: [mockModalFunctions[0]],
+  hpc_functions: [mockHpcFunctions[0]],
+  description: "A test garden",
+  year: 2025,
+  language: "en",
+  version: "1.0",
+  publisher: "Garden-AI",
+  contributors: [],
+  uuid: "garden-uuid",
+  created_at: "date",
+  updated_at: "date",
+  entrypoint_ids: [],
+  entrypoints: [],
+};
+
+const mockPatchGarden = vi.fn();
+
+// --- Test Setup ---
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { retry: false, staleTime: Infinity },
+  },
+});
+
+const renderFunctionManager = (garden: Garden) => {
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <FunctionManager garden={garden} />
+      </QueryClientProvider>
+    </MemoryRouter>
+  );
+};
+
+// --- Test Suite ---
+
+describe("FunctionManager", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    queryClient.clear();
+
+    // Default mocks for happy paths
+    (useGetUserInfo as vi.Mock).mockReturnValue({
+      data: mockOwner,
+      isLoading: false,
+      isError: false,
+    });
+    (useGetAllModalFunctions as vi.Mock).mockReturnValue({
+      data: mockModalFunctions,
+      isLoading: false,
+      isError: false,
+    });
+    (useHpcFunctions as vi.Mock).mockReturnValue({
+      data: mockHpcFunctions,
+      isLoading: false,
+      isError: false,
+    });
+    (usePatchGarden as vi.Mock).mockReturnValue({
+      mutateAsync: mockPatchGarden,
+      isPending: false,
+    });
+    (useGetModelDeployments as vi.Mock).mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    });
+    (toast.error as vi.Mock) = vi.fn();
+    (toast.info as vi.Mock) = vi.fn();
+    (toast.success as vi.Mock) = vi.fn();
+  });
+
+  // --- Task 2: Permissions ---
+
+  it("should show the 'Add/Remove Functions' button for the garden owner", () => {
+    renderFunctionManager(mockGarden);
+    expect(
+      screen.getByRole("button", { name: /add\/remove functions/i })
+    ).toBeInTheDocument();
+  });
+
+  it("should not show the 'Add/Remove Functions' button for a non-owner", () => {
+    (useGetUserInfo as vi.Mock).mockReturnValue({
+      data: mockNonOwner,
+      isLoading: false,
+      isError: false,
+    });
+    renderFunctionManager(mockGarden);
+    expect(
+      screen.queryByRole("button", { name: /add\/remove functions/i })
+    ).not.toBeInTheDocument();
+  });
+
+  // --- Task 3: Data Fetching and Display ---
+
+  it("should display merged functions in the table when data is loaded", async () => {
+    renderFunctionManager(mockGarden);
+    fireEvent.click(
+      screen.getByRole("button", { name: /add\/remove functions/i })
+    );
+
+    await waitFor(async () => {
+      const table = await screen.findByRole("table");
+      expect(within(table).getByText("Modal Func 1")).toBeInTheDocument();
+      expect(within(table).getByText("HPC Func 1")).toBeInTheDocument();
+      expect(within(table).getByText("Modal Func 2")).toBeInTheDocument();
+      expect(within(table).getByText("HPC Func 2")).toBeInTheDocument();
+    });
+  });
+
+  it("should show an error toast if fetching modal functions fails", async () => {
+    (useGetAllModalFunctions as vi.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+    renderFunctionManager(mockGarden);
+    fireEvent.click(
+      screen.getByRole("button", { name: /add\/remove functions/i })
+    );
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "Failed to load Modal functions."
+      );
+    });
+  });
+
+  it("should show a loading spinner while fetching functions", async () => {
+    (useGetAllModalFunctions as vi.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    (useHpcFunctions as vi.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+
+    const { container } = renderFunctionManager(mockGarden);
+    fireEvent.click(
+      screen.getByRole("button", { name: /add\/remove functions/i })
+    );
+
+    await screen.findByRole("status");
+  });
+
+  it("should show an error toast if fetching HPC functions fails", async () => {
+    (useHpcFunctions as vi.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+    renderFunctionManager(mockGarden);
+    fireEvent.click(
+      screen.getByRole("button", { name: /add\/remove functions/i })
+    );
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Failed to load HPC functions.");
+    });
+  });
+
+  // --- Task 4: Selection and Save Logic ---
+
+  it("should pre-select functions already in the garden", async () => {
+    renderFunctionManager(mockGarden);
+    fireEvent.click(
+      screen.getByRole("button", { name: /add\/remove functions/i })
+    );
+
+    await waitFor(() => {
+      const modalRow = screen.getByRole("row", { name: /modal func 1/i });
+      const hpcRow = screen.getByRole("row", { name: /hpc func 1/i });
+      expect(within(modalRow).getByRole("checkbox")).toBeChecked();
+      expect(within(hpcRow).getByRole("checkbox")).toBeChecked();
+    });
+  });
+
+  it("should call patchGarden with correct payload on save", async () => {
+    renderFunctionManager(mockGarden);
+    fireEvent.click(
+      screen.getByRole("button", { name: /add\/remove functions/i })
+    );
+
+    await waitFor(() => {
+      // Check "Modal Func 2"
+      const modal2Row = screen.getByRole("row", { name: /modal func 2/i });
+      fireEvent.click(within(modal2Row).getByRole("checkbox"));
+      
+      // Check "HPC Func 2"
+      const hpc2Row = screen.getByRole("row", { name: /hpc func 2/i });
+      fireEvent.click(within(hpc2Row).getByRole("checkbox"));
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /update garden/i }));
+
+    await waitFor(() => {
+      const expectedAuthors = ["Author One", "Author Two", "Author Three"];
+      expect(mockPatchGarden).toHaveBeenCalledWith(expect.objectContaining({
+        doi: mockGarden.doi,
+        garden: expect.objectContaining({
+          modal_function_ids: [1, 2],
+          hpc_function_ids: ["hpc-func-1-uuid", "hpc-func-2-uuid"],
+        }),
+      }));
+      const actualAuthors = mockPatchGarden.mock.calls[0][0].garden.authors;
+      expect(new Set(actualAuthors)).toEqual(new Set(expectedAuthors));
+    });
+  });
+
+  it("should call patchGarden with correct payload on function removal", async () => {
+    renderFunctionManager(mockGarden);
+    fireEvent.click(
+      screen.getByRole("button", { name: /add\/remove functions/i })
+    );
+
+    await waitFor(() => {
+      // Un-check "Modal Func 1" which was pre-selected
+      const modal1Row = screen.getByRole("row", { name: /modal func 1/i });
+      fireEvent.click(within(modal1Row).getByRole("checkbox"));
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /update garden/i }));
+
+    await waitFor(() => {
+      expect(mockPatchGarden).toHaveBeenCalledWith(
+        expect.objectContaining({
+          doi: mockGarden.doi,
+          garden: expect.objectContaining({
+            modal_function_ids: [], // Was [1], now empty
+            authors: ["Author Three"],
+          }),
+        })
+      );
+
+      // Check that hpc_function_ids was not sent
+      const patchPayload = mockPatchGarden.mock.calls[0][0].garden;
+      expect(patchPayload).not.toHaveProperty("hpc_function_ids");
+    });
+  });
+
+  it("should not call patchGarden if no changes were made", async () => {
+    renderFunctionManager(mockGarden);
+    fireEvent.click(
+      screen.getByRole("button", { name: /add\/remove functions/i })
+    );
+
+    await waitFor(() => {
+      // Open and immediately close
+      fireEvent.click(screen.getByRole("button", { name: /update garden/i }));
+    });
+
+    expect(mockPatchGarden).not.toHaveBeenCalled();
+    expect(toast.info).toHaveBeenCalledWith("No changes to save.");
+  });
+});

--- a/garden/tests/features/gardens/components/garden-page/FunctionManager.test.tsx
+++ b/garden/tests/features/gardens/components/garden-page/FunctionManager.test.tsx
@@ -1,4 +1,6 @@
-import { vi, describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
+import type { Mock } from "vitest";
+import { vi } from "vitest";
 import "@testing-library/jest-dom/vitest";
 import { screen, fireEvent, waitFor, within } from "@testing-library/react";
 import { render } from "@testing-library/react";
@@ -36,7 +38,6 @@ const mockOwner: User = {
   username: "owner",
   name: "Owner User",
   email: "owner@garden.ai",
-  globus_identity: "owner-uuid",
 };
 
 const mockNonOwner: User = {
@@ -44,61 +45,63 @@ const mockNonOwner: User = {
   username: "nonowner",
   name: "Non-Owner User",
   email: "nonowner@garden.ai",
-  globus_identity: "non-owner-uuid",
 };
 
 const mockModalFunctions: ModalFunction[] = [
   {
     id: 1,
     title: "Modal Func 1",
+    function_name: "modal_func_1",
     authors: ["Author One"],
-    container_uuid: "uuid1",
-    created_at: "date",
-    updated_at: "date",
-    doi: "doi1",
     description: "desc 1",
-    short_name: "mf1",
-    public: true,
+    is_archived: false,
+    function_text: "",
+    year: "2025",
+    example_usage: "",
+    modal_app_id: 1,
+    owner: "owner-uuid",
+    owner_identity_id: "owner-uuid",
+    hardware_spec: {},
   },
   {
     id: 2,
     title: "Modal Func 2",
     function_name: "modal_func_2",
     authors: ["Author Two"],
-    container_uuid: "uuid2",
-    created_at: "date",
-    updated_at: "date",
-    doi: "doi2",
     description: "desc 2",
-    short_name: "mf2",
-    public: true,
+    is_archived: false,
+    function_text: "",
+    year: "2025",
+    example_usage: "",
+    modal_app_id: 1,
+    owner: "owner-uuid",
+    owner_identity_id: "owner-uuid",
+    hardware_spec: {},
   },
 ];
 
 const mockHpcFunctions: HpcFunctionMetadataResponse[] = [
   {
-    id: "hpc-func-1-uuid",
+    id: 1,
     title: "HPC Func 1",
     function_name: "hpc_func_1",
     authors: ["Author Three"],
-    created_at: "date",
-    updated_at: "date",
-    doi: "doi3",
     description: "desc 3",
-    short_name: "hpc1",
-    public: true,
+    is_archived: false,
+    function_text: "",
+    year: "2025",
+    num_invocations: 0,
   },
   {
-    id: "hpc-func-2-uuid",
+    id: 2,
     title: "HPC Func 2",
     function_name: "hpc_func_2",
     authors: ["Author One"],
-    created_at: "date",
-    updated_at: "date",
-    doi: "doi4",
     description: "desc 4",
-    short_name: "hpc2",
-    public: true,
+    is_archived: false,
+    function_text: "",
+    year: "2025",
+    num_invocations: 0,
   },
 ];
 
@@ -110,17 +113,22 @@ const mockGarden: Garden = {
   modal_functions: [mockModalFunctions[0]],
   hpc_functions: [mockHpcFunctions[0]],
   description: "A test garden",
-  year: 2025,
+  year: "2025",
   language: "en",
   version: "1.0",
   publisher: "Garden-AI",
   contributors: [],
-  uuid: "garden-uuid",
-  created_at: "date",
-  updated_at: "date",
   entrypoint_ids: [],
   entrypoints: [],
-};
+  doi_is_draft: false,
+  marked_for_deletion: null,
+  state: "PUBLISHED",
+  modal_function_ids: [1],
+  hpc_function_ids: [1],
+  owner: "owner-uuid",
+  id: 1,
+  is_archived: false,
+} as Garden;
 
 const mockPatchGarden = vi.fn();
 
@@ -150,33 +158,33 @@ describe("FunctionManager", () => {
     queryClient.clear();
 
     // Default mocks for happy paths
-    (useGetUserInfo as vi.Mock).mockReturnValue({
+    (useGetUserInfo as Mock).mockReturnValue({
       data: mockOwner,
       isLoading: false,
       isError: false,
     });
-    (useGetAllModalFunctions as vi.Mock).mockReturnValue({
+    (useGetAllModalFunctions as Mock).mockReturnValue({
       data: mockModalFunctions,
       isLoading: false,
       isError: false,
     });
-    (useHpcFunctions as vi.Mock).mockReturnValue({
+    (useHpcFunctions as Mock).mockReturnValue({
       data: mockHpcFunctions,
       isLoading: false,
       isError: false,
     });
-    (usePatchGarden as vi.Mock).mockReturnValue({
+    (usePatchGarden as Mock).mockReturnValue({
       mutateAsync: mockPatchGarden,
       isPending: false,
     });
-    (useGetModelDeployments as vi.Mock).mockReturnValue({
+    (useGetModelDeployments as Mock).mockReturnValue({
       data: [],
       isLoading: false,
       isError: false,
     });
-    (toast.error as vi.Mock) = vi.fn();
-    (toast.info as vi.Mock) = vi.fn();
-    (toast.success as vi.Mock) = vi.fn();
+    (toast.error as Mock) = vi.fn();
+    (toast.info as Mock) = vi.fn();
+    (toast.success as Mock) = vi.fn();
   });
 
   // --- Task 2: Permissions ---
@@ -189,7 +197,7 @@ describe("FunctionManager", () => {
   });
 
   it("should not show the 'Add/Remove Functions' button for a non-owner", () => {
-    (useGetUserInfo as vi.Mock).mockReturnValue({
+    (useGetUserInfo as Mock).mockReturnValue({
       data: mockNonOwner,
       isLoading: false,
       isError: false,
@@ -218,7 +226,7 @@ describe("FunctionManager", () => {
   });
 
   it("should show an error toast if fetching modal functions fails", async () => {
-    (useGetAllModalFunctions as vi.Mock).mockReturnValue({
+    (useGetAllModalFunctions as Mock).mockReturnValue({
       data: undefined,
       isLoading: false,
       isError: true,
@@ -236,11 +244,11 @@ describe("FunctionManager", () => {
   });
 
   it("should show a loading spinner while fetching functions", async () => {
-    (useGetAllModalFunctions as vi.Mock).mockReturnValue({
+    (useGetAllModalFunctions as Mock).mockReturnValue({
       data: undefined,
       isLoading: true,
     });
-    (useHpcFunctions as vi.Mock).mockReturnValue({
+    (useHpcFunctions as Mock).mockReturnValue({
       data: undefined,
       isLoading: true,
     });
@@ -254,7 +262,7 @@ describe("FunctionManager", () => {
   });
 
   it("should show an error toast if fetching HPC functions fails", async () => {
-    (useHpcFunctions as vi.Mock).mockReturnValue({
+    (useHpcFunctions as Mock).mockReturnValue({
       data: undefined,
       isLoading: false,
       isError: true,
@@ -309,7 +317,7 @@ describe("FunctionManager", () => {
         doi: mockGarden.doi,
         garden: expect.objectContaining({
           modal_function_ids: [1, 2],
-          hpc_function_ids: ["hpc-func-1-uuid", "hpc-func-2-uuid"],
+          hpc_function_ids: [1, 2],
         }),
       }));
       const actualAuthors = mockPatchGarden.mock.calls[0][0].garden.authors;

--- a/garden/tsconfig.json
+++ b/garden/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "esnext"],
     "target": "ESNext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "vitest/globals"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Resolves: #451 

This PR adds logic to include HPC functions in the function selection table allowing users to add HPC functions to their gardens.

Note: Most of the diff is from some actual unit tests!!

## Demo
https://github.com/user-attachments/assets/17237f3f-1b9c-4c6a-98d8-6955cb63394d

## What is still missing
- While this lets users add/remove HPC functions from their gardens, the HPC functions are still not visible in the UI since we don't have cards for HPC functions yet. That will come in #450.
