### PR TITLE
Update schemas and components for new search specific types

### DIFF
--- a/garden/src/features/gardens/api/useGetGardens.ts
+++ b/garden/src/features/gardens/api/useGetGardens.ts
@@ -18,29 +18,27 @@ const getGardens = async (params: GetGardensParams): Promise<Garden[]> => {
   try {
     const response = await axios.get(`/gardens`, { params });
     return response.data;
-  } catch (error) {
-    throw new Error("Error fetching garden by DOI");
+  } catch {
+    throw new Error("Error fetching gardens");
   }
 };
 
-export const useGetGardens = (params: GetGardensParams) => {
+export const useGetGardens = (params: GetGardensParams, options?: { enabled?: boolean }) => {
   const queryClient = useQueryClient();
   const query = useQuery<Garden[], Error>({
     queryKey: ["gardens", params],
     queryFn: () => getGardens(params),
+    enabled: options?.enabled !== false, // Default to true unless explicitly set to false
   });
 
-  // Cache gardens and modal functions when gardens are successfully fetched
+  // Cache gardens when they are successfully fetched
   React.useEffect(() => {
     if (query.data) {
       query.data.forEach((garden) => {
         queryClient.setQueryData(["gardens", garden.doi], garden);
-        // gardens currently contain their associated function metadata,
-        // cache them so we can avoid sending requests for functions
-        // we have already seen.
-        garden.modal_functions?.forEach((fn) => {
-          queryClient.setQueryData(["modalFunctions", fn.id], fn);
-        });
+        // NOTE: We do NOT cache modal_functions here because garden search results
+        // contain ModalFunctionSearchResult which lacks function_text, file_contents, etc.
+        // Components should fetch full metadata via useGetModalFunction when needed.
       });
     }
   }, [query.data, queryClient]);

--- a/garden/src/features/search/api/useSearchGardens.ts
+++ b/garden/src/features/search/api/useSearchGardens.ts
@@ -29,18 +29,6 @@ export const useSearchGardens = (searchOptions: GardenSearchRequest, options?: {
     enabled: options?.enabled,
   });
 
-  // Cache gardens and modal functions when search results are successfully fetched
-  React.useEffect(() => {
-    if (query.data?.garden_meta) {
-      query.data.garden_meta.forEach((garden) => {
-        queryClient.setQueryData(["gardens", garden.doi], garden);
-        garden.modal_functions?.forEach((fn) => {
-          queryClient.setQueryData(["modalFunctions", fn.id], fn);
-        });
-      });
-    }
-  }, [query.data, queryClient]);
-
   return query;
 };
 

--- a/garden/src/features/search/api/useSearchGardens.ts
+++ b/garden/src/features/search/api/useSearchGardens.ts
@@ -1,6 +1,6 @@
 import React from "react";
 import { keepPreviousData, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Garden, GardenSearchFilter, GardenSearchRequest, GardenSearchResponse } from "@/types";
+import { Garden, GardenSearchFilter, GardenSearchRequest, GardenSearchResponse, GardenSearchMetadataResponse } from "@/types";
 import axios from "@/lib/axios";
 
 const searchGardens = async (searchOptions: GardenSearchRequest): Promise<GardenSearchResponse> => {
@@ -33,7 +33,7 @@ export const useSearchGardens = (searchOptions: GardenSearchRequest, options?: {
 };
 
 export const transformSearchResultToGardens = (searchResult?: GardenSearchResponse): Garden[] => {
-  return searchResult?.garden_meta || [];
+  return (searchResult?.garden_meta || []) as Garden[];
 };
 
 export const transformSearchParamsToSearchRequest = (searchParams: URLSearchParams): any => {

--- a/garden/src/features/ugmi/components/BaseGardenPanel.tsx
+++ b/garden/src/features/ugmi/components/BaseGardenPanel.tsx
@@ -100,7 +100,7 @@ export const BaseGardenPanel: React.FC<BaseGardenPanelProps> = ({
       />
 
       <div className="flex-1 overflow-hidden">
-        <div className="flex-1 space-y-1 overflow-y-auto p-2">
+        <div className="h-full space-y-1 overflow-y-auto p-2">
           {isLoading ? (
             <div className="flex h-full items-center justify-center">
               <div className="text-sm text-gray-500">Loading...</div>

--- a/garden/src/features/ugmi/components/FunctionTreeNode.tsx
+++ b/garden/src/features/ugmi/components/FunctionTreeNode.tsx
@@ -37,10 +37,11 @@ const FunctionDisplay: React.FC<{
       : "group flex items-center rounded-md border border-transparent transition-all duration-150 hover:border-blue-200 hover:bg-blue-50 hover:shadow-sm";
   }
 
-  // Get display name - HPC functions use title, Modal functions use function_name
+  // Get display name - use title for all functions (search results don't include function_name)
+  // Full metadata will have function_name, but search results only have title
   const displayName = isHpc
-    ? (fn as HpcFunction).title || fn.function_name
-    : (fn as ModalFunction).function_name;
+    ? (fn as HpcFunction).title || (fn as HpcFunction).function_name
+    : (fn as ModalFunction).title;
 
   return (
     <div

--- a/garden/src/features/ugmi/components/LeftSidePanel.tsx
+++ b/garden/src/features/ugmi/components/LeftSidePanel.tsx
@@ -36,6 +36,8 @@ export const LeftSidePanel = ({ onItemSelected, selectedItem, selection, onDeplo
     refetch: refetchGardens
   } = useGetGardens({
     owner_uuid: userInfo?.identity_id,
+  }, {
+    enabled: !!userInfo?.identity_id,
   });
 
   const savedGardenDois = userInfo?.saved_garden_dois || [];

--- a/garden/src/features/ugmi/components/LeftSidePanel.tsx
+++ b/garden/src/features/ugmi/components/LeftSidePanel.tsx
@@ -51,7 +51,7 @@ export const LeftSidePanel = ({ onItemSelected, selectedItem, selection, onDeplo
   const panelRefs = createPanelRefs(['savedGardensPanelRef', 'myGardensPanelRef', 'functionLibraryPanelRef'] as const);
   const { handlePanelExpand } = usePanelExpansion(panelRefs);
 
-  const savedGardens = savedGardensResponse?.garden_meta || [];
+  const savedGardens = (savedGardensResponse?.garden_meta || []) as Garden[];
 
   const handleGardenCreated = () => {
     refetchGardens();

--- a/garden/src/features/ugmi/components/MainContentPanel.tsx
+++ b/garden/src/features/ugmi/components/MainContentPanel.tsx
@@ -25,7 +25,7 @@ export const MainContentPanel = ({ entity, onAfterDelete }: MainContentPanelProp
       isSuperUser);
 
   return (
-    <div className="flex flex-col flex-1 bg-white">
+    <div className="flex flex-col flex-1 bg-white overflow-hidden">
       {entityType === null || entity === null ? (
         <div className="flex h-full items-center justify-center">
           <div className="space-y-2 text-center">
@@ -35,7 +35,7 @@ export const MainContentPanel = ({ entity, onAfterDelete }: MainContentPanelProp
           </div>
         </div>
       ) : (
-        <div className="scrollbar-thin scrollbar-track-transparent h-full overflow-y-auto">
+        <div className="scrollbar-thin scrollbar-track-transparent flex-1 overflow-y-auto">
           {entityType === "modal-function" ? (
             <UnifiedFunctionContent
               modalFunction={entity as ModalFunction}

--- a/garden/src/features/ugmi/components/MyFunctionLibraryView.tsx
+++ b/garden/src/features/ugmi/components/MyFunctionLibraryView.tsx
@@ -166,7 +166,7 @@ export const MyFunctionLibraryView = ({
       />
 
       {/* Content */}
-      <div className="flex-1 space-y-1 overflow-y-auto p-2">
+      <div className="h-[calc(100%-4rem)] space-y-1 overflow-y-auto p-2">
         {isLoading ? (
           <div className="flex h-full items-center justify-center">
             <div className="text-sm text-gray-500">Loading...</div>

--- a/garden/src/features/ugmi/components/OpenTabsBar.tsx
+++ b/garden/src/features/ugmi/components/OpenTabsBar.tsx
@@ -52,7 +52,7 @@ const getEntityName = (entity: Entity): string => {
     if (type === "garden") {
         return (entity as Garden).title || "Untitled Garden";
     } else if (type === "modal-function" || type === "hpc-function") {
-        return (entity as ModalFunction).function_name || "Untitled Function";
+        return (entity as ModalFunction).function_name || (entity as ModalFunction).title || "Untitled Function";
     } else if (type === "deployment") {
         return (entity as ModelDeployment).name || "Untitled Deployment";
     }

--- a/garden/src/features/ugmi/components/UnifiedFunctionContent.tsx
+++ b/garden/src/features/ugmi/components/UnifiedFunctionContent.tsx
@@ -7,6 +7,7 @@ import { FunctionExample } from "../../functions/shared/components/FunctionExamp
 import AssociatedMaterials from "../../functions/shared/components/AssociatedMaterials";
 import { ModalFunction } from "@/types";
 import { GardenFunction } from "../../functions/shared/types/function.types";
+import LoadingSpinner from "@/components/LoadingSpinner";
 
 type UnifiedFunctionContentProps = {
     modalFunction: ModalFunction;
@@ -17,23 +18,34 @@ export const UnifiedFunctionContent = ({
     modalFunction,
     ownsThisFunction,
 }: UnifiedFunctionContentProps) => {
-    // Fetch fresh modal function data to ensure updates are reflected
-    const { data: freshModalFunction } = useGetModalFunction(modalFunction.id.toString());
+    // Fetch full modal function metadata (search results are incomplete)
+    const { data: freshModalFunction, isLoading } = useGetModalFunction(modalFunction.id.toString());
     const { mutateAsync: patchModalFunction } = usePatchModalFunction();
 
-    const currentModalFunction = freshModalFunction || modalFunction;
+    // Define callback before early return to avoid hook order issues
+    const handleUpdate = useCallback(async (updateData: Partial<ModalFunction>) => {
+        if (!freshModalFunction) return;
+        await patchModalFunction({
+            id: freshModalFunction.id,
+            modalFunction: updateData
+        });
+    }, [patchModalFunction, freshModalFunction]);
+
+    // Wait for full metadata before rendering
+    if (isLoading || !freshModalFunction) {
+        return (
+            <div className="flex h-full items-center justify-center">
+                <LoadingSpinner />
+            </div>
+        );
+    }
+
+    const currentModalFunction = freshModalFunction;
 
     const gardenFunction: GardenFunction = {
         ...currentModalFunction,
         functionType: 'modal',
     };
-
-    const handleUpdate = useCallback(async (updateData: Partial<ModalFunction>) => {
-        await patchModalFunction({
-            id: currentModalFunction.id,
-            modalFunction: updateData
-        });
-    }, [patchModalFunction, currentModalFunction.id]);
 
     const generateDefaultExample = (functionName: string) => {
         return `from garden_ai import GardenClient

--- a/garden/src/types/backend-schema.ts
+++ b/garden/src/types/backend-schema.ts
@@ -780,8 +780,6 @@ export interface components {
              * @default false
              */
             is_archived: boolean;
-            /** Function Text */
-            function_text: string;
             /** Title */
             title: string;
             /** Description */
@@ -806,6 +804,8 @@ export interface components {
             datasets?: components["schemas"]["_DatasetMetadata"][];
             /** Notebooks */
             notebooks?: components["schemas"]["_NotebookMetadata"][];
+            /** Function Text */
+            function_text: string;
             /** Doi */
             doi: string;
             /** Doi Is Draft */
@@ -841,8 +841,6 @@ export interface components {
              * @default false
              */
             is_archived: boolean;
-            /** Function Text */
-            function_text: string;
             /** Title */
             title: string;
             /** Description */
@@ -867,6 +865,8 @@ export interface components {
             datasets?: components["schemas"]["_DatasetMetadata"][];
             /** Notebooks */
             notebooks?: components["schemas"]["_NotebookMetadata"][];
+            /** Function Text */
+            function_text: string;
             /** Doi */
             doi: string;
             /** Doi Is Draft */
@@ -1145,6 +1145,76 @@ export interface components {
              */
             operation: ("AND" | "OR") | null;
         };
+        /** GardenSearchMetadataResponse */
+        GardenSearchMetadataResponse: {
+            /** Title */
+            title: string;
+            /** Authors */
+            authors?: string[];
+            /** Contributors */
+            contributors?: string[];
+            /** Doi */
+            doi: string;
+            /**
+             * Doi Is Draft
+             * @default true
+             */
+            doi_is_draft: boolean;
+            /** Description */
+            description: string | null;
+            /**
+             * Publisher
+             * @default Garden-AI
+             */
+            publisher: string;
+            /** Year */
+            year?: string;
+            /**
+             * Language
+             * @default en
+             */
+            language: string;
+            /** Tags */
+            tags?: string[];
+            /**
+             * Version
+             * @default 0.0.1
+             */
+            version: string;
+            /** Entrypoint Aliases */
+            entrypoint_aliases?: {
+                [key: string]: string;
+            };
+            /**
+             * Is Archived
+             * @default false
+             */
+            is_archived: boolean;
+            /** Owner */
+            owner: string;
+            /**
+             * Owner Identity Id
+             * Format: uuid
+             */
+            owner_identity_id: string;
+            /** Id */
+            id: number;
+            /** Entrypoints */
+            entrypoints?: components["schemas"]["EntrypointMetadataResponse"][];
+            /** Modal Functions */
+            modal_functions?: components["schemas"]["ModalFunctionSearchResult"][];
+            /** Hpc Functions */
+            hpc_functions?: components["schemas"]["HpcFunctionSearchResult"][];
+            /** Marked For Deletion */
+            marked_for_deletion: string | null;
+            readonly state: components["schemas"]["GardenState"];
+            /** Entrypoint Ids */
+            readonly entrypoint_ids: string[];
+            /** Modal Function Ids */
+            readonly modal_function_ids: number[];
+            /** Hpc Function Ids */
+            readonly hpc_function_ids: number[];
+        };
         /** GardenSearchRequest */
         GardenSearchRequest: {
             /** Q */
@@ -1173,7 +1243,7 @@ export interface components {
             /** Offset */
             offset: number;
             /** Garden Meta */
-            garden_meta: components["schemas"]["GardenMetadataResponse"][];
+            garden_meta: components["schemas"]["GardenSearchMetadataResponse"][];
             facets: components["schemas"]["GardenSearchFacets"];
         };
         /** GardenSearchSort */
@@ -1234,8 +1304,6 @@ export interface components {
              * @default false
              */
             is_archived: boolean;
-            /** Function Text */
-            function_text: string;
             /** Title */
             title: string;
             /** Description */
@@ -1260,6 +1328,8 @@ export interface components {
             datasets?: components["schemas"]["_DatasetMetadata"][];
             /** Notebooks */
             notebooks?: components["schemas"]["_NotebookMetadata"][];
+            /** Function Text */
+            function_text: string;
             /** Function Name */
             function_name: string;
             /** Endpoint Ids */
@@ -1272,8 +1342,6 @@ export interface components {
              * @default false
              */
             is_archived: boolean;
-            /** Function Text */
-            function_text: string;
             /** Title */
             title: string;
             /** Description */
@@ -1298,6 +1366,8 @@ export interface components {
             datasets?: components["schemas"]["_DatasetMetadata"][];
             /** Notebooks */
             notebooks?: components["schemas"]["_NotebookMetadata"][];
+            /** Function Text */
+            function_text: string;
             /** Id */
             id: number;
             /** Function Name */
@@ -1346,6 +1416,49 @@ export interface components {
             function_name?: string | null;
             /** Endpoint Ids */
             endpoint_ids?: number[] | null;
+        };
+        /** HpcFunctionSearchResult */
+        HpcFunctionSearchResult: {
+            /**
+             * Is Archived
+             * @default false
+             */
+            is_archived: boolean;
+            /** Title */
+            title: string;
+            /** Description */
+            description: string | null;
+            /** Year */
+            year: string;
+            /** Authors */
+            authors?: string[];
+            /** Tags */
+            tags?: string[];
+            /** Test Functions */
+            test_functions?: string[];
+            /** Requirements */
+            requirements?: string[];
+            /** Models */
+            models?: components["schemas"]["_ModelMetadata"][];
+            /** Repositories */
+            repositories?: components["schemas"]["_RepositoryMetadata"][];
+            /** Papers */
+            papers?: components["schemas"]["_PaperMetadata"][];
+            /** Datasets */
+            datasets?: components["schemas"]["_DatasetMetadata"][];
+            /** Notebooks */
+            notebooks?: components["schemas"]["_NotebookMetadata"][];
+            /** Id */
+            id: number;
+            /** Function Name */
+            function_name: string;
+            /** Available Endpoints */
+            available_endpoints?: components["schemas"]["HpcEndpointInfo"][];
+            /**
+             * Num Invocations
+             * @default 0
+             */
+            num_invocations: number;
         };
         /** HpcInvocationCreateRequest */
         HpcInvocationCreateRequest: {
@@ -1485,8 +1598,6 @@ export interface components {
              * @default false
              */
             is_archived: boolean;
-            /** Function Text */
-            function_text: string;
             /** Title */
             title: string;
             /** Description */
@@ -1511,10 +1622,10 @@ export interface components {
             datasets?: components["schemas"]["_DatasetMetadata"][];
             /** Notebooks */
             notebooks?: components["schemas"]["_NotebookMetadata"][];
+            /** Function Text */
+            function_text: string;
             /** Function Name */
             function_name: string;
-            /** File Contents */
-            file_contents?: string | null;
             /** Doi */
             doi?: string | null;
             /** Conda Requirements */
@@ -1524,6 +1635,8 @@ export interface components {
              * @default
              */
             example_usage: string;
+            /** File Contents */
+            file_contents?: string | null;
         };
         /** ModalFunctionMetadataResponse */
         ModalFunctionMetadataResponse: {
@@ -1532,8 +1645,6 @@ export interface components {
              * @default false
              */
             is_archived: boolean;
-            /** Function Text */
-            function_text: string;
             /** Title */
             title: string;
             /** Description */
@@ -1558,10 +1669,10 @@ export interface components {
             datasets?: components["schemas"]["_DatasetMetadata"][];
             /** Notebooks */
             notebooks?: components["schemas"]["_NotebookMetadata"][];
+            /** Function Text */
+            function_text: string;
             /** Function Name */
             function_name: string;
-            /** File Contents */
-            file_contents?: string | null;
             /** Doi */
             doi?: string | null;
             /** Conda Requirements */
@@ -1571,6 +1682,8 @@ export interface components {
              * @default
              */
             example_usage: string;
+            /** File Contents */
+            file_contents?: string | null;
             /**
              * Id
              * @description The unique identifier for the modal function
@@ -1634,6 +1747,64 @@ export interface components {
             doi?: string | null;
             /** Function Name */
             function_name?: string | null;
+        };
+        /** ModalFunctionSearchResult */
+        ModalFunctionSearchResult: {
+            /**
+             * Is Archived
+             * @default false
+             */
+            is_archived: boolean;
+            /** Title */
+            title: string;
+            /** Description */
+            description: string | null;
+            /** Year */
+            year: string;
+            /** Authors */
+            authors?: string[];
+            /** Tags */
+            tags?: string[];
+            /** Test Functions */
+            test_functions?: string[];
+            /** Requirements */
+            requirements?: string[];
+            /** Models */
+            models?: components["schemas"]["_ModelMetadata"][];
+            /** Repositories */
+            repositories?: components["schemas"]["_RepositoryMetadata"][];
+            /** Papers */
+            papers?: components["schemas"]["_PaperMetadata"][];
+            /** Datasets */
+            datasets?: components["schemas"]["_DatasetMetadata"][];
+            /** Notebooks */
+            notebooks?: components["schemas"]["_NotebookMetadata"][];
+            /**
+             * Id
+             * @description The unique identifier for the modal function
+             */
+            id: number;
+            /** Modal App Id */
+            modal_app_id: number;
+            /**
+             * Owner
+             * @default
+             */
+            owner: string;
+            /**
+             * Owner Identity Id
+             * Format: uuid
+             */
+            owner_identity_id: string;
+            /** Hardware Spec */
+            hardware_spec: {
+                [key: string]: unknown;
+            };
+            /**
+             * Num Invocations
+             * @description The number of times this function has been invoked
+             */
+            num_invocations?: number;
         };
         /** ModalInvocationOutputsResponse */
         ModalInvocationOutputsResponse: {

--- a/garden/src/types/backend-schema.ts
+++ b/garden/src/types/backend-schema.ts
@@ -2333,7 +2333,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["GardenMetadataResponse"][];
+                    "application/json": components["schemas"]["GardenSearchMetadataResponse"][];
                 };
             };
             /** @description Validation Error */

--- a/garden/src/types/index.ts
+++ b/garden/src/types/index.ts
@@ -54,6 +54,7 @@ type GardenSearchFacets = components["schemas"]["GardenSearchFacets"];
 type GardenSearchFilter = Omit<components["schemas"]["GardenSearchFilter"], 'operation'> & {
   operation?: components["schemas"]["GardenSearchFilter"]['operation'];
 };
+type GardenSearchMetadataResponse = components["schemas"]["GardenSearchMetadataResponse"];
 
 type BenchmarkRequest = components["schemas"]["BenchmarkRequest"];
 
@@ -99,6 +100,7 @@ export type {
   GardenSearchResponse,
   GardenSearchFacets,
   GardenSearchFilter,
+  GardenSearchMetadataResponse,
   AsyncModalAppMetadataResponse,
   AsyncModalJobStatus,
   ModalFileMetadataRequest,


### PR DESCRIPTION
This PR updates the relevant components in the search page and UGMI to work with the new search-specific schemas in https://github.com/Garden-AI/garden-backend/pull/377.

This means we have to send requests to pull the full function metadata when rendering the detail pages instead of pre-caching then when we fetch gardens.

## Testing
Manually