### PR TITLE
Tweak HPC function upload form

### DIFF
--- a/garden/src/features/functions/hpc/components/CreateHpcFunctionForm.tsx
+++ b/garden/src/features/functions/hpc/components/CreateHpcFunctionForm.tsx
@@ -177,57 +177,94 @@ export const CreateHpcFunctionForm: React.FC<CreateHpcFunctionFormProps> = ({ on
           <div className="space-y-1">
             <FormLabel>Upload groundhog-hpc Script</FormLabel>
             <FormDescription>Upload a Python file containing @hog.function() decorated functions</FormDescription>
-            <div
-              className={`rounded-lg border-2 border-dashed p-8 text-center transition-colors cursor-pointer ${isDragging
-                ? "border-primary bg-primary/5"
-                : "border-muted-foreground/25 hover:border-primary/50 hover:bg-muted/50"
-                }`}
-              onDragOver={handleDragOver}
-              onDragLeave={handleDragLeave}
-              onDrop={handleDrop}
-              onClick={() => fileInputRef.current?.click()}
-            >
-              <Upload className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
-              <div className="space-y-3">
-                <p className="text-sm font-medium">
-                  Drag and drop your Python file here
-                </p>
-                <div className="flex items-center justify-center gap-2">
-                  <div className="h-px w-16 bg-border" />
-                  <span className="text-xs text-muted-foreground">or</span>
-                  <div className="h-px w-16 bg-border" />
+
+            {!functionCode ? (
+              <div
+                className={`rounded-lg border-2 border-dashed p-8 text-center transition-colors cursor-pointer ${isDragging
+                  ? "border-primary bg-primary/5"
+                  : "border-muted-foreground/25 hover:border-primary/50 hover:bg-muted/50"
+                  }`}
+                onDragOver={handleDragOver}
+                onDragLeave={handleDragLeave}
+                onDrop={handleDrop}
+                onClick={() => fileInputRef.current?.click()}
+              >
+                <Upload className="mx-auto h-12 w-12 text-muted-foreground mb-4" />
+                <div className="space-y-3">
+                  <p className="text-sm font-medium">
+                    Drag and drop your Python file here
+                  </p>
+                  <div className="flex items-center justify-center gap-2">
+                    <div className="h-px w-16 bg-border" />
+                    <span className="text-xs text-muted-foreground">or</span>
+                    <div className="h-px w-16 bg-border" />
+                  </div>
+                  <div>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                    >
+                      Click to Browse
+                    </Button>
+                  </div>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept=".py"
+                    className="hidden"
+                    onChange={async (e) => {
+                      const file = e.target.files?.[0];
+                      if (file) {
+                        await handleFile(file);
+                      }
+                    }}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Supports .py files only
+                  </p>
                 </div>
-                <div>
+              </div>
+            ) : (
+              <Card className="bg-green-50 border-green-200">
+                <CardContent className="flex items-center justify-between p-4">
+                  <div className="flex items-center gap-3">
+                    <div className="flex h-10 w-10 items-center justify-center rounded-full bg-green-100">
+                      <FileCode className="h-5 w-5 text-green-600" />
+                    </div>
+                    <div>
+                      <p className="font-medium text-sm text-green-900">
+                        {uploadedFileName || "Python script loaded"}
+                      </p>
+                      <p className="text-xs text-green-700">
+                        {functionCode.length.toLocaleString()} characters • {parsedFunctions.length} function{parsedFunctions.length !== 1 ? 's' : ''} found
+                      </p>
+                    </div>
+                  </div>
                   <Button
                     type="button"
                     variant="outline"
                     size="sm"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="shrink-0"
                   >
-                    Click to Browse
+                    Change File
                   </Button>
-                </div>
-                <input
-                  ref={fileInputRef}
-                  type="file"
-                  accept=".py"
-                  className="hidden"
-                  onChange={async (e) => {
-                    const file = e.target.files?.[0];
-                    if (file) {
-                      await handleFile(file);
-                    }
-                  }}
-                />
-                <p className="text-xs text-muted-foreground">
-                  Supports .py files only
-                </p>
-              </div>
-              {functionCode && (
-                <div className="mt-4 text-sm text-green-600 font-medium">
-                  ✓ File loaded ({functionCode.length} characters)
-                </div>
-              )}
-            </div>
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept=".py"
+                    className="hidden"
+                    onChange={async (e) => {
+                      const file = e.target.files?.[0];
+                      if (file) {
+                        await handleFile(file);
+                      }
+                    }}
+                  />
+                </CardContent>
+              </Card>
+            )}
           </div>
 
           {/* Endpoint Selection Section */}

--- a/garden/src/features/functions/hpc/components/CreateHpcFunctionForm.tsx
+++ b/garden/src/features/functions/hpc/components/CreateHpcFunctionForm.tsx
@@ -22,6 +22,7 @@ import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/
 import { Textarea } from "@/components/shadcn/textarea";
 import SyntaxHighlighter from "@/components/SyntaxHighlighter";
 import { HpcEndpointSelector } from "./HpcEndpointSelector";
+import MultipleSelector, { Option } from "@/components/shadcn/multiple-select";
 
 const hpcFunctionSchema = z.object({});
 
@@ -32,6 +33,9 @@ interface SelectedFunction {
   title: string;
   description: string;
   selected: boolean;
+  authors: string[];
+  contributors: string[];
+  tags: string[];
 }
 
 interface CreateHpcFunctionFormProps {
@@ -66,6 +70,9 @@ export const CreateHpcFunctionForm: React.FC<CreateHpcFunctionFormProps> = ({ on
           title: functionNameToTitle(fn.name),
           description: "",
           selected: true, // Select all by default
+          authors: [],
+          contributors: [],
+          tags: [],
         }));
         setParsedFunctions(selectedFunctions);
         toast.success(`Loaded ${file.name} - found ${functions.length} function${functions.length > 1 ? 's' : ''}`);
@@ -130,8 +137,8 @@ export const CreateHpcFunctionForm: React.FC<CreateHpcFunctionFormProps> = ({ on
           description: fn.description.trim() || null,
           year: new Date().getFullYear().toString(),
           is_archived: false,
-          authors: [],
-          tags: [],
+          authors: fn.authors,
+          tags: fn.tags,
           test_functions: [],
           requirements: [],
           models: [],
@@ -171,11 +178,10 @@ export const CreateHpcFunctionForm: React.FC<CreateHpcFunctionFormProps> = ({ on
             <FormLabel>Upload groundhog-hpc Script</FormLabel>
             <FormDescription>Upload a Python file containing @hog.function() decorated functions</FormDescription>
             <div
-              className={`rounded-lg border-2 border-dashed p-8 text-center transition-colors cursor-pointer ${
-                isDragging
-                  ? "border-primary bg-primary/5"
-                  : "border-muted-foreground/25 hover:border-primary/50 hover:bg-muted/50"
-              }`}
+              className={`rounded-lg border-2 border-dashed p-8 text-center transition-colors cursor-pointer ${isDragging
+                ? "border-primary bg-primary/5"
+                : "border-muted-foreground/25 hover:border-primary/50 hover:bg-muted/50"
+                }`}
               onDragOver={handleDragOver}
               onDragLeave={handleDragLeave}
               onDrop={handleDrop}
@@ -290,7 +296,7 @@ export const CreateHpcFunctionForm: React.FC<CreateHpcFunctionFormProps> = ({ on
                           )}
                         </div>
                       </AccordionTrigger>
-                      <AccordionContent className="space-y-4 px-4 pt-4">
+                      <AccordionContent className="space-y-6 px-4 pt-4">
                         <div className="space-y-1">
                           <label className="text-sm font-medium">Function Name</label>
                           <code className="block rounded bg-muted px-3 py-2 text-sm font-mono">
@@ -331,6 +337,57 @@ export const CreateHpcFunctionForm: React.FC<CreateHpcFunctionFormProps> = ({ on
                           />
                           <p className="text-xs text-muted-foreground">
                             Explain what your function does and how it should be used
+                          </p>
+                        </div>
+
+                        <div className="space-y-1">
+                          <label className="text-sm font-medium">Model Authors</label>
+                          <MultipleSelector
+                            value={fn.authors.map(a => ({ value: a, label: a }))}
+                            onChange={(options: Option[]) => {
+                              const updated = [...parsedFunctions];
+                              updated[index].authors = options.map(o => o.value);
+                              setParsedFunctions(updated);
+                            }}
+                            placeholder="Add Model Authors"
+                            creatable
+                          />
+                          <p className="text-xs text-muted-foreground">
+                            The main researchers involved in producing this model
+                          </p>
+                        </div>
+
+                        <div className="space-y-1">
+                          <label className="text-sm font-medium">Gardeners (Contributors)</label>
+                          <MultipleSelector
+                            value={fn.contributors.map(c => ({ value: c, label: c }))}
+                            onChange={(options: Option[]) => {
+                              const updated = [...parsedFunctions];
+                              updated[index].contributors = options.map(o => o.value);
+                              setParsedFunctions(updated);
+                            }}
+                            placeholder="Add Gardeners"
+                            creatable
+                          />
+                          <p className="text-xs text-muted-foreground">
+                            Acknowledge contributors to the development of this function
+                          </p>
+                        </div>
+
+                        <div className="space-y-1">
+                          <label className="text-sm font-medium">Tags</label>
+                          <MultipleSelector
+                            value={fn.tags.map(t => ({ value: t, label: t }))}
+                            onChange={(options: Option[]) => {
+                              const updated = [...parsedFunctions];
+                              updated[index].tags = options.map(o => o.value);
+                              setParsedFunctions(updated);
+                            }}
+                            placeholder="Add tags"
+                            creatable
+                          />
+                          <p className="text-xs text-muted-foreground">
+                            Tags help users discover your function
                           </p>
                         </div>
                       </AccordionContent>


### PR DESCRIPTION
Resolves: #467
Resolves: #464 

This PR adds the missing metadata fields for hpc functions in the upload form that we have for modal functions: authors, gardens, and tags. Included is a tweak to the UX where after uploading a file, the upload section still dominated the page and it was not super obvious that there were options to add metadata to the parsed functions unless the user scrolled down a bit. Now the upload section collapses bringing the metadata editing to the attention of the user.


https://github.com/user-attachments/assets/1522e36e-66f4-4484-98e7-4d9a9554376c


## Testing
Manually