### PR TITLE
Update hpc upload form to handle @hog.methods

### DIFF
--- a/garden/src/features/functions/hpc/components/CreateHpcFunctionForm.tsx
+++ b/garden/src/features/functions/hpc/components/CreateHpcFunctionForm.tsx
@@ -61,7 +61,7 @@ export const CreateHpcFunctionForm: React.FC<CreateHpcFunctionFormProps> = ({ on
       const functions = parseHpcFunctions(text);
 
       if (functions.length === 0) {
-        toast.warning(`Loaded ${file.name}, but no @hog.function() decorated functions found`);
+        toast.warning(`Loaded ${file.name}, but no @hog.function() or @hog.method() decorated functions found`);
         setParsedFunctions([]);
       } else {
         // Create SelectedFunction objects with auto-generated titles
@@ -176,7 +176,7 @@ export const CreateHpcFunctionForm: React.FC<CreateHpcFunctionFormProps> = ({ on
         <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
           <div className="space-y-1">
             <FormLabel>Upload groundhog-hpc Script</FormLabel>
-            <FormDescription>Upload a Python file containing @hog.function() decorated functions</FormDescription>
+            <FormDescription>Upload a Python file containing @hog.function() or @hog.method() decorated functions</FormDescription>
 
             {!functionCode ? (
               <div
@@ -307,7 +307,7 @@ export const CreateHpcFunctionForm: React.FC<CreateHpcFunctionFormProps> = ({ on
               <div className="border-b bg-gray-50 p-4">
                 <h3 className="text-lg font-semibold">Edit Function Details</h3>
                 <p className="text-sm text-gray-600">
-                  Found {parsedFunctions.length} @hog.function() decorated function{parsedFunctions.length > 1 ? 's' : ''}.
+                  Found {parsedFunctions.length} @hog.function() or @hog.method() decorated function{parsedFunctions.length > 1 ? 's' : ''}.
                   Select and customize the functions you want to create.
                 </p>
               </div>

--- a/garden/src/features/functions/hpc/utils/parseHpcFunctions.ts
+++ b/garden/src/features/functions/hpc/utils/parseHpcFunctions.ts
@@ -1,6 +1,6 @@
 /**
  * Parses groundhog-hpc function names from Python code.
- * Looks for functions decorated with @hog.function()
+ * Looks for functions decorated with @hog.function() or @hog.method()
  */
 
 export interface ParsedHpcFunction {
@@ -9,7 +9,7 @@ export interface ParsedHpcFunction {
 }
 
 /**
- * Extracts all function names decorated with @hog.function() from Python code
+ * Extracts all function names decorated with @hog.function() or @hog.method() from Python code
  * @param code - The Python source code to parse
  * @returns Array of parsed function information
  */
@@ -19,12 +19,16 @@ export function parseHpcFunctions(code: string): ParsedHpcFunction[] {
 
   // Pattern to match function name from def statement
   const functionPattern = /def\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/;
+  // Pattern to match class name
+  const classPattern = /class\s+([a-zA-Z_][a-zA-Z0-9_]*)/;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
 
-    // Check if this line has a @hog.function decorator
-    if (line.includes('@hog.function')) {
+    // Check if this line has a @hog.function or @hog.method decorator
+    if (line.includes('@hog.function') || line.includes('@hog.method')) {
+      const isMethod = line.includes('@hog.method');
+
       // Move forward until we find a line starting with 'def'
       for (let j = i + 1; j < lines.length; j++) {
         const nextLine = lines[j];
@@ -32,8 +36,31 @@ export function parseHpcFunctions(code: string): ParsedHpcFunction[] {
         if (nextLine.trim().startsWith('def')) {
           const match = nextLine.match(functionPattern);
           if (match) {
+            let functionName = match[1];
+
+            // If it's a method, try to find the class
+            if (isMethod) {
+              const defIndentation = nextLine.search(/\S/);
+
+              // Search backwards for the class definition
+              for (let k = j - 1; k >= 0; k--) {
+                const prevLine = lines[k];
+                const prevLineTrimmed = prevLine.trim();
+                const prevIndentation = prevLine.search(/\S/);
+
+                // Found a class definition with less indentation
+                if (prevLineTrimmed.startsWith('class') && prevIndentation < defIndentation && prevIndentation !== -1) {
+                  const classMatch = prevLineTrimmed.match(classPattern);
+                  if (classMatch) {
+                    functionName = `${classMatch[1]}.${functionName}`;
+                    break;
+                  }
+                }
+              }
+            }
+
             functions.push({
-              name: match[1],
+              name: functionName,
               lineNumber: j + 1, // +1 for 1-based line numbers
             });
           }
@@ -47,7 +74,7 @@ export function parseHpcFunctions(code: string): ParsedHpcFunction[] {
 }
 
 /**
- * Validates that the code contains at least one @hog.function() decorated function
+ * Validates that the code contains at least one @hog.function() or @hog.method() decorated function
  * @param code - The Python source code to validate
  * @returns True if at least one HPC function is found
  */
@@ -58,8 +85,15 @@ export function hasHpcFunctions(code: string): boolean {
 /**
  * Converts a snake_case function name to a more readable title
  * e.g., "say_hello" -> "Say Hello"
+ * e.g., "Statistics.compute_mean" -> "Statistics: Compute Mean"
  */
 export function functionNameToTitle(name: string): string {
+  // Handle namespaced methods from @hog.method
+  if (name.includes('.')) {
+    const [className, methodName] = name.split('.');
+    return `${className}: ${functionNameToTitle(methodName)}`;
+  }
+
   return name
     .split('_')
     .map(word => word.charAt(0).toUpperCase() + word.slice(1))

--- a/garden/tests/features/functions/hpc/utils/parseHpcFunctions.test.ts
+++ b/garden/tests/features/functions/hpc/utils/parseHpcFunctions.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { parseHpcFunctions, hasHpcFunctions, functionNameToTitle } from '@/features/functions/hpc/utils/parseHpcFunctions';
+
+describe('parseHpcFunctions', () => {
+  it('should parse @hog.function decorators', () => {
+    const code = `
+@hog.function()
+def my_func():
+    pass
+    `;
+    const result = parseHpcFunctions(code);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ name: 'my_func', lineNumber: 3 });
+  });
+
+  it('should parse @hog.method decorators', () => {
+    const code = `
+class MyStats:
+    @hog.method(endpoint="anvil")
+    def compute_mean(numbers):
+        return sum(numbers) / len(numbers)
+    `;
+    const result = parseHpcFunctions(code);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ name: 'MyStats.compute_mean', lineNumber: 4 });
+  });
+
+  it('should namespace @hog.method functions with their class name', () => {
+    const code = `
+class Statistics:
+    @hog.method()
+    def compute_mean(numbers):
+        pass
+    `;
+    const result = parseHpcFunctions(code);
+    expect(result[0].name).toBe('Statistics.compute_mean');
+  });
+
+  it('should parse multiple decorators in the same file', () => {
+    const code = `
+@hog.function()
+def func1():
+    pass
+
+class MyClass:
+    @hog.method()
+    def method1():
+        pass
+    `;
+    const result = parseHpcFunctions(code);
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe('func1');
+    expect(result[1].name).toBe('MyClass.method1');
+  });
+
+  it('should return an empty array if no decorators are present', () => {
+    const code = `
+def regular_func():
+    pass
+    `;
+    const result = parseHpcFunctions(code);
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe('hasHpcFunctions', () => {
+  it('should return true if @hog.function is present', () => {
+    const code = '@hog.function()\ndef f(): pass';
+    expect(hasHpcFunctions(code)).toBe(true);
+  });
+
+  it('should return true if @hog.method is present', () => {
+    const code = '@hog.method()\ndef f(): pass';
+    expect(hasHpcFunctions(code)).toBe(true);
+  });
+
+  it('should return false if no HPC decorators are present', () => {
+    const code = 'def f(): pass';
+    expect(hasHpcFunctions(code)).toBe(false);
+  });
+});
+
+describe('functionNameToTitle', () => {
+  it('should convert snake_case to Title Case', () => {
+    expect(functionNameToTitle('my_function_name')).toBe('My Function Name');
+    expect(functionNameToTitle('hello')).toBe('Hello');
+  });
+
+  it('should handle namespaced names from @hog.method', () => {
+    expect(functionNameToTitle('Statistics.compute_mean')).toBe('Statistics: Compute Mean');
+  });
+});


### PR DESCRIPTION
Resolves: #477 

This PR updates the hog script parsing logic to find `@hog.methods` inside python classes.


https://github.com/user-attachments/assets/33ab5aeb-6bd5-4b5d-ae05-95cba3a36c91

For reference here is the hog script I was testing with:
```python
import groundhog_hpc as hog

@hog.function()
def bar():
    pass

class Foo:
    @hog.method()
    def bar():
        pass

    @hog.method()
    def baz():
        pass


@hog.function()
def baz():
    pass

```