### PR TITLE
Create HPC function cards, integrate into garden pages

### DIFF
--- a/garden/src/features/gardens/components/GardenTabbedSection.tsx
+++ b/garden/src/features/gardens/components/GardenTabbedSection.tsx
@@ -1,316 +1,367 @@
 import React, { useCallback } from "react";
 import { Card, CardContent } from "@/components/shadcn/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/shadcn/tabs";
-import { DatabaseIcon, BookIcon, CodeIcon, FunctionSquare, ScrollTextIcon, LucideIcon } from "lucide-react";
-import { Garden, ModalFunction } from "@/types";
+import {
+  DatabaseIcon,
+  BookIcon,
+  CodeIcon,
+  FunctionSquare,
+  ScrollTextIcon,
+  LucideIcon,
+} from "lucide-react";
+import { Garden } from "@/types";
 import EntrypointBox from "./EntrypointBox";
 import ModalFunctionBox from "./ModalFunctionBox";
-import { useDatasetManagement, usePaperManagement, useRepositoryManagement, useNotebookManagement } from '@/features/materials/hooks/useMaterialManagement';
+import HpcFunctionCard from "./HpcFunctionCard";
+import {
+  useDatasetManagement,
+  usePaperManagement,
+  useRepositoryManagement,
+  useNotebookManagement,
+} from "@/features/materials/hooks/useMaterialManagement";
 import { getUniqueItemCount } from "../utils/garden.utils";
 
 import FunctionManager from "./garden-page/FunctionManager";
 
-import {
-    AddMaterialWithFunctionSelect,
-    MaterialCardWithRemoval
-} from "@/features/materials";
+import { AddMaterialWithFunctionSelect, MaterialCardWithRemoval } from "@/features/materials";
 
-const TabTrigger = ({ icon: Icon, name, count, value }: { icon: LucideIcon, name: string, count: number, value: string }) => {
-    return (
-        <TabsTrigger
-            value={value}
-            className="data-[state=active]:bg-white data-[state=active]:shadow-sm text-sm"
-        >
-            <div className="flex items-center justify-between">
-                <Icon className="h-4 w-4" />
-                <span className="hidden lg:block ml-1.5">{name}</span>
-                {count > 0 && (
-                    <span className="hidden sm:inline ml-1">
-                        ({count})
-                    </span>
-                )}
-            </div>
-        </TabsTrigger>
-    );
+const TabTrigger = ({
+  icon: Icon,
+  name,
+  count,
+  value,
+}: {
+  icon: LucideIcon;
+  name: string;
+  count: number;
+  value: string;
+}) => {
+  return (
+    <TabsTrigger
+      value={value}
+      className="text-sm data-[state=active]:bg-white data-[state=active]:shadow-sm"
+    >
+      <div className="flex items-center justify-between">
+        <Icon className="h-4 w-4" />
+        <span className="ml-1.5 hidden lg:block">{name}</span>
+        {count > 0 && <span className="ml-1 hidden sm:inline">({count})</span>}
+      </div>
+    </TabsTrigger>
+  );
 };
 
-export const GardenTabbedSection = ({ garden, ownsThisGarden }: { garden: Garden, ownsThisGarden: boolean }) => {
-    const { materials: datasets, refreshMaterials: refreshDatasets, findFunctionsWithMaterial: findDatasetFunctions } = useDatasetManagement(garden);
-    const { materials: papers, refreshMaterials: refreshPapers, findFunctionsWithMaterial: findPaperFunctions } = usePaperManagement(garden);
-    const { materials: repositories, refreshMaterials: refreshRepositories, findFunctionsWithMaterial: findRepositoryFunctions } = useRepositoryManagement(garden);
-    const { materials: notebooks, refreshMaterials: refreshNotebooks, findFunctionsWithMaterial: findNotebookFunctions } = useNotebookManagement(garden);
+export const GardenTabbedSection = ({
+  garden,
+  ownsThisGarden,
+}: {
+  garden: Garden;
+  ownsThisGarden: boolean;
+}) => {
+  const {
+    materials: datasets,
+    refreshMaterials: refreshDatasets,
+    findFunctionsWithMaterial: findDatasetFunctions,
+  } = useDatasetManagement(garden);
+  const {
+    materials: papers,
+    refreshMaterials: refreshPapers,
+    findFunctionsWithMaterial: findPaperFunctions,
+  } = usePaperManagement(garden);
+  const {
+    materials: repositories,
+    refreshMaterials: refreshRepositories,
+    findFunctionsWithMaterial: findRepositoryFunctions,
+  } = useRepositoryManagement(garden);
+  const {
+    materials: notebooks,
+    refreshMaterials: refreshNotebooks,
+    findFunctionsWithMaterial: findNotebookFunctions,
+  } = useNotebookManagement(garden);
 
-    // Callback to refresh all materials after adding/updating/removing
-    const handleMaterialsChange = useCallback(async () => {
-        await Promise.all([
-            refreshDatasets(),
-            refreshPapers(),
-            refreshRepositories(),
-            refreshNotebooks()
-        ]);
-    }, [refreshDatasets, refreshPapers, refreshRepositories, refreshNotebooks]);
+  // Callback to refresh all materials after adding/updating/removing
+  const handleMaterialsChange = useCallback(async () => {
+    await Promise.all([
+      refreshDatasets(),
+      refreshPapers(),
+      refreshRepositories(),
+      refreshNotebooks(),
+    ]);
+  }, [refreshDatasets, refreshPapers, refreshRepositories, refreshNotebooks]);
 
-    const handleMaterialAdded = useCallback(async () => {
-        await handleMaterialsChange();
-    }, [handleMaterialsChange]);
+  const handleMaterialAdded = useCallback(async () => {
+    await handleMaterialsChange();
+  }, [handleMaterialsChange]);
 
-    const handleMaterialUpdated = useCallback(async () => {
-        await handleMaterialsChange();
-    }, [handleMaterialsChange]);
+  const handleMaterialUpdated = useCallback(async () => {
+    await handleMaterialsChange();
+  }, [handleMaterialsChange]);
 
-    const handleMaterialRemoved = useCallback(async () => {
-        await handleMaterialsChange();
-    }, [handleMaterialsChange]);
+  const handleMaterialRemoved = useCallback(async () => {
+    await handleMaterialsChange();
+  }, [handleMaterialsChange]);
 
-    return (
-        <Tabs
-            defaultValue={
-                garden.modal_functions?.length ? "functions" :
-                    datasets.length ? "datasets" :
-                        papers.length ? "papers" :
-                            notebooks.length ? "notebooks" :
-                                "functions"
-            }
-            className="flex flex-col w-full"
-        >
-            <TabsList className="mb-2 bg-gray-200 p-0.5 grid grid-cols-5">
-                <TabTrigger
-                    icon={FunctionSquare}
-                    count={garden.modal_functions?.length || 0}
-                    name="Functions"
-                    value="functions"
-                />
-                <TabTrigger
-                    icon={DatabaseIcon}
-                    count={getUniqueItemCount(garden.modal_functions, 'datasets')}
-                    name="Datasets"
-                    value="datasets"
-                />
-                <TabTrigger
-                    icon={ScrollTextIcon}
-                    count={getUniqueItemCount(garden.modal_functions, 'papers')}
-                    name="Papers"
-                    value="papers"
-                />
-                <TabTrigger
-                    icon={CodeIcon}
-                    count={getUniqueItemCount(garden.modal_functions, 'repositories')}
-                    name="Repos"
-                    value="repositories"
-                />
-                <TabTrigger
-                    icon={BookIcon}
-                    count={getUniqueItemCount(garden.modal_functions, 'notebooks')}
-                    name="Notebooks"
-                    value="notebooks"
-                />
-            </TabsList>
+  return (
+    <Tabs
+      defaultValue={
+        garden.modal_functions?.length || garden.hpc_functions?.length || garden.entrypoints?.length
+          ? "functions"
+          : datasets.length
+            ? "datasets"
+            : papers.length
+              ? "papers"
+              : notebooks.length
+                ? "notebooks"
+                : "functions"
+      }
+      className="flex w-full flex-col"
+    >
+      <TabsList className="mb-2 grid grid-cols-5 bg-gray-200 p-0.5">
+        <TabTrigger
+          icon={FunctionSquare}
+          count={
+            (garden.modal_functions?.length || 0) +
+            (garden.hpc_functions?.length || 0) +
+            (garden.entrypoints?.length || 0)
+          }
+          name="Functions"
+          value="functions"
+        />
+        <TabTrigger
+          icon={DatabaseIcon}
+          count={getUniqueItemCount(garden.modal_functions, "datasets")}
+          name="Datasets"
+          value="datasets"
+        />
+        <TabTrigger
+          icon={ScrollTextIcon}
+          count={getUniqueItemCount(garden.modal_functions, "papers")}
+          name="Papers"
+          value="papers"
+        />
+        <TabTrigger
+          icon={CodeIcon}
+          count={getUniqueItemCount(garden.modal_functions, "repositories")}
+          name="Repos"
+          value="repositories"
+        />
+        <TabTrigger
+          icon={BookIcon}
+          count={getUniqueItemCount(garden.modal_functions, "notebooks")}
+          name="Notebooks"
+          value="notebooks"
+        />
+      </TabsList>
 
-            <TabsContent value="functions" className="mt-0 relative">
-                <Card className="border-0 shadow-none bg-transparent">
-                    <CardContent className="pt-6">
-                        <div>
-                            <div className="flex items-center justify-between mb-3">
-                                <h3 className="text-lg font-medium flex items-center">
-                                    <FunctionSquare className="h-5 w-5 mr-2 text-green" />
-                                    Functions
-                                </h3>
+      <TabsContent value="functions" className="relative mt-0">
+        <Card className="border-0 bg-transparent shadow-none">
+          <CardContent className="pt-6">
+            <div>
+              <div className="mb-3 flex items-center justify-between">
+                <h3 className="flex items-center text-lg font-medium">
+                  <FunctionSquare className="mr-2 h-5 w-5 text-green" />
+                  Functions
+                </h3>
 
-                                {ownsThisGarden && (
-                                    <FunctionManager
-                                        garden={garden}
-                                        onSuccess={handleMaterialAdded}
-                                    />
-                                )}
-                            </div>
+                {ownsThisGarden && (
+                  <FunctionManager garden={garden} onSuccess={handleMaterialAdded} />
+                )}
+              </div>
 
-                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                {garden.entrypoints?.map((entrypoint, index) => (
-                                    <EntrypointBox
-                                        key={index}
-                                        entrypoint={entrypoint}
-                                    />
-                                ))}
-                                {garden.modal_functions?.map((modalFunction, index) => (
-                                    <ModalFunctionBox
-                                        key={index}
-                                        modalFunction={modalFunction}
-                                        gardenDoi={garden.doi}
-                                    />
-                                ))}
-                            </div>
-                        </div>
-                    </CardContent>
-                </Card>
-            </TabsContent>
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                {garden.entrypoints?.map((entrypoint, index) => (
+                  <EntrypointBox key={index} entrypoint={entrypoint} />
+                ))}
+                {garden.modal_functions?.map((modalFunction, index) => (
+                  <ModalFunctionBox
+                    key={index}
+                    modalFunction={modalFunction}
+                    gardenDoi={garden.doi}
+                  />
+                ))}
+                {garden.hpc_functions?.map((hpcFunction, index) => (
+                  <HpcFunctionCard key={index} hpcFunction={hpcFunction} />
+                ))}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </TabsContent>
 
-            <TabsContent value="datasets" className="mt-0 relative">
-                <Card className="border-0 shadow-none bg-transparent">
-                    <CardContent className="pt-6">
-                        <div>
-                            <div className="flex items-center justify-between mb-3">
-                                <h3 className="text-lg font-medium flex items-center">
-                                    <DatabaseIcon className="h-5 w-5 mr-2 text-green" />
-                                    Datasets
-                                </h3>
+      <TabsContent value="datasets" className="relative mt-0">
+        <Card className="border-0 bg-transparent shadow-none">
+          <CardContent className="pt-6">
+            <div>
+              <div className="mb-3 flex items-center justify-between">
+                <h3 className="flex items-center text-lg font-medium">
+                  <DatabaseIcon className="mr-2 h-5 w-5 text-green" />
+                  Datasets
+                </h3>
 
-                                {ownsThisGarden && (garden.modal_functions?.length ?? 0) > 0 && (
-                                    <AddMaterialWithFunctionSelect
-                                        garden={garden}
-                                        materialType="datasets"
-                                        onSuccess={handleMaterialAdded}
-                                    />
-                                )}
-                            </div>
+                {ownsThisGarden && (garden.modal_functions?.length ?? 0) > 0 && (
+                  <AddMaterialWithFunctionSelect
+                    garden={garden}
+                    materialType="datasets"
+                    onSuccess={handleMaterialAdded}
+                  />
+                )}
+              </div>
 
-                            {datasets.length > 0 ? (
-                                <div className="grid grid-cols-1 gap-8 py-2">
-                                    {datasets.map((dataset, index) => (
-                                        <MaterialCardWithRemoval
-                                            key={dataset.doi || index}
-                                            material={dataset}
-                                            materialType="dataset"
-                                            findAffectedFunctions={findDatasetFunctions}
-                                            ownsThisGarden={ownsThisGarden}
-                                            onMaterialUpdated={handleMaterialUpdated}
-                                            onMaterialRemoved={handleMaterialRemoved}
-                                            garden={garden}
-                                        />
-                                    ))}
-                                </div>
-                            ) : (
-                                <p className="text-gray-500 italic">No datasets associated with the functions in this garden</p>
-                            )}
-                        </div>
-                    </CardContent>
-                </Card>
-            </TabsContent>
+              {datasets.length > 0 ? (
+                <div className="grid grid-cols-1 gap-8 py-2">
+                  {datasets.map((dataset, index) => (
+                    <MaterialCardWithRemoval
+                      key={dataset.doi || index}
+                      material={dataset}
+                      materialType="dataset"
+                      findAffectedFunctions={findDatasetFunctions}
+                      ownsThisGarden={ownsThisGarden}
+                      onMaterialUpdated={handleMaterialUpdated}
+                      onMaterialRemoved={handleMaterialRemoved}
+                      garden={garden}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <p className="italic text-gray-500">
+                  No datasets associated with the functions in this garden
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </TabsContent>
 
-            <TabsContent value="papers" className="mt-0 relative">
-                <Card className="border-0 shadow-none bg-transparent">
-                    <CardContent className="pt-6">
-                        <div>
-                            <div className="flex items-center justify-between mb-3">
-                                <h3 className="text-lg font-medium flex items-center">
-                                    <BookIcon className="h-5 w-5 mr-2 text-green" />
-                                    Papers
-                                </h3>
+      <TabsContent value="papers" className="relative mt-0">
+        <Card className="border-0 bg-transparent shadow-none">
+          <CardContent className="pt-6">
+            <div>
+              <div className="mb-3 flex items-center justify-between">
+                <h3 className="flex items-center text-lg font-medium">
+                  <BookIcon className="mr-2 h-5 w-5 text-green" />
+                  Papers
+                </h3>
 
-                                {ownsThisGarden && (garden.modal_functions?.length ?? 0) > 0 && (
-                                    <AddMaterialWithFunctionSelect
-                                        garden={garden}
-                                        materialType="papers"
-                                        onSuccess={handleMaterialAdded}
-                                    />
-                                )}
-                            </div>
+                {ownsThisGarden && (garden.modal_functions?.length ?? 0) > 0 && (
+                  <AddMaterialWithFunctionSelect
+                    garden={garden}
+                    materialType="papers"
+                    onSuccess={handleMaterialAdded}
+                  />
+                )}
+              </div>
 
-                            {papers.length > 0 ? (
-                                <div className="grid grid-cols-1 gap-8 py-2">
-                                    {papers.map((paper, index) => (
-                                        <MaterialCardWithRemoval
-                                            key={paper.doi || paper.title || index}
-                                            material={paper}
-                                            materialType="paper"
-                                            findAffectedFunctions={findPaperFunctions}
-                                            ownsThisGarden={ownsThisGarden}
-                                            onMaterialUpdated={handleMaterialUpdated}
-                                            onMaterialRemoved={handleMaterialRemoved}
-                                            garden={garden}
-                                        />
-                                    ))}
-                                </div>
-                            ) : (
-                                <p className="text-gray-500 italic">No papers associated with the functions in this garden</p>
-                            )}
-                        </div>
-                    </CardContent>
-                </Card>
-            </TabsContent>
+              {papers.length > 0 ? (
+                <div className="grid grid-cols-1 gap-8 py-2">
+                  {papers.map((paper, index) => (
+                    <MaterialCardWithRemoval
+                      key={paper.doi || paper.title || index}
+                      material={paper}
+                      materialType="paper"
+                      findAffectedFunctions={findPaperFunctions}
+                      ownsThisGarden={ownsThisGarden}
+                      onMaterialUpdated={handleMaterialUpdated}
+                      onMaterialRemoved={handleMaterialRemoved}
+                      garden={garden}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <p className="italic text-gray-500">
+                  No papers associated with the functions in this garden
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </TabsContent>
 
-            <TabsContent value="repositories" className="mt-0 relative">
-                <Card className="border-0 shadow-none bg-transparent">
-                    <CardContent className="pt-6">
-                        <div>
-                            <div className="flex items-center justify-between mb-3">
-                                <h3 className="text-lg font-medium flex items-center">
-                                    <CodeIcon className="h-5 w-5 mr-2 text-green" />
-                                    Code Repositories
-                                </h3>
+      <TabsContent value="repositories" className="relative mt-0">
+        <Card className="border-0 bg-transparent shadow-none">
+          <CardContent className="pt-6">
+            <div>
+              <div className="mb-3 flex items-center justify-between">
+                <h3 className="flex items-center text-lg font-medium">
+                  <CodeIcon className="mr-2 h-5 w-5 text-green" />
+                  Code Repositories
+                </h3>
 
-                                {ownsThisGarden && (garden.modal_functions?.length ?? 0) > 0 && (
-                                    <AddMaterialWithFunctionSelect
-                                        garden={garden}
-                                        materialType="repositories"
-                                        onSuccess={handleMaterialAdded}
-                                    />
-                                )}
-                            </div>
+                {ownsThisGarden && (garden.modal_functions?.length ?? 0) > 0 && (
+                  <AddMaterialWithFunctionSelect
+                    garden={garden}
+                    materialType="repositories"
+                    onSuccess={handleMaterialAdded}
+                  />
+                )}
+              </div>
 
-                            {repositories.length > 0 ? (
-                                <div className="grid grid-cols-1 gap-8 py-2">
-                                    {repositories.map((repo, index) => (
-                                        <MaterialCardWithRemoval
-                                            key={repo.url || index}
-                                            material={repo}
-                                            materialType="repository"
-                                            findAffectedFunctions={findRepositoryFunctions}
-                                            ownsThisGarden={ownsThisGarden}
-                                            onMaterialUpdated={handleMaterialUpdated}
-                                            onMaterialRemoved={handleMaterialRemoved}
-                                            garden={garden}
-                                        />
-                                    ))}
-                                </div>
-                            ) : (
-                                <p className="text-gray-500 italic">No repositories associated with the functions in this garden</p>
-                            )}
-                        </div>
-                    </CardContent>
-                </Card>
-            </TabsContent>
+              {repositories.length > 0 ? (
+                <div className="grid grid-cols-1 gap-8 py-2">
+                  {repositories.map((repo, index) => (
+                    <MaterialCardWithRemoval
+                      key={repo.url || index}
+                      material={repo}
+                      materialType="repository"
+                      findAffectedFunctions={findRepositoryFunctions}
+                      ownsThisGarden={ownsThisGarden}
+                      onMaterialUpdated={handleMaterialUpdated}
+                      onMaterialRemoved={handleMaterialRemoved}
+                      garden={garden}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <p className="italic text-gray-500">
+                  No repositories associated with the functions in this garden
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </TabsContent>
 
-            <TabsContent value="notebooks" className="mt-0 relative">
-                <Card className="border-0 shadow-none bg-transparent">
-                    <CardContent className="pt-6">
-                        <div>
-                            <div className="flex items-center justify-between mb-3">
-                                <h3 className="text-lg font-medium flex items-center">
-                                    <ScrollTextIcon className="h-5 w-5 mr-2 text-green" />
-                                    Notebooks
-                                </h3>
+      <TabsContent value="notebooks" className="relative mt-0">
+        <Card className="border-0 bg-transparent shadow-none">
+          <CardContent className="pt-6">
+            <div>
+              <div className="mb-3 flex items-center justify-between">
+                <h3 className="flex items-center text-lg font-medium">
+                  <ScrollTextIcon className="mr-2 h-5 w-5 text-green" />
+                  Notebooks
+                </h3>
 
-                                {ownsThisGarden && (
-                                    <AddMaterialWithFunctionSelect
-                                        garden={garden}
-                                        materialType="notebooks"
-                                        onSuccess={handleMaterialAdded}
-                                    />
-                                )}
-                            </div>
+                {ownsThisGarden && (
+                  <AddMaterialWithFunctionSelect
+                    garden={garden}
+                    materialType="notebooks"
+                    onSuccess={handleMaterialAdded}
+                  />
+                )}
+              </div>
 
-                            {notebooks.length > 0 ? (
-                                <div className="grid grid-cols-1 gap-8 py-2">
-                                    {notebooks.map((notebook, index) => (
-                                        <MaterialCardWithRemoval
-                                            key={notebook.url || index}
-                                            material={notebook}
-                                            materialType="notebook"
-                                            findAffectedFunctions={findNotebookFunctions}
-                                            ownsThisGarden={ownsThisGarden}
-                                            onMaterialUpdated={handleMaterialUpdated}
-                                            onMaterialRemoved={handleMaterialRemoved}
-                                            garden={garden}
-                                        />
-                                    ))}
-                                </div>
-                            ) : (
-                                <p className="text-gray-500 italic">No notebooks associated with the functions in this garden</p>
-                            )}
-                        </div>
-                    </CardContent>
-                </Card>
-            </TabsContent>
-        </Tabs>
-    );
-}
+              {notebooks.length > 0 ? (
+                <div className="grid grid-cols-1 gap-8 py-2">
+                  {notebooks.map((notebook, index) => (
+                    <MaterialCardWithRemoval
+                      key={notebook.url || index}
+                      material={notebook}
+                      materialType="notebook"
+                      findAffectedFunctions={findNotebookFunctions}
+                      ownsThisGarden={ownsThisGarden}
+                      onMaterialUpdated={handleMaterialUpdated}
+                      onMaterialRemoved={handleMaterialRemoved}
+                      garden={garden}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <p className="italic text-gray-500">
+                  No notebooks associated with the functions in this garden
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </TabsContent>
+    </Tabs>
+  );
+};

--- a/garden/src/features/gardens/components/HpcFunctionCard.tsx
+++ b/garden/src/features/gardens/components/HpcFunctionCard.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { HpcFunctionMetadataResponse } from "@/types";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardFooter,
+  MarkdownCardContent,
+} from "@/components/shadcn/card";
+import { FunctionSquare, Tag } from "lucide-react";
+import { toast } from "sonner";
+
+interface HpcFunctionCardProps {
+  hpcFunction: HpcFunctionMetadataResponse;
+}
+
+const HpcFunctionCard = ({ hpcFunction }: HpcFunctionCardProps) => {
+  if (!hpcFunction) {
+    return null;
+  }
+
+  const handleClick = () => {
+    toast.info("HPC Function pages coming soon!", {
+      description: "Detailed HPC function pages are currently under development.",
+      duration: 3000,
+    });
+  };
+
+  return (
+    <Card
+      className="group flex h-full cursor-pointer flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm backdrop-blur-sm transition-all hover:shadow-md"
+      onClick={handleClick}
+    >
+      <CardHeader className="border-b border-gray-100 bg-gradient-to-r from-white to-gray-50 pb-2 pt-5">
+        <div className="flex items-center gap-3">
+          <div className="flex-shrink-0 rounded-lg bg-blue-600/10 p-2 text-blue-600">
+            <FunctionSquare className="h-4 w-4" />
+          </div>
+          <CardTitle className="text-lg font-medium tracking-tight text-gray-800">
+            {hpcFunction.title || "Untitled"}
+          </CardTitle>
+        </div>
+      </CardHeader>
+
+      <MarkdownCardContent
+        className="max-h-[120px] flex-grow gap-3 overflow-hidden text-sm text-gray-700"
+        content={hpcFunction.description || "No description available"}
+      />
+
+      {hpcFunction.tags && hpcFunction.tags.length > 0 && (
+        <CardFooter className="flex flex-row items-center border-t border-gray-100 bg-gray-50/80 px-5 py-3 text-xs text-gray-600">
+          <div className="flex w-full items-center justify-between gap-3">
+            {/* Tags Section */}
+            <div className="flex items-center gap-1 overflow-hidden">
+              <Tag className="h-3 w-3 flex-shrink-0" />
+              <span className="truncate">
+                {hpcFunction.tags.slice(0, 2).join(", ")}
+                {hpcFunction.tags.length > 2 ? "..." : ""}
+              </span>
+            </div>
+          </div>
+        </CardFooter>
+      )}
+    </Card>
+  );
+};
+
+export default HpcFunctionCard;

--- a/garden/src/features/search/components/SearchResult.tsx
+++ b/garden/src/features/search/components/SearchResult.tsx
@@ -14,7 +14,12 @@ import {
   MarkdownCardContent,
 } from "@/components/shadcn/card";
 import { Table, TableBody, TableCell, TableHeader, TableRow } from "@/components/shadcn/table";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/shadcn/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/shadcn/tooltip";
 
 import { BookOpenIcon, CalendarIcon, TagIcon } from "lucide-react";
 import { PersonIcon } from "@radix-ui/react-icons";
@@ -22,34 +27,56 @@ import { PersonIcon } from "@radix-ui/react-icons";
 import SaveGardenButton from "../../gardens/components/SaveGardenButton";
 import { ShareGardenButton } from "../../gardens/components/ShareGardenButton";
 import { Button } from "@/components/shadcn/button";
+import { toast } from "sonner";
 
-export const SearchResult = ({ garden, verbose, showPublishedBanner = true,
-}: { garden: Garden; verbose: boolean; showPublishedBanner?: boolean; }) => {
-  const functions = [...(garden.entrypoints ?? []), ...(garden.modal_functions ?? [])];
+export const SearchResult = ({
+  garden,
+  verbose,
+  showPublishedBanner = true,
+}: {
+  garden: Garden;
+  verbose: boolean;
+  showPublishedBanner?: boolean;
+}) => {
+  const functions = [
+    ...(garden.entrypoints ?? []),
+    ...(garden.modal_functions ?? []),
+    ...(garden.hpc_functions ?? []),
+  ];
   const [showMore, setShowMore] = useState(false);
 
   const handleShowMore = () => {
     setShowMore(!showMore);
-  }
+  };
   return (
-    <Card className={`relative transition-colors hover:shadow-lg ${garden.is_archived ? "bg-gray-100" : "hover:bg-gray-50"}`}>
-      <CardHeader className={`${(showPublishedBanner || garden.is_archived || garden.doi_is_draft) ? "pt-8" : ""}`}>
+    <Card
+      className={`relative transition-colors hover:shadow-lg ${garden.is_archived ? "bg-gray-100" : "hover:bg-gray-50"}`}
+    >
+      <CardHeader
+        className={`${showPublishedBanner || garden.is_archived || garden.doi_is_draft ? "pt-8" : ""}`}
+      >
         {showPublishedBanner && (
-          <div style={{ backgroundColor: "#C2E6CA", color: "#11451F" }}
-            className="absolute top-0 left-0 w-full rounded-t-md px-4 py-1 text-center text-sm font-semibold shadow-sm">
+          <div
+            style={{ backgroundColor: "#C2E6CA", color: "#11451F" }}
+            className="absolute left-0 top-0 w-full rounded-t-md px-4 py-1 text-center text-sm font-semibold shadow-sm"
+          >
             Published
           </div>
         )}
         <div className="flex items-start justify-between space-x-3">
           {garden.is_archived && (
-            <div style={{ backgroundColor: "#D2D1F7", color: "#3C2F67" }}
-              className="absolute top-0 left-0 w-full rounded-t-md px-4 py-1 text-center text-sm font-semibold shadow-sm">
+            <div
+              style={{ backgroundColor: "#D2D1F7", color: "#3C2F67" }}
+              className="absolute left-0 top-0 w-full rounded-t-md px-4 py-1 text-center text-sm font-semibold shadow-sm"
+            >
               Archived
             </div>
           )}
           {garden.doi_is_draft && (
-            <div style={{ backgroundColor: "#DBE9FF", color: "#28487B" }}
-              className="absolute top-0 left-0 w-full rounded-t-md px-4 py-1 text-center text-sm font-semibold shadow-sm">
+            <div
+              style={{ backgroundColor: "#DBE9FF", color: "#28487B" }}
+              className="absolute left-0 top-0 w-full rounded-t-md px-4 py-1 text-center text-sm font-semibold shadow-sm"
+            >
               Draft
             </div>
           )}
@@ -68,8 +95,10 @@ export const SearchResult = ({ garden, verbose, showPublishedBanner = true,
         >
           DOI: {garden.doi}
           {garden.marked_for_deletion && garden.doi_is_draft && (
-            <div style={{ backgroundColor: "#F0C2BD", color: "#411528" }}
-              className="ml-2 inline-block rounded px-2 py-0.5 text-xs font-medium">
+            <div
+              style={{ backgroundColor: "#F0C2BD", color: "#411528" }}
+              className="ml-2 inline-block rounded px-2 py-0.5 text-xs font-medium"
+            >
               Marked for Deletion
             </div>
           )}
@@ -88,14 +117,14 @@ export const SearchResult = ({ garden, verbose, showPublishedBanner = true,
 
       <div className="p-1">
         <MarkdownCardContent
-          className={`m-2 p-2 text-balanced ${(showMore) ? "" : "line-clamp-3"}`}
+          className={`text-balanced m-2 p-2 ${showMore ? "" : "line-clamp-3"}`}
           content={garden.description || "*No description available*"}
         />
         <Button
           onClick={handleShowMore}
-          className="text-black text-xs bg-inherit hover:text-blue-400 hover:bg-inherit hover:underline"
+          className="bg-inherit text-xs text-black hover:bg-inherit hover:text-blue-400 hover:underline"
         >
-          {(showMore) ? "Show Less" : "Show More"}
+          {showMore ? "Show Less" : "Show More"}
         </Button>
       </div>
 
@@ -113,32 +142,52 @@ export const SearchResult = ({ garden, verbose, showPublishedBanner = true,
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {functions?.map((func, index) => (
-                    <TableRow key={index}>
-                      <TableCell>
-                        <Link
-                          className="font-semibold"
-                          to={`/modal-functions/${encodeURIComponent(func.id)}`}
-                        >
-                          {func.title}
-                        </Link>
-                      </TableCell>
-                      <TableCell>
-                        <p className="line-clamp-3">{func.description}</p>
-                      </TableCell>
-                      <TableCell>
-                        {func.tags?.map((tag, index) => (
-                          <Badge
-                            key={index}
-                            variant="outline"
-                            className="cursor-default whitespace-nowrap bg-primary font-thin capitalize text-primary-foreground transition-colors hover:bg-primary/70"
-                          >
-                            {tag}
-                          </Badge>
-                        ))}
-                      </TableCell>
-                    </TableRow>
-                  ))}
+                  {functions?.map((func, index) => {
+                    // Check if this is an HPC function by seeing if it's in the hpc_functions array
+                    const isHpcFunction = garden.hpc_functions?.some((hpc) => hpc.id === func.id);
+
+                    return (
+                      <TableRow key={index}>
+                        <TableCell>
+                          {isHpcFunction ? (
+                            <span
+                              className="cursor-pointer font-semibold text-blue-600 hover:underline"
+                              onClick={() =>
+                                toast.info("HPC Function pages coming soon!", {
+                                  description:
+                                    "Detailed HPC function pages are currently under development.",
+                                  duration: 3000,
+                                })
+                              }
+                            >
+                              {func.title}
+                            </span>
+                          ) : (
+                            <Link
+                              className="font-semibold"
+                              to={`/modal-functions/${encodeURIComponent(func.id)}`}
+                            >
+                              {func.title}
+                            </Link>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <p className="line-clamp-3">{func.description}</p>
+                        </TableCell>
+                        <TableCell>
+                          {func.tags?.map((tag, index) => (
+                            <Badge
+                              key={index}
+                              variant="outline"
+                              className="cursor-default whitespace-nowrap bg-primary font-thin capitalize text-primary-foreground transition-colors hover:bg-primary/70"
+                            >
+                              {tag}
+                            </Badge>
+                          ))}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
                 </TableBody>
               </Table>
             </ScrollArea>


### PR DESCRIPTION
Resolves: #456 

This PR adds an `HpcFunctionCard` component and integrates it into garden pages in the 'Functions' section. HPC functions are colored differently from modal functions to indicate they are different. Since full function pages for HPC funtions aren't ready yet (coming soon in #457) , when a user clicks an HPC function we show a toast saying detail pages are coming soon!

This PR also updates the search results to show HPC functions when the 'Show Functions' toggle in turned on.


https://github.com/user-attachments/assets/b20be7c6-24dd-4543-9766-f1ba9093acd8

We can probably do a little more to refine the styling and how/if we want to present more info about what endpoints HPC functions can run on etc. I will consult with our resident design expert @nhouston125 and come up with a plan!