### PR TITLE
search result hpc functions navigate to function page

### DIFF
--- a/garden/src/features/search/components/SearchResult.tsx
+++ b/garden/src/features/search/components/SearchResult.tsx
@@ -145,23 +145,16 @@ export const SearchResult = ({
                   {functions?.map((func, index) => {
                     // Check if this is an HPC function by seeing if it's in the hpc_functions array
                     const isHpcFunction = garden.hpc_functions?.some((hpc) => hpc.id === func.id);
-
                     return (
                       <TableRow key={index}>
                         <TableCell>
                           {isHpcFunction ? (
-                            <span
-                              className="cursor-pointer font-semibold text-blue-600 hover:underline"
-                              onClick={() =>
-                                toast.info("HPC Function pages coming soon!", {
-                                  description:
-                                    "Detailed HPC function pages are currently under development.",
-                                  duration: 3000,
-                                })
-                              }
+                            <Link
+                              className="font-semibold"
+                              to={`/hpc-functions/${encodeURIComponent(func.id)}`}
                             >
                               {func.title}
-                            </span>
+                            </Link>
                           ) : (
                             <Link
                               className="font-semibold"


### PR DESCRIPTION
This is a quick addendum to #457

I realized I forgot to update the 'Under Construction' toast in search results when 'Show Functions' is toggled on and a user clicks an HPC function. This PR updates the search results to navigate to the appropriate function page instead of showing the toast!

https://github.com/user-attachments/assets/25cb02c8-6b8c-494f-a702-d2c2397d6bcc

