### PR TITLE
fix modal app validation error reporting

### DIFF
--- a/garden/src/features/functions/modal/api/useModalAppForm.tsx
+++ b/garden/src/features/functions/modal/api/useModalAppForm.tsx
@@ -11,6 +11,7 @@ import { ModalFileMetadataResponse } from "@/types";
 import { ValidationError, DeploymentError } from "./useModalAppUpload";
 import { useQueryClient } from "@tanstack/react-query";
 import axios from "@/lib/axios";
+import { AxiosError } from "axios";
 import { ModelDeployment } from "@/features/model-deployments/ModelDeployments";
 
 export const modalAppFormSchema = z.object({
@@ -79,9 +80,6 @@ export const useModalAppForm = ({
     validateModalFile,
     deployModalApp,
     updateModalApp,
-    isValidating: useModalAppUploadIsValidating,
-    validationError: useModalAppUploadValidationError,
-    deploymentError: useModalAppUploadDeploymentError,
     clearErrors
   } = useModalAppUpload();
 
@@ -118,29 +116,21 @@ export const useModalAppForm = ({
       // Automatically validate the file after loading
       const metadata = await validateModalFile(fileContents);
 
-      if (metadata) {
-        setIsValidated(true);
-        // Initialize the modal_functions field with the validated metadata
-        const functions = metadata.modal_functions || [];
-        form.setValue("modal.modal_functions", functions);
-        setModalMetadata(metadata);
-        toast.success("Modal file validated successfully");
-      } else {
-        // If validateModalFile returns null but didn't throw an error,
-        // check if useModalAppUpload has a validation error
-        if (useModalAppUploadValidationError) {
-          setValidationError(useModalAppUploadValidationError);
-        } else {
-          setValidationError({
-            message: "File validation failed. Please check your file and try again.",
-            isApiError: false
-          });
-        }
-        toast.error("File validation failed");
-      }
+      setIsValidated(true);
+      // Initialize the modal_functions field with the validated metadata
+      const functions = metadata.modal_functions || [];
+      form.setValue("modal.modal_functions", functions);
+      setModalMetadata(metadata);
+      toast.success("Modal file validated successfully");
     } catch (error) {
-      if (useModalAppUploadValidationError) {
-        setValidationError(useModalAppUploadValidationError);
+      // Handle AxiosError by extracting detail and suggested_fix from response
+      if (error instanceof AxiosError) {
+        const apiError = ApiError.fromAxiosError(error);
+        setValidationError({
+          message: apiError.message,
+          suggestedFix: apiError.suggestedFix,
+          isApiError: true
+        });
       } else if (error instanceof ApiError) {
         setValidationError({
           message: error.message,
@@ -328,9 +318,16 @@ export const useModalAppForm = ({
         }
       }
     } catch (error: unknown) {
-      // Get the properly formatted error from useModalAppUpload
-      if (useModalAppUploadDeploymentError) {
-        setDeploymentError(useModalAppUploadDeploymentError);
+      // Handle AxiosError by extracting detail and suggested_fix from response
+      if (error instanceof AxiosError) {
+        const apiError = ApiError.fromAxiosError(error);
+        setDeploymentError({
+          message: apiError.message,
+          suggestedFix: apiError.suggestedFix,
+          deploymentOutput: apiError.deploymentOutput,
+          isTimeout: false,
+          isApiError: true
+        });
       } else if (error instanceof ApiError) {
         setDeploymentError({
           message: error.message,

--- a/garden/src/features/functions/modal/api/useModalAppUpload.tsx
+++ b/garden/src/features/functions/modal/api/useModalAppUpload.tsx
@@ -35,7 +35,7 @@ interface ExtendedModalFileMetadata extends ModalFileMetadataResponse {
 }
 
 export interface UseModalAppUploadReturn {
-  validateModalFile: (fileContents: string) => Promise<ModalFileMetadataResponse | null>;
+  validateModalFile: (fileContents: string) => Promise<ModalFileMetadataResponse>;
   deployModalApp: (fileContents: string, modalMetadata: ModalFileMetadataResponse, ownerIdentityId?: string) => Promise<number | undefined>;
   updateModalApp: (fileContents: string, appId: number) => Promise<number | undefined>;
   modalMetadata: ExtendedModalFileMetadata | null;
@@ -101,7 +101,7 @@ export const useModalAppUpload = (): UseModalAppUploadReturn => {
     throw error;
   };
 
-  const validateModalFile = async (fileContents: string): Promise<ModalFileMetadataResponse | null> => {
+  const validateModalFile = async (fileContents: string): Promise<ModalFileMetadataResponse> => {
     setValidationError(null);
 
     try {
@@ -109,10 +109,10 @@ export const useModalAppUpload = (): UseModalAppUploadReturn => {
       setModalMetadata(metadata);
       return metadata;
     } catch (error) {
-      setValidationError({
-        ...processError(error),
-      });
-      return null;
+      const processed = processError(error);
+      setValidationError(processed);
+      // Re-throw so caller can also handle it (avoids stale closure issues)
+      throw error;
     }
   };
 

--- a/garden/src/features/gardens/utils/garden.utils.ts
+++ b/garden/src/features/gardens/utils/garden.utils.ts
@@ -95,16 +95,19 @@ export class ApiError extends Error {
       deployment_output?: string,
     }
 
-    const raw_data: ModalException = error.response?.data as ModalException;
-    const responseData = {
+    const raw_data = error.response?.data as ModalException | undefined;
+
+    // Handle case where there's no response data
+    if (!raw_data) {
+      return new ApiError(error.message || 'Unknown API Error');
+    }
+
+    const responseData: ApiErrorInfo = {
       detail: raw_data.detail,
       suggestedFix: raw_data.suggested_fix,
       deploymentOutput: raw_data.deployment_output,
-    } as ApiErrorInfo;
+    };
     let message = 'Unknown API Error';
-    if (!responseData) {
-      return new ApiError(error.message || message);
-    }
 
     let suggestedFix = responseData.suggestedFix;
     const deploymentOutput = responseData.deploymentOutput;


### PR DESCRIPTION
Resolves: #481 

This PR fixes the logic that extracts the details and suggested fixes the backend reports when validating a modal app fails.

Before:
<img width="1117" height="567" alt="image" src="https://github.com/user-attachments/assets/d4c26cbc-e5c7-4718-8831-2ab259fa582a" />

After:
<img width="728" height="812" alt="image" src="https://github.com/user-attachments/assets/5c9ed848-29ad-4a93-9b10-c4e030ead7fe" />

Manual testing with the modal app from https://github.com/Garden-AI/garden/issues/657 