### PR TITLE
Add HPC related filters to search page

### DIFF
--- a/garden/src/features/search/components/Filters.tsx
+++ b/garden/src/features/search/components/Filters.tsx
@@ -90,10 +90,17 @@ const SearchFilters = ({
               const buckets = showAllFacets[facet.name]
                 ? facet.values
                 : facet.values.slice(0, 7);
+              const formatFacetName = (name: string) => {
+                // Special case for HPC
+                if (name === "hpc_endpoints") return "HPC Endpoints";
+                // Default: capitalize and replace underscores with spaces
+                return name.split("_").join(" ");
+              };
+
               return (
                 <AccordionItem key={facet.name} value={facet.name}>
                   <AccordionTrigger>
-                    <Label className="capitalize">{facet.name.split("_").join(" ")}</Label>
+                    <Label className="capitalize">{formatFacetName(facet.name)}</Label>
                   </AccordionTrigger>
                   <AccordionContent className="pl-2 max-h-48 overflow-y-auto pr-2">
                       {buckets.map((bucket, index) => (

--- a/garden/src/features/search/components/Filters.tsx
+++ b/garden/src/features/search/components/Filters.tsx
@@ -10,6 +10,12 @@ import { Label } from "@/components/shadcn/label";
 import { Button } from "@/components/shadcn/button";
 import { GardenSearchResult } from "../hooks/useSearchResults";
 import { useState } from "react";
+import {
+  updateFilterValue,
+  updateFunctionTypeFilter as updateFunctionTypeFilterHelper,
+  getDefaultFilterState,
+  formatFacetName,
+} from "../utils/filterUpdateHelpers";
 
 const SearchFilters = ({
   searchResult,
@@ -23,28 +29,19 @@ const SearchFilters = ({
   const [showAllFacets, setShowAllFacets] = useState<Record<string, boolean>>({});
 
   const updateFilter = (facet: string, bucket: string, isChecked: boolean) => {
-    const selected = selectedFilters[facet] || [];
-    const updated = isChecked ? [...selected, bucket] : selected.filter((b: any) => b !== bucket);
-    setSelectedFilters({ ...selectedFilters, [facet]: updated });
+    const updated = updateFilterValue(selectedFilters, facet, bucket, isChecked);
+    setSelectedFilters(updated);
   };
 
   const updateFunctionTypeFilter = (functionType: string, isChecked: boolean) => {
-    const selected = selectedFilters["function_type"] || [];
-
-    // Prevent deselecting if it's the only one selected
-    if (!isChecked && selected.length === 1 && selected.includes(functionType)) {
-      return;
+    const updated = updateFunctionTypeFilterHelper(selectedFilters, functionType, isChecked);
+    if (updated) {
+      setSelectedFilters(updated);
     }
-
-    const updated = isChecked
-      ? [...selected, functionType]
-      : selected.filter((type) => type !== functionType);
-    setSelectedFilters({ ...selectedFilters, function_type: updated });
   };
 
   const clearFilters = () => {
-    // Reset to default state with both function types selected
-    setSelectedFilters({ function_type: ["modal", "hpc"] });
+    setSelectedFilters(getDefaultFilterState());
   };
 
   const facets = searchResult.facets;
@@ -90,12 +87,6 @@ const SearchFilters = ({
               const buckets = showAllFacets[facet.name]
                 ? facet.values
                 : facet.values.slice(0, 7);
-              const formatFacetName = (name: string) => {
-                // Special case for HPC
-                if (name === "hpc_endpoints") return "HPC Endpoints";
-                // Default: capitalize and replace underscores with spaces
-                return name.split("_").join(" ");
-              };
 
               return (
                 <AccordionItem key={facet.name} value={facet.name}>

--- a/garden/src/features/search/components/Filters.tsx
+++ b/garden/src/features/search/components/Filters.tsx
@@ -28,12 +28,26 @@ const SearchFilters = ({
     setSelectedFilters({ ...selectedFilters, [facet]: updated });
   };
 
+  const updateFunctionTypeFilter = (functionType: string, isChecked: boolean) => {
+    const selected = selectedFilters["function_type"] || [];
+
+    // Prevent deselecting if it's the only one selected
+    if (!isChecked && selected.length === 1 && selected.includes(functionType)) {
+      return;
+    }
+
+    const updated = isChecked
+      ? [...selected, functionType]
+      : selected.filter((type) => type !== functionType);
+    setSelectedFilters({ ...selectedFilters, function_type: updated });
+  };
+
   const clearFilters = () => {
-    setSelectedFilters({});
+    // Reset to default state with both function types selected
+    setSelectedFilters({ function_type: ["modal", "hpc"] });
   };
 
   const facets = searchResult.facets;
-  if (!facets.length) return null;
 
   return (
     <div className="sticky top-16 max-h-[80vh] overflow-y-auto rounded-lg border shadow-md bg-white p-4 space-y-4">
@@ -41,7 +55,37 @@ const SearchFilters = ({
             <Filter className="mr-2 h-5 w-5" />
             Filters
           </h3>
-          <Accordion type="multiple" className="px-2" defaultValue={facets.map((f) => f.name)}>
+          <Accordion type="multiple" className="px-2" defaultValue={[...facets.map((f) => f.name), "function_type"]}>
+            {/* Function Type Filter */}
+            <AccordionItem value="function_type">
+              <AccordionTrigger>
+                <Label>Function Type</Label>
+              </AccordionTrigger>
+              <AccordionContent className="pl-2 pr-2">
+                <div className="mb-2 flex items-center gap-2">
+                  <Checkbox
+                    id="function-type-modal"
+                    checked={selectedFilters["function_type"]?.includes("modal") || false}
+                    onCheckedChange={(checked) =>
+                      updateFunctionTypeFilter("modal", checked as boolean)
+                    }
+                  />
+                  <Label htmlFor="function-type-modal">Modal Functions</Label>
+                </div>
+                <div className="mb-2 flex items-center gap-2">
+                  <Checkbox
+                    id="function-type-hpc"
+                    checked={selectedFilters["function_type"]?.includes("hpc") || false}
+                    onCheckedChange={(checked) =>
+                      updateFunctionTypeFilter("hpc", checked as boolean)
+                    }
+                  />
+                  <Label htmlFor="function-type-hpc">HPC Functions</Label>
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+
+            {/* Dynamic Facets from Backend */}
             {facets.map((facet) => {
               const buckets = showAllFacets[facet.name]
                 ? facet.values

--- a/garden/src/features/search/hooks/useSearchResults.ts
+++ b/garden/src/features/search/hooks/useSearchResults.ts
@@ -8,7 +8,7 @@ import {
 import { Garden, GardenSearchRequest } from "@/types";
 
 type SortOrder = "asc" | "desc" | "relevance" | null;
-const filterKeys = ["tags", "model_authors", "gardeners", "year", "function_type"];
+const filterKeys = ["tags", "model_authors", "gardeners", "year", "function_type", "hpc_endpoints"];
 
 interface GardenSearchResult {
   total: number;
@@ -79,32 +79,44 @@ export const useSearchResults = (): SearchResultsState => {
   const gardens: Garden[] = useMemo(() => {
     const allGardens = transformSearchResultToGardens(searchResult);
 
-    // Apply client-side function type filter
-    const functionTypeFilters = selectedFilters["function_type"];
-    if (!functionTypeFilters || functionTypeFilters.length === 0) {
-      return allGardens;
-    }
-
+    // Apply client-side filters
     return allGardens.filter((garden) => {
-      const hasModal = functionTypeFilters.includes("modal");
-      const hasHpc = functionTypeFilters.includes("hpc");
+      // Function type filter
+      const functionTypeFilters = selectedFilters["function_type"];
+      if (functionTypeFilters && functionTypeFilters.length > 0) {
+        const hasModal = functionTypeFilters.includes("modal");
+        const hasHpc = functionTypeFilters.includes("hpc");
 
-      // If both are selected, show gardens with either type
-      if (hasModal && hasHpc) {
-        return (
-          (garden.modal_function_ids && garden.modal_function_ids.length > 0) ||
-          (garden.hpc_function_ids && garden.hpc_function_ids.length > 0)
-        );
+        // If both are selected, show gardens with either type
+        if (hasModal && hasHpc) {
+          const matchesFunctionType =
+            (garden.modal_function_ids && garden.modal_function_ids.length > 0) ||
+            (garden.hpc_function_ids && garden.hpc_function_ids.length > 0);
+          if (!matchesFunctionType) return false;
+        } else if (hasModal) {
+          // Only modal is selected
+          if (!garden.modal_function_ids || garden.modal_function_ids.length === 0) {
+            return false;
+          }
+        } else if (hasHpc) {
+          // Only hpc is selected
+          if (!garden.hpc_function_ids || garden.hpc_function_ids.length === 0) {
+            return false;
+          }
+        }
       }
 
-      // If only modal is selected
-      if (hasModal) {
-        return garden.modal_function_ids && garden.modal_function_ids.length > 0;
-      }
-
-      // If only hpc is selected
-      if (hasHpc) {
-        return garden.hpc_function_ids && garden.hpc_function_ids.length > 0;
+      // HPC endpoints filter
+      const endpointFilters = selectedFilters["hpc_endpoints"];
+      if (endpointFilters && endpointFilters.length > 0 && garden.hpc_functions) {
+        // Check if any HPC function has any of the selected endpoints
+        const hasMatchingEndpoint = garden.hpc_functions.some((hpcFunc) => {
+          if (!hpcFunc.available_endpoints) return false;
+          return hpcFunc.available_endpoints.some((endpoint) =>
+            endpointFilters.includes(endpoint.name)
+          );
+        });
+        if (!hasMatchingEndpoint) return false;
       }
 
       return true;
@@ -184,7 +196,7 @@ export const useSearchResults = (): SearchResultsState => {
       return b.count - a.count;
     };
 
-    return Object.entries(searchResult.facets).map(
+    const backendFacets = Object.entries(searchResult.facets).map(
       ([name, values]: [string, Record<string, number>]) => ({
         name,
         values: Object.entries(values)
@@ -192,7 +204,39 @@ export const useSearchResults = (): SearchResultsState => {
           .sort((a, b) => facetComparator(a, b, name)),
       }),
     );
-  }, [searchResult]);
+
+    // Generate endpoint facet from HPC functions in gardens
+    const endpointCounts: Record<string, number> = {};
+    gardens.forEach((garden) => {
+      if (garden.hpc_functions) {
+        const gardenEndpoints = new Set<string>();
+        garden.hpc_functions.forEach((hpcFunc) => {
+          if (hpcFunc.available_endpoints) {
+            hpcFunc.available_endpoints.forEach((endpoint) => {
+              gardenEndpoints.add(endpoint.name);
+            });
+          }
+        });
+        // Count each endpoint once per garden
+        gardenEndpoints.forEach((endpointName) => {
+          endpointCounts[endpointName] = (endpointCounts[endpointName] || 0) + 1;
+        });
+      }
+    });
+
+    // Add endpoint facet if there are any endpoints
+    if (Object.keys(endpointCounts).length > 0) {
+      const endpointFacet = {
+        name: "hpc_endpoints",
+        values: Object.entries(endpointCounts)
+          .map(([value, count]) => ({ value, count }))
+          .sort((a, b) => facetComparator(a, b, "hpc_endpoints")),
+      };
+      return [...backendFacets, endpointFacet];
+    }
+
+    return backendFacets;
+  }, [searchResult, gardens, selectedFilters]);
 
   return {
     searchResult: {

--- a/garden/src/features/search/hooks/useSearchResults.ts
+++ b/garden/src/features/search/hooks/useSearchResults.ts
@@ -8,7 +8,7 @@ import {
 import { Garden, GardenSearchRequest } from "@/types";
 
 type SortOrder = "asc" | "desc" | "relevance" | null;
-const filterKeys = ["tags", "model_authors", "gardeners", "year"];
+const filterKeys = ["tags", "model_authors", "gardeners", "year", "function_type"];
 
 interface GardenSearchResult {
   total: number;
@@ -60,6 +60,12 @@ export const useSearchResults = (): SearchResultsState => {
         filters[key] = value.split(",");
       }
     });
+
+    // Default to both function types if not specified
+    if (!filters["function_type"]) {
+      filters["function_type"] = ["modal", "hpc"];
+    }
+
     return filters;
   }, [searchParams]);
 
@@ -70,14 +76,44 @@ export const useSearchResults = (): SearchResultsState => {
 
   const { data: searchResult, isLoading, isFetching, isError } = useSearchGardens(searchRequest);
 
-  const gardens: Garden[] = useMemo(
-    () => transformSearchResultToGardens(searchResult),
-    [searchResult],
-  );
+  const gardens: Garden[] = useMemo(() => {
+    const allGardens = transformSearchResultToGardens(searchResult);
+
+    // Apply client-side function type filter
+    const functionTypeFilters = selectedFilters["function_type"];
+    if (!functionTypeFilters || functionTypeFilters.length === 0) {
+      return allGardens;
+    }
+
+    return allGardens.filter((garden) => {
+      const hasModal = functionTypeFilters.includes("modal");
+      const hasHpc = functionTypeFilters.includes("hpc");
+
+      // If both are selected, show gardens with either type
+      if (hasModal && hasHpc) {
+        return (
+          (garden.modal_function_ids && garden.modal_function_ids.length > 0) ||
+          (garden.hpc_function_ids && garden.hpc_function_ids.length > 0)
+        );
+      }
+
+      // If only modal is selected
+      if (hasModal) {
+        return garden.modal_function_ids && garden.modal_function_ids.length > 0;
+      }
+
+      // If only hpc is selected
+      if (hasHpc) {
+        return garden.hpc_function_ids && garden.hpc_function_ids.length > 0;
+      }
+
+      return true;
+    });
+  }, [searchResult, selectedFilters]);
 
   const totalPages: number = useMemo(
-    () => Math.ceil((searchResult?.total || 0) / Number(resultsPerPage)),
-    [searchResult?.total, resultsPerPage],
+    () => Math.ceil(gardens.length / Number(resultsPerPage)),
+    [gardens.length, resultsPerPage],
   );
 
   const updateSearchParams = useCallback(
@@ -160,7 +196,7 @@ export const useSearchResults = (): SearchResultsState => {
 
   return {
     searchResult: {
-      total: searchResult?.total || 0,
+      total: gardens.length,
       hasNextPage: page < totalPages,
       gardens,
       totalPages,

--- a/garden/src/features/search/hooks/useSearchResults.ts
+++ b/garden/src/features/search/hooks/useSearchResults.ts
@@ -6,6 +6,8 @@ import {
   transformSearchResultToGardens,
 } from "@/features/search/api/useSearchGardens";
 import { Garden, GardenSearchRequest } from "@/types";
+import { applyClientSideFilters } from "../utils/filterHelpers";
+import { processFacets, type Facet } from "../utils/facetHelpers";
 
 type SortOrder = "asc" | "desc" | "relevance" | null;
 const filterKeys = ["tags", "model_authors", "gardeners", "year", "function_type", "hpc_endpoints"];
@@ -15,13 +17,7 @@ interface GardenSearchResult {
   hasNextPage: boolean;
   gardens: Garden[];
   totalPages: number;
-  facets: Array<{
-    name: string;
-    values: Array<{
-      value: string;
-      count: number;
-    }>;
-  }>;
+  facets: Facet[];
 }
 
 interface SearchResultsState {
@@ -78,49 +74,7 @@ export const useSearchResults = (): SearchResultsState => {
 
   const gardens: Garden[] = useMemo(() => {
     const allGardens = transformSearchResultToGardens(searchResult);
-
-    // Apply client-side filters
-    return allGardens.filter((garden) => {
-      // Function type filter
-      const functionTypeFilters = selectedFilters["function_type"];
-      if (functionTypeFilters && functionTypeFilters.length > 0) {
-        const hasModal = functionTypeFilters.includes("modal");
-        const hasHpc = functionTypeFilters.includes("hpc");
-
-        // If both are selected, show gardens with either type
-        if (hasModal && hasHpc) {
-          const matchesFunctionType =
-            (garden.modal_function_ids && garden.modal_function_ids.length > 0) ||
-            (garden.hpc_function_ids && garden.hpc_function_ids.length > 0);
-          if (!matchesFunctionType) return false;
-        } else if (hasModal) {
-          // Only modal is selected
-          if (!garden.modal_function_ids || garden.modal_function_ids.length === 0) {
-            return false;
-          }
-        } else if (hasHpc) {
-          // Only hpc is selected
-          if (!garden.hpc_function_ids || garden.hpc_function_ids.length === 0) {
-            return false;
-          }
-        }
-      }
-
-      // HPC endpoints filter
-      const endpointFilters = selectedFilters["hpc_endpoints"];
-      if (endpointFilters && endpointFilters.length > 0 && garden.hpc_functions) {
-        // Check if any HPC function has any of the selected endpoints
-        const hasMatchingEndpoint = garden.hpc_functions.some((hpcFunc) => {
-          if (!hpcFunc.available_endpoints) return false;
-          return hpcFunc.available_endpoints.some((endpoint) =>
-            endpointFilters.includes(endpoint.name)
-          );
-        });
-        if (!hasMatchingEndpoint) return false;
-      }
-
-      return true;
-    });
+    return applyClientSideFilters(allGardens, selectedFilters);
   }, [searchResult, selectedFilters]);
 
   const totalPages: number = useMemo(
@@ -176,66 +130,7 @@ export const useSearchResults = (): SearchResultsState => {
 
   const facets = useMemo(() => {
     if (!searchResult?.facets) return [];
-
-    const facetComparator = (
-      a: { value: string; count: number },
-      b: { value: string; count: number },
-      name: string,
-    ) => {
-      const filterIsAppliedToA = selectedFilters[name]?.includes(a.value);
-      const filterIsAppliedToB = selectedFilters[name]?.includes(b.value);
-
-      // If the filter is applied to A but not B, A should rank higher, and vice versa
-      if (filterIsAppliedToA && !filterIsAppliedToB) {
-        return -1;
-      }
-      if (!filterIsAppliedToA && filterIsAppliedToB) {
-        return 1;
-      }
-      // If the filter is applied to both, the one with the higher count should rank higher
-      return b.count - a.count;
-    };
-
-    const backendFacets = Object.entries(searchResult.facets).map(
-      ([name, values]: [string, Record<string, number>]) => ({
-        name,
-        values: Object.entries(values)
-          .map(([value, count]: [string, number]) => ({ value, count }))
-          .sort((a, b) => facetComparator(a, b, name)),
-      }),
-    );
-
-    // Generate endpoint facet from HPC functions in gardens
-    const endpointCounts: Record<string, number> = {};
-    gardens.forEach((garden) => {
-      if (garden.hpc_functions) {
-        const gardenEndpoints = new Set<string>();
-        garden.hpc_functions.forEach((hpcFunc) => {
-          if (hpcFunc.available_endpoints) {
-            hpcFunc.available_endpoints.forEach((endpoint) => {
-              gardenEndpoints.add(endpoint.name);
-            });
-          }
-        });
-        // Count each endpoint once per garden
-        gardenEndpoints.forEach((endpointName) => {
-          endpointCounts[endpointName] = (endpointCounts[endpointName] || 0) + 1;
-        });
-      }
-    });
-
-    // Add endpoint facet if there are any endpoints
-    if (Object.keys(endpointCounts).length > 0) {
-      const endpointFacet = {
-        name: "hpc_endpoints",
-        values: Object.entries(endpointCounts)
-          .map(([value, count]) => ({ value, count }))
-          .sort((a, b) => facetComparator(a, b, "hpc_endpoints")),
-      };
-      return [...backendFacets, endpointFacet];
-    }
-
-    return backendFacets;
+    return processFacets(searchResult.facets, gardens, selectedFilters);
   }, [searchResult, gardens, selectedFilters]);
 
   return {

--- a/garden/src/features/search/utils/facetHelpers.ts
+++ b/garden/src/features/search/utils/facetHelpers.ts
@@ -1,0 +1,105 @@
+import { Garden } from "@/types";
+
+export interface FacetValue {
+  value: string;
+  count: number;
+}
+
+export interface Facet {
+  name: string;
+  values: FacetValue[];
+}
+
+/**
+ * Comparator for sorting facet values by selection status and count
+ */
+export const createFacetComparator = (
+  selectedFilters: Record<string, string[]>,
+  facetName: string
+) => {
+  return (a: FacetValue, b: FacetValue): number => {
+    const filterIsAppliedToA = selectedFilters[facetName]?.includes(a.value);
+    const filterIsAppliedToB = selectedFilters[facetName]?.includes(b.value);
+
+    // If the filter is applied to A but not B, A should rank higher, and vice versa
+    if (filterIsAppliedToA && !filterIsAppliedToB) {
+      return -1;
+    }
+    if (!filterIsAppliedToA && filterIsAppliedToB) {
+      return 1;
+    }
+    // If the filter is applied to both, the one with the higher count should rank higher
+    return b.count - a.count;
+  };
+};
+
+/**
+ * Generate HPC endpoint facet from gardens
+ */
+export const generateEndpointFacet = (
+  gardens: Garden[],
+  selectedFilters: Record<string, string[]>
+): Facet | null => {
+  const endpointCounts: Record<string, number> = {};
+
+  gardens.forEach((garden) => {
+    if (garden.hpc_functions) {
+      const gardenEndpoints = new Set<string>();
+      garden.hpc_functions.forEach((hpcFunc) => {
+        if (hpcFunc.available_endpoints) {
+          hpcFunc.available_endpoints.forEach((endpoint) => {
+            gardenEndpoints.add(endpoint.name);
+          });
+        }
+      });
+      // Count each endpoint once per garden
+      gardenEndpoints.forEach((endpointName) => {
+        endpointCounts[endpointName] = (endpointCounts[endpointName] || 0) + 1;
+      });
+    }
+  });
+
+  // Return null if there are no endpoints
+  if (Object.keys(endpointCounts).length === 0) {
+    return null;
+  }
+
+  const comparator = createFacetComparator(selectedFilters, "hpc_endpoints");
+
+  return {
+    name: "hpc_endpoints",
+    values: Object.entries(endpointCounts)
+      .map(([value, count]) => ({ value, count }))
+      .sort(comparator),
+  };
+};
+
+/**
+ * Transform backend facets and add client-side facets
+ */
+export const processFacets = (
+  backendFacets: Record<string, Record<string, number>>,
+  gardens: Garden[],
+  selectedFilters: Record<string, string[]>
+): Facet[] => {
+  // Process backend facets
+  const processedBackendFacets = Object.entries(backendFacets).map(
+    ([name, values]: [string, Record<string, number>]) => {
+      const comparator = createFacetComparator(selectedFilters, name);
+      return {
+        name,
+        values: Object.entries(values)
+          .map(([value, count]: [string, number]) => ({ value, count }))
+          .sort(comparator),
+      };
+    }
+  );
+
+  // Generate endpoint facet
+  const endpointFacet = generateEndpointFacet(gardens, selectedFilters);
+
+  // Add endpoint facet if it exists
+  return endpointFacet
+    ? [...processedBackendFacets, endpointFacet]
+    : processedBackendFacets;
+};

--- a/garden/src/features/search/utils/filterHelpers.ts
+++ b/garden/src/features/search/utils/filterHelpers.ts
@@ -1,0 +1,80 @@
+import { Garden } from "@/types";
+
+/**
+ * Check if a garden matches the function type filter criteria
+ */
+export const matchesFunctionTypeFilter = (
+  garden: Garden,
+  functionTypeFilters: string[] | undefined
+): boolean => {
+  if (!functionTypeFilters || functionTypeFilters.length === 0) {
+    return true;
+  }
+
+  const hasModal = functionTypeFilters.includes("modal");
+  const hasHpc = functionTypeFilters.includes("hpc");
+
+  const hasModalFunctions = garden.modal_function_ids && garden.modal_function_ids.length > 0;
+  const hasHpcFunctions = garden.hpc_function_ids && garden.hpc_function_ids.length > 0;
+
+  // If both are selected, show gardens with either type
+  if (hasModal && hasHpc) {
+    return hasModalFunctions || hasHpcFunctions;
+  }
+
+  // If only modal is selected
+  if (hasModal) {
+    return hasModalFunctions;
+  }
+
+  // If only hpc is selected
+  if (hasHpc) {
+    return hasHpcFunctions;
+  }
+
+  return true;
+};
+
+/**
+ * Check if a garden matches the HPC endpoint filter criteria
+ */
+export const matchesEndpointFilter = (
+  garden: Garden,
+  endpointFilters: string[] | undefined
+): boolean => {
+  if (!endpointFilters || endpointFilters.length === 0) {
+    return true;
+  }
+
+  if (!garden.hpc_functions) {
+    return false;
+  }
+
+  // Check if any HPC function has any of the selected endpoints
+  return garden.hpc_functions.some((hpcFunc) => {
+    if (!hpcFunc.available_endpoints) return false;
+    return hpcFunc.available_endpoints.some((endpoint) =>
+      endpointFilters.includes(endpoint.name)
+    );
+  });
+};
+
+/**
+ * Apply all client-side filters to gardens
+ */
+export const applyClientSideFilters = (
+  gardens: Garden[],
+  selectedFilters: Record<string, string[]>
+): Garden[] => {
+  return gardens.filter((garden) => {
+    if (!matchesFunctionTypeFilter(garden, selectedFilters["function_type"])) {
+      return false;
+    }
+
+    if (!matchesEndpointFilter(garden, selectedFilters["hpc_endpoints"])) {
+      return false;
+    }
+
+    return true;
+  });
+};

--- a/garden/src/features/search/utils/filterUpdateHelpers.ts
+++ b/garden/src/features/search/utils/filterUpdateHelpers.ts
@@ -1,0 +1,56 @@
+/**
+ * Update a generic filter by adding or removing a value
+ */
+export const updateFilterValue = (
+  selectedFilters: Record<string, string[]>,
+  filterKey: string,
+  value: string,
+  isChecked: boolean
+): Record<string, string[]> => {
+  const selected = selectedFilters[filterKey] || [];
+  const updated = isChecked
+    ? [...selected, value]
+    : selected.filter((v) => v !== value);
+  return { ...selectedFilters, [filterKey]: updated };
+};
+
+/**
+ * Update function type filter with special logic to prevent deselecting all
+ */
+export const updateFunctionTypeFilter = (
+  selectedFilters: Record<string, string[]>,
+  functionType: string,
+  isChecked: boolean
+): Record<string, string[]> | null => {
+  const selected = selectedFilters["function_type"] || [];
+
+  // Prevent deselecting if it's the only one selected
+  if (!isChecked && selected.length === 1 && selected.includes(functionType)) {
+    return null; // Signal no update should happen
+  }
+
+  const updated = isChecked
+    ? [...selected, functionType]
+    : selected.filter((type) => type !== functionType);
+
+  return { ...selectedFilters, function_type: updated };
+};
+
+/**
+ * Get default filter state (used for clearing filters)
+ */
+export const getDefaultFilterState = (): Record<string, string[]> => {
+  return {
+    function_type: ["modal", "hpc"],
+  };
+};
+
+/**
+ * Format facet name for display
+ */
+export const formatFacetName = (name: string): string => {
+  // Special case for HPC
+  if (name === "hpc_endpoints") return "HPC Endpoints";
+  // Default: capitalize and replace underscores with spaces
+  return name.split("_").join(" ");
+};


### PR DESCRIPTION
Resolves: #465 

This PR add filters to the search page to allow filtering gardens by whether they have HPC functions or not (as well as modal functions), and if any HPC functions are associated with an endpoint, gardens can be filtered by endpoint as well.


https://github.com/user-attachments/assets/21abf2c8-4918-4115-8856-d5f3407991db

All of the new filtering logic lives client-side. I figure in this case it was easier and cleaner to do this on the client since sending a new search request just to filter by function type is a bit overkill when we can easily pull out gardens with hpc or modal functions easily once we get the results of the text search. This does mean I had to add some logic to update the facet counts we get from the backend once the local filtering has been applied, but its not too much work.

## Testing
Manually