### PR TITLE
Deselect Items & Tab Interface

### DIFF
--- a/garden/src/features/ugmi/UnifiedManagementInterface.tsx
+++ b/garden/src/features/ugmi/UnifiedManagementInterface.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ResizablePanelGroup, ResizableHandle } from "@/components/shadcn/resizable";
+import { ResizablePanelGroup, ResizableHandle, ResizablePanel } from "@/components/shadcn/resizable";
 import { DndContext, DragOverlay } from "@dnd-kit/core";
 import { toast } from "sonner";
 import { Garden } from "@/types";
@@ -7,19 +7,23 @@ import { ModelDeployment } from "../model-deployments/ModelDeployments";
 import { LeftSidePanel } from "./components/LeftSidePanel";
 import { MainContentPanel } from "./components/MainContentPanel";
 import { RightSidePanel } from "./components/RightSidePanel";
+import { OpenTabsBar } from "./components/OpenTabsBar";
 import { useQueryClient } from "@tanstack/react-query";
 import { useSelection } from "./hooks";
+import { useTabManager } from "./hooks/useTabManager";
 import { useDragDrop } from "./hooks/useDragDrop";
 import { Entity } from "./types";
 
 export const UnifiedManagementInterface = () => {
   const queryClient = useQueryClient();
 
-  // Initialize hooks
   const selection = useSelection();
+  const tabs = useTabManager();
   const dragAndDrop = useDragDrop();
 
   const handleItemSelected = (entity: Entity, event?: { ctrlKey?: boolean; metaKey?: boolean; shiftKey?: boolean }) => {
+    tabs.openTab(entity);
+    
     if (event) {
       selection.handleClick(entity, event);
     } else {
@@ -28,13 +32,41 @@ export const UnifiedManagementInterface = () => {
   };
 
   const handleAfterDelete = () => {
+    if (selection.primarySelection) {
+      const entityId = tabs.openTabs.find(tab => 
+        tab.entity === selection.primarySelection
+      )?.id;
+      
+      if (entityId) {
+        tabs.closeTab(entityId);
+      }
+    }
+    
     selection.clearSelection();
   };
 
   const handleDeploymentCreated = (deployment: ModelDeployment) => {
-    // Select the new deployment
+    tabs.openTab(deployment);
     selection.selectSingle(deployment);
   };
+
+  const handleTabClick = (tabId: string) => {
+    tabs.setActiveTab(tabId);
+    const tabEntity = tabs.openTabs.find(tab => tab.id === tabId)?.entity;
+    if (tabEntity) {
+      selection.selectSingle(tabEntity);
+    }
+  };
+
+  const handleTabClose = (tabId: string) => {
+    tabs.closeTab(tabId);
+    
+    if (tabs.openTabs.length === 1) {
+      selection.clearSelection();
+    }
+  };
+
+  const displayEntity = tabs.getActiveEntity();
 
   return (
     <DndContext
@@ -58,20 +90,30 @@ export const UnifiedManagementInterface = () => {
             withHandle
             className="w-1 bg-slate-200 transition-colors hover:bg-slate-300"
           />
-          <MainContentPanel entity={selection.primarySelection} onAfterDelete={handleAfterDelete} />
+          
+          <ResizablePanel minSize={25} defaultSize={40} className="flex flex-col bg-white">
+            <OpenTabsBar
+              tabs={tabs.openTabs}
+              activeTabId={tabs.activeTabId}
+              onTabClick={handleTabClick}
+              onTabClose={handleTabClose}
+              onReorder={tabs.reorderTabs}
+            />
+            <MainContentPanel entity={displayEntity} onAfterDelete={handleAfterDelete} />
+          </ResizablePanel>
+          
           <ResizableHandle
             withHandle
             className="w-1 bg-slate-200 transition-colors hover:bg-slate-300"
           />
           <RightSidePanel
-            entity={selection.primarySelection}
+            entity={displayEntity}
             onItemSelected={handleItemSelected}
             selection={selection}
           />
         </ResizablePanelGroup>
       </div>
 
-      {/* Floating Drop Indicator */}
       {dragAndDrop.isDragging && dragAndDrop.activeDropTarget && (
         <div className="fixed top-4 left-1/2 transform -translate-x-1/2 z-50 pointer-events-none">
           <div className="bg-blue-600 text-white px-4 py-2 rounded-lg shadow-lg flex items-center gap-2 font-medium">

--- a/garden/src/features/ugmi/components/MainContentPanel.tsx
+++ b/garden/src/features/ugmi/components/MainContentPanel.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { ResizablePanel } from "@/components/shadcn/resizable";
 import { useGlobusAuth } from "@globus/react-auth-context";
 import { SUPER_USERS } from "@/utils/utils";
 import { ModelDeploymentDetails } from "../../model-deployments/ModelDeploymentDetails";
@@ -26,8 +25,8 @@ export const MainContentPanel = ({ entity, onAfterDelete }: MainContentPanelProp
       isSuperUser);
 
   return (
-    <ResizablePanel minSize={25} defaultSize={40} className="flex flex-col bg-white">
-      {entityType === null ? (
+    <div className="flex flex-col flex-1 bg-white">
+      {entityType === null || entity === null ? (
         <div className="flex h-full items-center justify-center">
           <div className="space-y-2 text-center">
             <div className="text-4xl">🌿</div>
@@ -55,7 +54,6 @@ export const MainContentPanel = ({ entity, onAfterDelete }: MainContentPanelProp
           )}
         </div>
       )}
-    </ResizablePanel>
+    </div>
   );
 };
-

--- a/garden/src/features/ugmi/components/OpenTabsBar.tsx
+++ b/garden/src/features/ugmi/components/OpenTabsBar.tsx
@@ -37,30 +37,26 @@ const restrictToHorizontalAxis: Modifier = ({ transform }) => {
 
 const getEntityIcon = (entity: Entity) => {
     const type = matchEntityType(entity);
-    switch (type) {
-        case "garden":
-            return Sprout;
-        case "function":
-            return Library;
-        case "deployment":
-            return Package;
-        default:
-            return Library;
+    if (type === "garden") {
+        return Sprout;
+    } else if (type === "modal-function" || type === "hpc-function") {
+        return Library;
+    } else if (type === "deployment") {
+        return Package;
     }
+    return Library;
 };
 
 const getEntityName = (entity: Entity): string => {
     const type = matchEntityType(entity);
-    switch (type) {
-        case "garden":
-            return (entity as Garden).title || "Untitled Garden";
-        case "function":
-            return (entity as ModalFunction).function_name || "Untitled Function";
-        case "deployment":
-            return (entity as ModelDeployment).name || "Untitled Deployment";
-        default:
-            return "Unknown";
+    if (type === "garden") {
+        return (entity as Garden).title || "Untitled Garden";
+    } else if (type === "modal-function" || type === "hpc-function") {
+        return (entity as ModalFunction).function_name || "Untitled Function";
+    } else if (type === "deployment") {
+        return (entity as ModelDeployment).name || "Untitled Deployment";
     }
+    return "Unknown";
 };
 
 interface SortableTabProps {

--- a/garden/src/features/ugmi/components/OpenTabsBar.tsx
+++ b/garden/src/features/ugmi/components/OpenTabsBar.tsx
@@ -1,0 +1,210 @@
+import React from "react";
+import { X, Sprout, Library, Package } from "lucide-react";
+import { 
+    DndContext, 
+    closestCenter, 
+    PointerSensor, 
+    useSensor, 
+    useSensors,
+    DragEndEvent,
+    Modifier
+} from "@dnd-kit/core";
+import { 
+    SortableContext, 
+    useSortable, 
+    horizontalListSortingStrategy,
+    arrayMove 
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Entity, matchEntityType } from "../types";
+import { Garden, ModalFunction } from "@/types";
+import { ModelDeployment } from "../../model-deployments/ModelDeployments";
+
+interface OpenTabsBarProps {
+    tabs: Array<{ entity: Entity; id: string }>;
+    activeTabId: string | null;
+    onTabClick: (id: string) => void;
+    onTabClose: (id: string) => void;
+    onReorder: (newOrder: Array<{ entity: Entity; id: string }>) => void;
+}
+
+const restrictToHorizontalAxis: Modifier = ({ transform }) => {
+    return {
+        ...transform,
+        y: 0,
+    };
+};
+
+const getEntityIcon = (entity: Entity) => {
+    const type = matchEntityType(entity);
+    switch (type) {
+        case "garden":
+            return Sprout;
+        case "function":
+            return Library;
+        case "deployment":
+            return Package;
+        default:
+            return Library;
+    }
+};
+
+const getEntityName = (entity: Entity): string => {
+    const type = matchEntityType(entity);
+    switch (type) {
+        case "garden":
+            return (entity as Garden).title || "Untitled Garden";
+        case "function":
+            return (entity as ModalFunction).function_name || "Untitled Function";
+        case "deployment":
+            return (entity as ModelDeployment).name || "Untitled Deployment";
+        default:
+            return "Unknown";
+    }
+};
+
+interface SortableTabProps {
+    tab: { entity: Entity; id: string };
+    isActive: boolean;
+    onTabClick: (id: string) => void;
+    onTabClose: (id: string) => void;
+}
+
+const SortableTab: React.FC<SortableTabProps> = ({ tab, isActive, onTabClick, onTabClose }) => {
+    const [isDraggingState, setIsDraggingState] = React.useState(false);
+
+    const {
+        attributes,
+        listeners,
+        setNodeRef,
+        transform,
+        transition,
+        isDragging,
+    } = useSortable({ 
+        id: tab.id,
+        data: {
+            type: 'tab',
+            tab: tab
+        }
+    });
+
+    React.useEffect(() => {
+        setIsDraggingState(isDragging);
+    }, [isDragging]);
+
+    const style = {
+        transform: CSS.Translate.toString(transform),
+        transition: isDragging ? undefined : 'none',
+        opacity: isDragging ? 0.5 : 1,
+        cursor: isDragging ? 'grabbing' : 'grab',
+    };
+
+    const IconComponent = getEntityIcon(tab.entity);
+    const name = getEntityName(tab.entity);
+
+    const handleClick = (e: React.MouseEvent) => {
+        if (isDraggingState || (e.target as HTMLElement).closest('button')) {
+            return;
+        }
+        onTabClick(tab.id);
+    };
+
+    return (
+        <div
+            ref={setNodeRef}
+            style={style}
+            className={`
+                group flex items-center gap-2 rounded-md px-3 py-1.5 text-sm
+                flex-shrink-0 max-w-[220px] select-none
+                ${isActive
+                    ? "bg-white shadow-sm border border-gray-200 text-gray-900"
+                    : "bg-transparent text-gray-600 hover:bg-gray-100"
+                }
+            `}
+            onClick={handleClick}
+            {...attributes}
+            {...listeners}
+        >
+            <IconComponent className="h-4 w-4 flex-shrink-0 pointer-events-none" />
+            <span className="truncate flex-1 font-medium pointer-events-none">{name}</span>
+            <button
+                onClick={(e) => {
+                    e.stopPropagation();
+                    onTabClose(tab.id);
+                }}
+                onPointerDown={(e) => {
+                    e.stopPropagation();
+                }}
+                className={`
+                    rounded p-0.5 transition-colors flex-shrink-0 pointer-events-auto
+                    ${isActive
+                        ? "hover:bg-gray-200 text-gray-500 hover:text-gray-700"
+                        : "opacity-0 group-hover:opacity-100 hover:bg-gray-200 text-gray-400 hover:text-gray-600"
+                    }
+                `}
+                aria-label="Close tab"
+            >
+                <X className="h-3.5 w-3.5" />
+            </button>
+        </div>
+    );
+};
+
+export const OpenTabsBar: React.FC<OpenTabsBarProps> = ({
+    tabs,
+    activeTabId,
+    onTabClick,
+    onTabClose,
+    onReorder,
+}) => {
+    const sensors = useSensors(
+        useSensor(PointerSensor, {
+            activationConstraint: {
+                distance: 1,
+                tolerance: 5,
+            },
+        })
+    );
+
+    const handleDragEnd = (event: DragEndEvent) => {
+        const { active, over } = event;
+
+        if (over && active.id !== over.id) {
+            const oldIndex = tabs.findIndex(tab => tab.id === active.id);
+            const newIndex = tabs.findIndex(tab => tab.id === over.id);
+
+            if (oldIndex !== -1 && newIndex !== -1) {
+                const newOrder = arrayMove(tabs, oldIndex, newIndex);
+                onReorder(newOrder);
+            }
+        }
+    };
+
+    if (tabs.length === 0) return null;
+
+    return (
+        <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+            modifiers={[restrictToHorizontalAxis]}
+        >
+            <div className="flex items-center gap-1 border-b border-gray-200 bg-gray-50 px-4 py-2 overflow-x-auto scrollbar-thin scrollbar-track-transparent min-h-[52px]">
+                <SortableContext 
+                    items={tabs.map(t => t.id)} 
+                    strategy={horizontalListSortingStrategy}
+                >
+                    {tabs.map((tab) => (
+                        <SortableTab
+                            key={tab.id}
+                            tab={tab}
+                            isActive={tab.id === activeTabId}
+                            onTabClick={onTabClick}
+                            onTabClose={onTabClose}
+                        />
+                    ))}
+                </SortableContext>
+            </div>
+        </DndContext>
+    );
+};

--- a/garden/src/features/ugmi/hooks/useDragDrop.ts
+++ b/garden/src/features/ugmi/hooks/useDragDrop.ts
@@ -16,16 +16,30 @@ export function useDragDrop() {
 
   const handleDragStart = useCallback((event: any) => {
     const { active } = event;
+    
+    if (active.data.current?.type === 'tab') {
+      return;
+    }
+    
     setDraggedItems([active.data.current]);
   }, []);
 
   const handleDragOver = useCallback((event: any) => {
-    const { over } = event;
+    const { over, active } = event;
+    
+    if (active.data.current?.type === 'tab') {
+      return;
+    }
+    
     setActiveDropTarget(over?.id || null);
   }, []);
 
   const handleDragEnd = useCallback((event: DragEndEvent) => {
     const { over, active } = event;
+    
+    if (active.data.current?.type === 'tab') {
+      return;
+    }
     
     if (over && over.data.current?.onDrop && active.data.current) {
       over.data.current.onDrop([active.data.current]);

--- a/garden/src/features/ugmi/hooks/useTabManager.ts
+++ b/garden/src/features/ugmi/hooks/useTabManager.ts
@@ -1,0 +1,88 @@
+import { useState, useCallback } from "react";
+import { Entity, getEntityId } from "../types";
+
+export interface TabItem {
+    entity: Entity;
+    id: string;
+}
+
+export function useTabManager() {
+    const [openTabs, setOpenTabs] = useState<TabItem[]>([]);
+    const [activeTabId, setActiveTabId] = useState<string | null>(null);
+
+    const openTab = useCallback((entity: Entity) => {
+        const entityId = getEntityId(entity);
+        
+        setOpenTabs(prev => {
+            const existingTab = prev.find(tab => tab.id === entityId);
+            if (existingTab) {
+                setActiveTabId(entityId);
+                return prev;
+            }
+            
+            const newTab: TabItem = { entity, id: entityId };
+            setActiveTabId(entityId);
+            return [...prev, newTab];
+        });
+    }, []);
+
+    const closeTab = useCallback((entityId: string) => {
+        setOpenTabs(prev => {
+            const newTabs = prev.filter(tab => tab.id !== entityId);
+            
+            if (activeTabId === entityId) {
+                if (newTabs.length > 0) {
+                    const closedIndex = prev.findIndex(tab => tab.id === entityId);
+                    const newActiveIndex = closedIndex > 0 ? closedIndex - 1 : 0;
+                    setActiveTabId(newTabs[newActiveIndex]?.id || null);
+                } else {
+                    setActiveTabId(null);
+                }
+            }
+            
+            return newTabs;
+        });
+    }, [activeTabId]);
+
+    const setActiveTab = useCallback((entityId: string) => {
+        setActiveTabId(entityId);
+    }, []);
+
+    const getActiveEntity = useCallback((): Entity | null => {
+        if (!activeTabId) return null;
+        const activeTab = openTabs.find(tab => tab.id === activeTabId);
+        return activeTab?.entity || null;
+    }, [activeTabId, openTabs]);
+
+    const closeAllTabs = useCallback(() => {
+        setOpenTabs([]);
+        setActiveTabId(null);
+    }, []);
+
+    const isTabOpen = useCallback((entity: Entity): boolean => {
+        const entityId = getEntityId(entity);
+        return openTabs.some(tab => tab.id === entityId);
+    }, [openTabs]);
+
+    const reorderTabs = useCallback((newOrder: TabItem[]) => {
+        setOpenTabs(newOrder);
+    }, []);
+
+    return {
+        // State
+        openTabs,
+        activeTabId,
+        hasOpenTabs: openTabs.length > 0,
+        
+        // Actions
+        openTab,
+        closeTab,
+        setActiveTab,
+        closeAllTabs,
+        reorderTabs,
+        
+        // Helpers
+        getActiveEntity,
+        isTabOpen,
+    };
+}


### PR DESCRIPTION
## Deselect Items & Tab Interface - UGMI Update
### Resolves #445 
---
- Edited `UnifiedManagementInterface.tsx` to add tabbed entity management via `useTabManager` and `OpenTabsBar`, update selection and closing handling, and move the `ResizablePanel` wrapper to contain both the tab bar and main content.
- Edited `MainContentPanel.tsx` to remove the `ResizablePanel` wrapper, use a flex container, and refine the empty state check.
- Edited `useDragDrop.ts` to add type guards preventing tab drag events from interfering with item drag-and-drop.
- Created `useTabManager.ts` as a new hook managing tab opening, closing, reordering, and active states.
- Created `OpenTabsBar.tsx` as a new tab bar component with entity-specific icons, close buttons, and drag-and-drop reordering constrained to horizontal movement.
---
### Originally, there was no way to deselect the current item open within the main panel.
<img width="1070" height="360" alt="image" src="https://github.com/user-attachments/assets/4ac7f349-8d34-46af-9448-720c9a5ec9ac" />

---
- Added a tab interface with the main panel, which allows the user to have several items open at a time. 
- Each tab is indicated with an entity-specific icon to indicate to the user what each tab contains at a glance. 
- Additionally, the tabs can be dragged and reordered, and even closed, bringing the user back to the default main panel view.
<img width="1092" height="186" alt="image" src="https://github.com/user-attachments/assets/27626e28-7c2a-46ea-bf7e-38707861f968" />
